### PR TITLE
Fix error handling by using authentication error class

### DIFF
--- a/webauth/index.js
+++ b/webauth/index.js
@@ -2,7 +2,6 @@ import Agent from './agent';
 import { NativeModules, Platform } from 'react-native';
 
 import url from 'url';
-import Auth0Error from '../auth/auth0Error';
 import AuthError from '../auth/authError';
 
 const { A0Auth0 } = NativeModules;
@@ -79,7 +78,7 @@ export default class WebAuth {
         const query = url.parse(redirectUrl, true).query;
         const { code, state: resultState, error } = query;
         if (error) {
-          throw new Auth0Error({ json: query, status: 0 });
+          throw new AuthError({ json: query, status: 0 });
         }
         if (resultState !== expectedState) {
           throw new AuthError({


### PR DESCRIPTION
### Changes

The error handling for the WebAuth controller was wrong. Should be using the `AuthError` instead of a generic `Auth0Error` class.

### References

https://github.com/auth0/react-native-auth0/issues/220

### Testing

Manual testing only.

* [ ] This change adds unit test coverage
* [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] All existing and new tests complete without errors
* [x] All active GitHub checks have passed