### PR TITLE
[Android] Open web auth with default browser or chrome if available (fixes #200)

### DIFF
--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -3,8 +3,11 @@ package com.auth0.react;
 
 import android.app.Activity;
 import android.app.PendingIntent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Handler;
 import android.support.annotation.NonNull;
 import android.support.customtabs.CustomTabsIntent;
@@ -22,14 +25,23 @@ import java.io.UnsupportedEncodingException;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
 
 public class A0Auth0Module extends ReactContextBaseJavaModule implements LifecycleEventListener {
 
     private static final String US_ASCII = "US-ASCII";
     private static final String SHA_256 = "SHA-256";
     private static final int CANCEL_EVENT_DELAY = 100;
+    private static final String ACTION_CUSTOM_TABS_CONNECTION = "android.support.customtabs.action.CustomTabsService";
+    //Known Browsers with Custom Tabs support
+    private static final String CHROME_STABLE = "com.android.chrome";
+    private static final String CHROME_SYSTEM = "com.google.android.apps.chrome";
+    private static final String CHROME_BETA = "com.android.chrome.beta";
+    private static final String CHROME_DEV = "com.android.chrome.dev";
 
     private final ReactApplicationContext reactContext;
     private Callback callback;
@@ -55,11 +67,15 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Lifecyc
     @ReactMethod
     public void showUrl(String url, boolean closeOnLoad, Callback callback) {
         final Activity activity = getCurrentActivity();
-
         this.callback = callback;
         if (activity != null) {
+            String browserPackage = getBestBrowserPackage(activity);
+
             CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
             CustomTabsIntent customTabsIntent = builder.build();
+            if(browserPackage != null) {
+                customTabsIntent.intent.setPackage(browserPackage);
+            }
             customTabsIntent.launchUrl(activity, Uri.parse(url));
         } else {
             final Intent intent = new Intent(Intent.ACTION_VIEW);
@@ -149,5 +165,49 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Lifecyc
     @Override
     public void onHostDestroy() {
 
+    }
+
+    /**
+     * Query the OS for a Custom Tab compatible Browser application.
+     * It will pick the default browser first if is Custom Tab compatible, then any Chrome browser or the first Custom Tab compatible browser.
+     *
+     * @param context a valid Context
+     * @return the recommended Browser application package name, compatible with Custom Tabs. Null if no compatible browser is found.
+     */
+    static String getBestBrowserPackage(Activity activity) {
+        PackageManager pm = activity.getPackageManager();
+        Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"));
+        ResolveInfo webHandler = pm.resolveActivity(browserIntent,
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PackageManager.MATCH_ALL : PackageManager.MATCH_DEFAULT_ONLY);
+        String defaultBrowser = null;
+        if (webHandler != null) {
+            defaultBrowser = webHandler.activityInfo.packageName;
+        }
+
+        List<ResolveInfo> resolvedActivityList = pm.queryIntentActivities(browserIntent, 0);
+        List<String> customTabsBrowsers = new ArrayList<>();
+        for (ResolveInfo info : resolvedActivityList) {
+            Intent serviceIntent = new Intent();
+            serviceIntent.setAction(ACTION_CUSTOM_TABS_CONNECTION);
+            serviceIntent.setPackage(info.activityInfo.packageName);
+            if (pm.resolveService(serviceIntent, 0) != null) {
+                customTabsBrowsers.add(info.activityInfo.packageName);
+            }
+        }
+        if (customTabsBrowsers.contains(defaultBrowser)) {
+            return defaultBrowser;
+        } else if (customTabsBrowsers.contains(CHROME_STABLE)) {
+            return CHROME_STABLE;
+        } else if (customTabsBrowsers.contains(CHROME_SYSTEM)) {
+            return CHROME_SYSTEM;
+        } else if (customTabsBrowsers.contains(CHROME_BETA)) {
+            return CHROME_BETA;
+        } else if (customTabsBrowsers.contains(CHROME_DEV)) {
+            return CHROME_DEV;
+        } else if (!customTabsBrowsers.isEmpty()) {
+            return customTabsBrowsers.get(0);
+        } else {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
### Changes

Added method to android class to select default browser or chrome if available when opening web auth. This prevents the poor UX when asking the suer to select a browser to fulfil the web auth intent if they have multiple installed. This also streamlines testing on browserstack, as the Android image has multiple browsers installed by default.

### References

fixes #200 

https://support.auth0.com/tickets/00421464

### Testing

1. Download multiple browsers on Android
2. Open web auth within app
3. Should not show browser selection, should use default / chrome to fulfil intent if available
