### PR TITLE
Remove override annotation on createJSModules method

### DIFF
--- a/android/src/main/java/com/auth0/react/A0Auth0Package.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Package.java
@@ -18,7 +18,7 @@ public class A0Auth0Package implements ReactPackage {
 
     // Required @Override for RN v0.46.x and earlier
     public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
+      return Collections.emptyList();
     }
 
     @Override

--- a/android/src/main/java/com/auth0/react/A0Auth0Package.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Package.java
@@ -17,11 +17,6 @@ public class A0Auth0Package implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }

--- a/android/src/main/java/com/auth0/react/A0Auth0Package.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Package.java
@@ -18,7 +18,7 @@ public class A0Auth0Package implements ReactPackage {
 
     // Required @Override for RN v0.46.x and earlier
     public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return new ArrayList<>();
+        return Collections.emptyList();
     }
 
     @Override

--- a/android/src/main/java/com/auth0/react/A0Auth0Package.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Package.java
@@ -16,6 +16,11 @@ public class A0Auth0Package implements ReactPackage {
       return Arrays.<NativeModule>asList(new A0Auth0Module(reactContext));
     }
 
+    // Required @Override for RN v0.46.x and earlier
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return new ArrayList<>();
+    }
+
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();


### PR DESCRIPTION
React Native v0.47.0 removes the createJSModules call, so this @Override now breaks the build.

```
:react-native-code-push:compileReleaseJavaWithJavac - is not incremental (e.g. outputs have changed, no previous execution, etc.).
/Users/Luke/Projects/ClientPOC/node_modules/react-native-code-push/android/app/src/main/java/com/microsoft/codepush/react/CodePush.java:305: error: method does not override or implement a method from a supertype
    @Override
    ^
```

Confirmed this change fixes the build.  See RN Breaking Changes in the v0.47.0 release: https://github.com/facebook/react-native/releases/tag/v0.47.0

See also identical change e.g. in react-native-code-push: https://github.com/Microsoft/react-native-code-push/pull/895/commits/dff9f47a4b8b31e9ad4bfe36acf57fff8291163d