### PR TITLE
Issue: Android platform does not do logout from IDP Auth0.

### DIFF
--- a/webauth/index.js
+++ b/webauth/index.js
@@ -103,7 +103,7 @@ export default class WebAuth {
    * @memberof WebAuth
    */
   clearSession(options = {}) {
-    if (Platform.OS !== 'ios') {
+    if (Platform.OS !== 'ios' || Platform.OS !== 'android') {
       return Promise.reject(
         new AuthError({
           json: {

--- a/webauth/index.js
+++ b/webauth/index.js
@@ -103,22 +103,21 @@ export default class WebAuth {
    * @memberof WebAuth
    */
   clearSession(options = {}) {
-    if (Platform.OS !== 'ios' || Platform.OS !== 'android') {
-      return Promise.reject(
-        new AuthError({
-          json: {
-            error: 'a0.platform.not_available',
-            error_description: `Cannot perform operation in platform ${
-              Platform.OS
-            }`
-          },
-          status: 0
-        })
-      );
-    }
-    const { client, agent } = this;
-    const federated = options.federated || false;
-    const logoutUrl = client.logoutUrl(options);
-    return agent.show(logoutUrl, true);
+    if (Platform.OS == 'ios' || Platform.OS == 'android' ) {
+      const { client, agent } = this;
+      const federated = options.federated || false;
+      const logoutUrl = client.logoutUrl(options);
+      return agent.show(logoutUrl, true);
+    } else {
+        return Promise.reject(
+          new AuthError({
+            json: {
+              error: 'a0.platform.not_available',
+              error_description: `Cannot perform operation in platform ${Platform.OS}`
+            },
+            status: 0
+          })
+        );
+     }
   }
 }


### PR DESCRIPTION
### Changes
On Android platform, logout is not performed at Auth0 as logout URL is not requested.
Logout is only done for iOS platform and for all other platforms session remains active on Auth0.

Added check for android and iOS platform, for other unknown platforms error would be thrown.
