### PR TITLE
Change customtabs version to the same as default build tools

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,6 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.android.support:customtabs:23.3.0'
+    compile 'com.android.support:customtabs:23.0.1'
 }
   


### PR DESCRIPTION
This change fixes an issue several adopters are running into: "Could not invoke A0Auth.showUrl".  See: https://github.com/auth0/react-native-auth0/issues/67#issuecomment-322209597


Fixes #67 