### PR TITLE
Handle missing kid (key id) on the JWKS

### DIFF
--- a/src/jwt/__tests__/jwt.spec.js
+++ b/src/jwt/__tests__/jwt.spec.js
@@ -54,9 +54,35 @@ describe('id token verification tests', () => {
         500,
       );
 
-      await expect(verify(testJwt)).rejects.toHaveProperty(
+      const result = verify(testJwt);
+
+      expect(result).rejects.toHaveProperty(
         'name',
         'a0.idtoken.key_retrieval_error',
+      );
+      expect(result).rejects.toHaveProperty(
+        'message',
+        'Could not find a public key for Key ID (kid) "1234"',
+      );
+    });
+
+    it('fails when jwk set does not contain the expected key id', async () => {
+      const testJwt =
+        'eyJhbGciOiJSUzI1NiIsImtpZCI6IjEyMzQifQ.eyJpc3MiOiJodHRwczovL3Rva2Vucy10ZXN0LmF1dGgwLmNvbS8iLCJzdWIiOiJhdXRoMHwxMjM0NTY3ODkiLCJhdWQiOlsidG9rZW5zLXRlc3QtMTIzIiwiZXh0ZXJuYWwtdGVzdC0xMjMiXSwiZXhwIjoxNTcwMjAyOTMxLCJpYXQiOjE1NzAwMzAxMzEsIm5vbmNlIjoiYTU5dms1OTIiLCJhenAiOiJ0b2tlbnMtdGVzdC0xMjMiLCJhdXRoX3RpbWUiOjE1NzAxMTY1MzAuNzk2fQ.Xad-J3PtImY3z--Gvj-H61tH18mCGQUUBkcug-CB5ehkjd56PXrA-AJHZK7OLryB_uj6sFKVn-V8Wr6t3KW7_Fd2n-__Ca2h6PtgIrjceZlHAQY4SgAk9tPmeeTOhs6KyXDeW0Ot0j3CP9p7nWxgCGMu_H5J5ZgJSVUVlffVpaIMEGiFZ_r71PLPtuTL3GsDwtICG_5xuqoR2YBLSpNuuc46t15i94E3JC1UXGryRfxVbeHg3x5DF9nf6eVkMHRdi-CdNQn2iD0G9OmxxELh-40pecbyUxLv4NfTHmbxOdvWRK00N8sgkElnPnoWXb5pacxLShFsBTJdXIsyqF_onA';
+
+      const jwks = getJwks();
+      jwks.keys[0].kid = '4321';
+
+      setupFetchMock({jwks});
+      const result = verify(testJwt);
+
+      expect(result).rejects.toHaveProperty(
+        'name',
+        'a0.idtoken.key_retrieval_error',
+      );
+      expect(result).rejects.toHaveProperty(
+        'message',
+        'Could not find a public key for Key ID (kid) "1234"',
       );
     });
 

--- a/src/jwt/signatureVerifier.js
+++ b/src/jwt/signatureVerifier.js
@@ -71,13 +71,16 @@ const getJwk = (domain, kid) => {
           k => k.use === 'sig' && k.kty === 'RSA' && k.kid && (k.n && k.e),
         )
         .find(k => k.kid === kid);
+      if (!key) {
+        throw new Error('Key not present');
+      }
       return Promise.resolve(key);
     })
     .catch(err => {
       return Promise.reject(
         idTokenError({
           error: 'key_retrieval_error',
-          desc: 'Unable to retrieve public keyset needed to verify token',
+          desc: `Could not find a public key for Key ID (kid) "${kid}"`,
         }),
       );
     });


### PR DESCRIPTION
### Changes

Added a missing use case in which the public key the SDK requires can't be found

### Testing

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
