### PR TITLE
Enable WebAuth Logout for Android & Fix iOS Logout.

### DIFF
--- a/webauth/__mocks__/auth0.js
+++ b/webauth/__mocks__/auth0.js
@@ -24,4 +24,6 @@ export default class A0Auth0 {
   oauthParameters(callback) {
     callback(this.parameters);
   }
+
+  bundleIdentifier = 'com.My.App';
 }

--- a/webauth/__mocks__/react-native.js
+++ b/webauth/__mocks__/react-native.js
@@ -5,5 +5,6 @@ const mock = {};
 
 mock.Linking = new Linking();
 mock.NativeModules = { A0Auth0: new A0Auth0() };
+mock.Platform = { OS: 'test-os' };
 
 module.exports = mock;

--- a/webauth/__tests__/webauth.spec.js
+++ b/webauth/__tests__/webauth.spec.js
@@ -1,0 +1,50 @@
+jest.mock('react-native');
+import Auth from '../../auth';
+import WebAuth from '../index';
+import { NativeModules } from 'react-native';
+import { URL } from 'url';
+
+const A0Auth0 = NativeModules.A0Auth0;
+
+describe('WebAuth', () => {
+  const auth = new Auth({ baseUrl: 'https://auth0.com', clientId: 'abc123' });
+  const webauth = new WebAuth(auth);
+
+  describe('clearSession', () => {
+    beforeEach(() => {
+      NativeModules.A0Auth0 = A0Auth0;
+      A0Auth0.reset();
+    });
+
+    it('should open log out URL', async () => {
+      await webauth.clearSession();
+
+      const parsedUrl = new URL(A0Auth0.url);
+      expect(parsedUrl.protocol).toEqual('https:');
+      expect(parsedUrl.hostname).toEqual('auth0.com');
+      const urlQuery = parsedUrl.searchParams;
+      expect(urlQuery.get('returnTo')).toEqual(
+        'com.my.app://auth0.com/test-os/com.My.App/callback'
+      );
+      expect(urlQuery.get('client_id')).toEqual('abc123');
+      expect(urlQuery.has('federated')).toEqual(false);
+      expect(urlQuery.has('auth0Client')).toEqual(true);
+    });
+
+    it('should open log out URL with federated=true', async () => {
+      const options = { federated: true };
+      await webauth.clearSession(options);
+
+      const parsedUrl = new URL(A0Auth0.url);
+      expect(parsedUrl.protocol).toEqual('https:');
+      expect(parsedUrl.hostname).toEqual('auth0.com');
+      const urlQuery = parsedUrl.searchParams;
+      expect(urlQuery.get('returnTo')).toEqual(
+        'com.my.app://auth0.com/test-os/com.My.App/callback'
+      );
+      expect(urlQuery.get('client_id')).toEqual('abc123');
+      expect(urlQuery.get('federated')).toEqual('true');
+      expect(urlQuery.has('auth0Client')).toEqual(true);
+    });
+  });
+});


### PR DESCRIPTION
### Changes

This PR enables the clear session feature for Android and fixes it for iOS.

When this is merged, it will **always** send the `client_id` and the `returnTo` parameters when opening the Auth0 logout URL. 

Devs would need to whitelist the `returnTo` URL in the "Allowed Logout URLs" section of their **application's settings** in the Auth0 dashboard. Fail to do so will show an error page when the redirect is attempted.


#### Sample usage:

```js
auth0.webAuth
   .clearSession({})
   .then(success => {
       //Logged out!
    })
    .catch(error => {
       //Browser closed by the user.
     });
```

### Breaking changes?
At first, seems to only affect _iOS only_ (because Android was disabled!). But if we look deeper, the current behavior is to open the logout URL without passing any `returnTo` nor `clientId` values. Testing this in an iOS simulator resulted in a browser showing the text "OK" and not redirecting back to the app. So even if the log out was successful, I had to manually close the browser in order to get back to the app.

With the changes introduced in this PR, users will either face the "URL not whitelisted" screen when there's a dashboard configuration error or return successfully to the app after logging out.

#### Current iOS behavior:

http://recordit.co/TQqX1AyApp

#### iOS behavior after this PR:

http://recordit.co/gWa1dlR8Zp

#### Android behavior after this PR:
http://recordit.co/GcPBbvQeNh

### Testing

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed