### PR TITLE
upgrade gradle configure for android build warning(fix#202)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,19 +1,20 @@
+def DEFAULT_COMPILE_SDK_VERSION = 23
+def DEFAULT_BUILD_TOOLS_VERSION = "23.0.1"
+def DEFAULT_TARGET_SDK_VERSION = 22
+def DEFAULT_SUPPORT_LIB_VERSION = "23.0.1"
+
 buildscript {
     repositories {
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath "com.android.tools.build:gradle:1.3.1"
     }
 }
 
 apply plugin: 'com.android.library'
 
-def DEFAULT_COMPILE_SDK_VERSION = 23
-def DEFAULT_BUILD_TOOLS_VERSION = "23.0.1"
-def DEFAULT_TARGET_SDK_VERSION = 22
-def DEFAULT_SUPPORT_LIB_VERSION = "23.0.1"
 
 android {
     compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
@@ -36,8 +37,9 @@ repositories {
 
 def supportVersion = rootProject.hasProperty('supportLibVersion') ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
 
+
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile "com.android.support:customtabs:${supportVersion}"
+    implementation 'com.facebook.react:react-native:+'
+    implementation "com.android.support:customtabs:${supportVersion}"
 }
 


### PR DESCRIPTION
### Changes
change the `compile` to `implementation` for below warning
> Configuration 'compile' is obsolete and has been replaced with 'implementation'.
It will be removed at the end of 2018


### Testing
I have test in my side and work fine

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed