### PR TITLE
android: allow root project to specify dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ android:windowSoftInputMode="adjustResize">
 </activity>
 ```
 
+In order to reduce the potential for conflict which may be caused by the presence of differing versions of the Android support libraries, you may wish to [configure project-wide properties](https://developer.android.com/studio/build/gradle-tips.html#configure-project-wide-properties) setting the compile SDK version, build tools version, target SDK, and support library, in your root project's `build.gradle`, which will then be respected by `react-native-auth0` and many other React Native modules.
+
 > For more info please read [react native docs](https://facebook.github.io/react-native/docs/linking.html)
 
 #### iOS

--- a/README.md
+++ b/README.md
@@ -77,9 +77,10 @@ android:windowSoftInputMode="adjustResize">
 </activity>
 ```
 
-In order to reduce the potential for conflict which may be caused by the presence of differing versions of the Android support libraries, you may wish to [configure project-wide properties](https://developer.android.com/studio/build/gradle-tips.html#configure-project-wide-properties) setting the compile SDK version, build tools version, target SDK, and support library, in your root project's `build.gradle`, which will then be respected by `react-native-auth0` and many other React Native modules.
-
 > For more info please read [react native docs](https://facebook.github.io/react-native/docs/linking.html)
+
+
+In order to reduce the potential for conflict which may be caused by the presence of differing versions of the Android support libraries, you may wish to [configure project-wide properties](https://developer.android.com/studio/build/gradle-tips.html#configure-project-wide-properties). Setting the Compile and Target SDK versions, Build Tools version, and Support Library version in your **root project's** `build.gradle` file will make `react-native-auth0` and many other React Native modules use them.
 
 #### iOS
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,3 @@
-project.ext {
-    buildToolsVersion = "23.0.1"
-}
-
 buildscript {
     repositories {
         jcenter()
@@ -14,13 +10,18 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def DEFAULT_COMPILE_SDK_VERSION = 23
+def DEFAULT_BUILD_TOOLS_VERSION = "23.0.1"
+def DEFAULT_TARGET_SDK_VERSION = 22
+def DEFAULT_SUPPORT_LIB_VERSION = "23.0.1"
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "${project.ext.buildToolsVersion}"
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
     }
@@ -33,8 +34,10 @@ repositories {
     mavenCentral()
 }
 
+def supportVersion = rootProject.hasProperty('supportLibVersion') ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
+
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile "com.android.support:customtabs:${project.ext.buildToolsVersion}"
+    compile "com.android.support:customtabs:${supportVersion}"
 }
 


### PR DESCRIPTION
React Native projects with multiple native dependencies often end up unintentionally relying on a variety of Android SDK versions, which can lead to unpredictable build-time failures or even run-time crashes, such as the weirdness in #67. Many libraries (see, e.g., react-community/react-native-maps#2047, invertase/react-native-firebase#1007) have been moving to a system of allowing the solution [recommended by google](https://developer.android.com/studio/build/gradle-tips.html#configure-project-wide-properties) of having the root project set properties with the desired dependency versions. This PR implements that solution for `react-native-auth0`.