### PR TITLE
Podspec restore react dependency

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -8,10 +8,12 @@ Pod::Spec.new do |s|
   s.summary      = "A0Auth0"
   s.homepage     = "https://github.com/auth0/react-native-auth0"
   s.license      = "MIT"
-  s.author             = { "auth0" => "oss@auth0.com" }
-  s.platform     = :ios, "7.0"
+  s.author       = { "auth0" => "oss@auth0.com" }
+  s.platform     = :ios, "9.0"
   s.source       = { :git => "https://github.com/auth0/react-native-auth0.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/*.{h,m}"
   s.requires_arc = true
+  
+  s.dependency "React"
 end
 


### PR DESCRIPTION
### Changes

Restore the `react` dependency in Podspec
Fixes #207 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed