### PR TITLE
Guard against unavailable captureStackTrace

### DIFF
--- a/utils/error.js
+++ b/utils/error.js
@@ -1,7 +1,9 @@
 export default class Auth0Error extends Error {
   constructor (json) {
     super();
-    Error.captureStackTrace(this, this.constructor);
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
     this.name = json.error || json.code || 'a0.internal.failed';
     this.message = json.description || json.error_description || response.statusText || response.status;
     this.json = json;


### PR DESCRIPTION
`Error.captureStackTrace` was unavailable in our react-native app. It did not cause a compile error but, rather it failed at runtime with the error:

`Error.captureStackTrace is not a function. In 'Error.captureStackTrace(t,t.constructor)', 'Error.captureStackTrace' is undefined`

Node Version: 6.6.0
