### PR TITLE
Added iOS SF/ASWeb AuthenticationSession support

### DIFF
--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -37,13 +37,13 @@ RCT_EXPORT_METHOD(hide) {
 }
 
 RCT_EXPORT_METHOD(showUrl:(NSString *)urlString closeOnLoad:(BOOL)closeOnLoad callback:(RCTResponseSenderBlock)callback) {
-    if (@available(iOS 11.0, *)) {
+    self.sessionCallback = callback;
+    self.closeOnLoad = closeOnLoad;
+    if (@available(iOS 13.0, *)) {
         [self presentAuthenticationSession:[NSURL URLWithString:urlString]];
     } else {
         [self presentSafariWithURL:[NSURL URLWithString:urlString]];
     }
-    self.sessionCallback = callback;
-    self.closeOnLoad = closeOnLoad;
 }
 
 RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {
@@ -89,12 +89,12 @@ RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {
                                           if ([[error domain] isEqualToString:ASWebAuthenticationSessionErrorDomain]) {
                                               switch ([error code]) {
                                                   case SFAuthenticationErrorCanceledLogin:
-                                                      callback(@[ERROR_CANCELLED]);
+                                                      callback(@[ERROR_CANCELLED, [NSNull null]]);
                                               }
                                           } else if(error) {
-                                              callback(@[error]);
+                                              callback(@[error, [NSNull null]]);
                                           } else if(callbackURL) {
-                                              callback(@[@{@"url": callbackURL.absoluteString}]);
+                                              callback(@[[NSNull null], callbackURL.absoluteString]);
                                           }
                                           self.authenticationSession = nil;
                                       }];
@@ -107,12 +107,12 @@ RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {
                                           if ([[error domain] isEqualToString:SFAuthenticationErrorDomain]) {
                                               switch ([error code]) {
                                                   case SFAuthenticationErrorCanceledLogin:
-                                                      callback(@[ERROR_CANCELLED]);
+                                                      callback(@[ERROR_CANCELLED, [NSNull null]]);
                                               }
                                           } else if(error) {
-                                              callback(@[error]);
+                                              callback(@[error, [NSNull null]]);
                                           } else if(callbackURL) {
-                                              callback(@[@{@"url": callbackURL.absoluteString}]);
+                                              callback(@[[NSNull null], callbackURL.absoluteString]);
                                           }
                                           self.authenticationSession = nil;
                                       }];
@@ -127,11 +127,11 @@ RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {
         [self.last.presentingViewController dismissViewControllerAnimated:animated
                                                                completion:^{
                                                                    if (error) {
-                                                                       callback(@[error]);
+                                                                       callback(@[error, [NSNull null]]);
                                                                    }
                                                                }];
     } else if (error) {
-        callback(@[error]);
+        callback(@[error, [NSNull null]]);
     }
     self.sessionCallback = nil;
     self.last = nil;

--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -2,6 +2,9 @@
 #import "A0Auth0.h"
 
 #import <SafariServices/SafariServices.h>
+#if __has_include("AuthenticationServices/AuthenticationServices.h")
+#import <AuthenticationServices/AuthenticationServices.h>
+#endif
 #import <CommonCrypto/CommonCrypto.h>
 
 #if __has_include("RCTUtils.h")
@@ -10,8 +13,12 @@
 #import <React/RCTUtils.h>
 #endif
 
+#define ERROR_CANCELLED @{@"error": @"a0.session.user_cancelled",@"error_description": @"User cancelled the Auth"}
+#define ERROR_FAILED_TO_LOAD @{@"error": @"a0.session.failed_load",@"error_description": @"Failed to load url"}
+
 @interface A0Auth0 () <SFSafariViewControllerDelegate>
 @property (weak, nonatomic) SFSafariViewController *last;
+@property (strong, nonatomic) NSObject *authenticationSession;
 @property (copy, nonatomic) RCTResponseSenderBlock sessionCallback;
 @property (assign, nonatomic) BOOL closeOnLoad;
 @end
