### PR TITLE
Fix android web authentication

### DIFF
--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -60,12 +60,11 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Lifecyc
         if (activity != null) {
             CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
             CustomTabsIntent customTabsIntent = builder.build();
-            customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
-            customTabsIntent.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             customTabsIntent.launchUrl(activity, Uri.parse(url));
         } else {
             final Intent intent = new Intent(Intent.ACTION_VIEW);
             intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             intent.setData(Uri.parse(url));
             getReactApplicationContext().startActivity(intent);
         }

--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -63,7 +63,6 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Lifecyc
             customTabsIntent.launchUrl(activity, Uri.parse(url));
         } else {
             final Intent intent = new Intent(Intent.ACTION_VIEW);
-            intent.addFlags(Intent.FLAG_ACTIVITY_NO_HISTORY);
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
             intent.setData(Uri.parse(url));
             getReactApplicationContext().startActivity(intent);


### PR DESCRIPTION
I want to clarify how each flow works:

CustomTabs are meant to be open within the app. The NEW_TASK flag should not be used on that case. Of course I wasn't aware of this behavior until we required to pause the activity to get some data from an external app, like gmail.

For the Browser intent logic, which is only used in the case of calling `showUrl` from a non-activity class, the NEW_TASK flag is required as the context used is the Application one instead of the Activity one. If this flag is not provided a runtime exception raises. Browser is "still used" when going through the CustomTabs logic and no CustomTabs compatible browser app is installed in the device.

The NO_HISTORY flag introduced in a previous commit to avoid leaving the browser app in the "recents app" view doesn't work as expected. Instead, it's making the custom tab or browser session refresh the webpage on the activity resume. I've removed both flags and might be worth checking [this sdk](https://github.com/auth0/Auth0.Android/blob/master/auth0/src/main/java/com/auth0/android/provider/CustomTabsController.java#L147) line as well.

This fixes https://github.com/auth0/react-native-auth0/issues/124