### PR TITLE
Remove obsolete React dependency from podspec.

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -13,7 +13,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/auth0/react-native-auth0.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/*.{h,m}"
   s.requires_arc = true
-
-  s.dependency "React"
 end
 


### PR DESCRIPTION
### Changes

The React pod is deprecated and, since React Native already requires React, we should remove this dependency from A0Auth0.podspec.

### References

This resolves issue #191 .

### Testing

With Auth0 for React Native installed, simply attempt to `pod install` from the `ios/` directory in an ejected app that uses CocoaPods. This pod and all other pods should successfully install.

* [x] This change has been tested on the latest version of the platform

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed