### PR TITLE
Update webAuth documentation 

### DIFF
--- a/webauth/index.js
+++ b/webauth/index.js
@@ -40,6 +40,7 @@ export default class WebAuth {
    * @param {String} [parameters.nonce] random string to prevent replay attacks of id_tokens.
    * @param {String} [parameters.audience] identifier of Resource Server (RS) to be included as audience (aud claim) of the issued access token
    * @param {String} [parameters.scope] scopes requested for the issued tokens. e.g. `openid profile`
+   * @param {String} [parameters.connection] The name of a social identity provider configured to your application, for example google-oauth2 or facebook. If null, it will redirect to the Auth0 Login Page and show the Login Widget.
    * @returns {Promise}
    * @see https://auth0.com/docs/api/authentication#authorize-client
    *

--- a/webauth/index.js
+++ b/webauth/index.js
@@ -35,6 +35,9 @@ export default class WebAuth {
    *
    * In iOS it will use `SFSafariViewController` and in Android Chrome Custom Tabs.
    *
+   * To learn more about how to customize the authorize call, check the Universal Login Page
+   * article at https://auth0.com/docs/hosted-pages/login
+   *
    * @param {Object} parameters parameters to send
    * @param {String} [parameters.state] random string to prevent CSRF attacks and used to discard unexepcted results. By default its a cryptographically secure random.
    * @param {String} [parameters.nonce] random string to prevent replay attacks of id_tokens.

--- a/webauth/index.js
+++ b/webauth/index.js
@@ -40,7 +40,7 @@ export default class WebAuth {
    * @param {String} [parameters.nonce] random string to prevent replay attacks of id_tokens.
    * @param {String} [parameters.audience] identifier of Resource Server (RS) to be included as audience (aud claim) of the issued access token
    * @param {String} [parameters.scope] scopes requested for the issued tokens. e.g. `openid profile`
-   * @param {String} [parameters.connection] The name of a social identity provider configured to your application, for example google-oauth2 or facebook. If null, it will redirect to the Auth0 Login Page and show the Login Widget.
+   * @param {String} [parameters.connection] The name of the identity provider to use, e.g. "google-oauth2" or "facebook". When not set, it will display Auth0's Universal Login Page.
    * @returns {Promise}
    * @see https://auth0.com/docs/api/authentication#authorize-client
    *


### PR DESCRIPTION
Auth0.js use webAuth.authorize({connection: "facebook"}) to support social login, but react-native-auth0 didn't document this parameter, so I added it to help others to know it