@@ -30,9 +37,14 @@ RCT_EXPORT_METHOD(hide) {
 }
 
 RCT_EXPORT_METHOD(showUrl:(NSString *)urlString closeOnLoad:(BOOL)closeOnLoad callback:(RCTResponseSenderBlock)callback) {
-    [self presentSafariWithURL:[NSURL URLWithString:urlString]];
-    self.closeOnLoad = closeOnLoad;
     self.sessionCallback = callback;
+    self.closeOnLoad = closeOnLoad;
+    
+    if (@available(iOS 13.0, *)) {
+        [self presentAuthenticationSession:[NSURL URLWithString:urlString]];
+    } else {
+        [self presentSafariWithURL:[NSURL URLWithString:urlString]];
+    }
 }
 
 RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {
@@ -56,6 +68,59 @@ RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {
     [self terminateWithError:RCTMakeError(@"Only one Safari can be visible", nil, nil) dismissing:YES animated:NO];
     [[self topViewControllerWithRootViewController:window.rootViewController] presentViewController:controller animated:YES completion:nil];
     self.last = controller;
+}
+
+- (void)presentAuthenticationSession:(NSURL *)url {
+    
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:url
+                                                resolvingAgainstBaseURL:NO];
+    NSArray *queryItems = urlComponents.queryItems;
+    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"name=%@", @"redirect_uri"];
+    NSURLQueryItem *queryItem = [[queryItems
+                                  filteredArrayUsingPredicate:predicate]
+                                 firstObject];
+    NSString *callbackURLScheme = queryItem.value;
+    
+    if (@available(iOS 12.0, *)) {
+        self.authenticationSession = [[ASWebAuthenticationSession alloc]
+                                      initWithURL:url callbackURLScheme:callbackURLScheme
+                                      completionHandler:^(NSURL * _Nullable callbackURL,
+                                                          NSError * _Nullable error) {
+                                          RCTResponseSenderBlock callback = self.sessionCallback ? self.sessionCallback : ^void(NSArray *_unused) {};
+                                          if ([[error domain] isEqualToString:ASWebAuthenticationSessionErrorDomain]) {
+                                              switch ([error code]) {
+                                                  case SFAuthenticationErrorCanceledLogin:
+                                                      callback(@[ERROR_CANCELLED]);
+                                              }
+                                          } else if(error) {
+                                              callback(@[error]);
+                                          } else if(callbackURL) {
+                                              callback(@[@{@"url": callbackURL.absoluteString}]);
+                                          }
+                                          self.authenticationSession = nil;
+                                      }];
+        [(ASWebAuthenticationSession*) self.authenticationSession start];
+    } else if (@available(iOS 12.0, *)) {
+        self.authenticationSession = [[SFAuthenticationSession alloc]
+                                      initWithURL:url callbackURLScheme:callbackURLScheme
+                                      completionHandler:^(NSURL * _Nullable callbackURL,
+                                                          NSError * _Nullable error) {
+                                          RCTResponseSenderBlock callback = self.sessionCallback ? self.sessionCallback : ^void(NSArray *_unused) {};
+                                          if ([[error domain] isEqualToString:SFAuthenticationErrorDomain]) {
+                                              switch ([error code]) {
+                                                  case SFAuthenticationErrorCanceledLogin:
+                                                      callback(@[ERROR_CANCELLED]);
+                                              }
+                                          } else if(error) {
+                                              callback(@[error]);
+                                          } else if(callbackURL) {
+                                              callback(@[@{@"url": callbackURL.absoluteString}]);
+                                          }
+                                          self.authenticationSession = nil;
+                                      }];
+        [(SFAuthenticationSession*) self.authenticationSession start];
+    }
+    
 }
 
 - (void)terminateWithError:(id)error dismissing:(BOOL)dismissing animated:(BOOL)animated {
@@ -87,22 +152,22 @@ RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {
 
 - (NSString *)sign:(NSString*)value {
     CC_SHA256_CTX ctx;
-
+    
     uint8_t * hashBytes = malloc(CC_SHA256_DIGEST_LENGTH * sizeof(uint8_t));
     memset(hashBytes, 0x0, CC_SHA256_DIGEST_LENGTH);
-
+    
     NSData *valueData = [value dataUsingEncoding:NSUTF8StringEncoding];
-
+    
     CC_SHA256_Init(&ctx);
     CC_SHA256_Update(&ctx, [valueData bytes], (CC_LONG)[valueData length]);
     CC_SHA256_Final(hashBytes, &ctx);
-
+    
     NSData *hash = [NSData dataWithBytes:hashBytes length:CC_SHA256_DIGEST_LENGTH];
-
+    
     if (hashBytes) {
         free(hashBytes);
     }
-
+    
     return [[[[hash base64EncodedStringWithOptions:0]
               stringByReplacingOccurrencesOfString:@"+" withString:@"-"]
              stringByReplacingOccurrencesOfString:@"/" withString:@"_"]
@@ -122,22 +187,14 @@ RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {
 #pragma mark - SFSafariViewControllerDelegate
 
 - (void)safariViewControllerDidFinish:(SFSafariViewController *)controller {
-    NSDictionary *error = @{
-                            @"error": @"a0.session.user_cancelled",
-                            @"error_description": @"User cancelled the Auth"
-                            };
-    [self terminateWithError:error dismissing:NO animated:NO];
+    [self terminateWithError:ERROR_CANCELLED dismissing:NO animated:NO];
 }
 
 - (void)safariViewController:(SFSafariViewController *)controller didCompleteInitialLoad:(BOOL)didLoadSuccessfully {
     if (self.closeOnLoad && didLoadSuccessfully) {
         [self terminateWithError:[NSNull null] dismissing:YES animated:YES];
     } else if (!didLoadSuccessfully) {
-        NSDictionary *error = @{
-                                @"error": @"a0.session.failed_load",
-                                @"error_description": @"Failed to load url"
-                                };
-        [self terminateWithError:error dismissing:YES animated:YES];
+        [self terminateWithError:ERROR_FAILED_TO_LOAD dismissing:YES animated:YES];
     }
 }
 

--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -37,14 +37,13 @@ RCT_EXPORT_METHOD(hide) {
 }
 
 RCT_EXPORT_METHOD(showUrl:(NSString *)urlString closeOnLoad:(BOOL)closeOnLoad callback:(RCTResponseSenderBlock)callback) {
-    self.sessionCallback = callback;
-    self.closeOnLoad = closeOnLoad;
-    
-    if (@available(iOS 13.0, *)) {
+    if (@available(iOS 11.0, *)) {
         [self presentAuthenticationSession:[NSURL URLWithString:urlString]];
     } else {
         [self presentSafariWithURL:[NSURL URLWithString:urlString]];
     }
+    self.sessionCallback = callback;
+    self.closeOnLoad = closeOnLoad;
 }
 
 RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {

--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -79,13 +79,13 @@ RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {
                                   filteredArrayUsingPredicate:predicate]
                                  firstObject];
     NSString *callbackURLScheme = queryItem.value;
+    RCTResponseSenderBlock callback = self.sessionCallback ? self.sessionCallback : ^void(NSArray *_unused) {};
     
     if (@available(iOS 12.0, *)) {
         self.authenticationSession = [[ASWebAuthenticationSession alloc]
                                       initWithURL:url callbackURLScheme:callbackURLScheme
                                       completionHandler:^(NSURL * _Nullable callbackURL,
                                                           NSError * _Nullable error) {
-                                          RCTResponseSenderBlock callback = self.sessionCallback ? self.sessionCallback : ^void(NSArray *_unused) {};
                                           if ([[error domain] isEqualToString:ASWebAuthenticationSessionErrorDomain]) {
                                               switch ([error code]) {
                                                   case SFAuthenticationErrorCanceledLogin:
@@ -99,12 +99,11 @@ RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {
                                           self.authenticationSession = nil;
                                       }];
         [(ASWebAuthenticationSession*) self.authenticationSession start];
-    } else if (@available(iOS 12.0, *)) {
+    } else if (@available(iOS 11.0, *)) {
         self.authenticationSession = [[SFAuthenticationSession alloc]
                                       initWithURL:url callbackURLScheme:callbackURLScheme
                                       completionHandler:^(NSURL * _Nullable callbackURL,
                                                           NSError * _Nullable error) {
-                                          RCTResponseSenderBlock callback = self.sessionCallback ? self.sessionCallback : ^void(NSArray *_unused) {};
                                           if ([[error domain] isEqualToString:SFAuthenticationErrorDomain]) {
                                               switch ([error code]) {
                                                   case SFAuthenticationErrorCanceledLogin:

--- a/webauth/agent.js
+++ b/webauth/agent.js
@@ -17,13 +17,13 @@ export default class Agent {
         resolve(event.url);
       };
       Linking.addEventListener('url', urlHandler);
-      NativeModules.A0Auth0.showUrl(url, closeOnLoad, result => {
+      NativeModules.A0Auth0.showUrl(url, closeOnLoad, (error, redirectURL) => {
         Linking.removeEventListener('url', urlHandler);
-        if (result && result.url) {
-          resolve(result.url);
-        } else if (result) {
-          reject(result);
-        } else if (closeOnLoad) {
+        if (error) {
+          reject(error);
+        } else if(redirectURL) {
+          resolve(redirectURL);
+        } else if(closeOnLoad) {
           resolve();
         }
       });

--- a/webauth/agent.js
+++ b/webauth/agent.js
@@ -17,10 +17,12 @@ export default class Agent {
         resolve(event.url);
       };
       Linking.addEventListener('url', urlHandler);
-      NativeModules.A0Auth0.showUrl(url, closeOnLoad, err => {
+      NativeModules.A0Auth0.showUrl(url, closeOnLoad, result => {
         Linking.removeEventListener('url', urlHandler);
-        if (err) {
-          reject(err);
+        if (result && result.url) {
+          resolve(result.url);
+        } else if (result) {
+          reject(result);
         } else if (closeOnLoad) {
           resolve();
         }


### PR DESCRIPTION
Adds support for iOS 11 SFAuthenticationSession & iOS 12 ASWebAuthenticationSession
This enables SSO in iOS 11+

No changes are required by the developer, all is handled internally.