### PR TITLE
Remove createJSModules method from A0Auth0Package (#71)

### DIFF
--- a/android/src/main/java/com/auth0/react/A0Auth0Package.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Package.java
@@ -17,11 +17,6 @@ public class A0Auth0Package implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-      return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
       return Collections.emptyList();
     }


### PR DESCRIPTION
Remove createJSModules method from A0Auth0Package since it was blocking
android to build properly. This error is related to the following breaking change
in react native:
https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8

It's interesting to note that any release that ships with this patch will not work
with any react-native release below 0.47.0. There are other approaches that allows the backward compatibility such as this one: https://github.com/react-community/react-native-image-picker/pull/653/files

Let me know which approach is the most appropriate to you.