### PR TITLE
Add requiresMainQueueSetup to fix warning in RN 0.49+

### DIFF
--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -43,6 +43,10 @@ RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {
     return @{ @"bundleIdentifier": [[NSBundle mainBundle] bundleIdentifier] };
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 #pragma mark - Internal methods
 
 - (void)presentSafariWithURL:(NSURL *)url {


### PR DESCRIPTION
In RN 0.49+ the following warning appears 
```Module A0Auth0 requires main queue setup since it overrides `constantsToExport` but doesn't implement `requiresMainQueueSetup. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.```

This implements the requiresMainQueueSetup method and returns `true`.