### PR TITLE
Added token exchange for native social endpoint [SDK-1307]

### DIFF
--- a/src/auth/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/auth/__tests__/__snapshots__/index.spec.js.snap
@@ -25,6 +25,60 @@ Array [
 ]
 `;
 
+exports[`auth code exchange for native social should handle oauth error 1`] = `[invalid_request: Invalid grant]`;
+
+exports[`auth code exchange for native social should handle unexpected error 1`] = `[a0.response.invalid: Internal Server Error]`;
+
+exports[`auth code exchange for native social should return successful response 1`] = `
+Object {
+  "accessToken": "an access token",
+  "expiresIn": 1234567890,
+  "idToken": "an id token",
+  "scope": "openid",
+  "state": "a random state for auth",
+}
+`;
+
+exports[`auth code exchange for native social should return successful response with optional parameters 1`] = `
+Object {
+  "accessToken": "an access token",
+  "expiresIn": 1234567890,
+  "idToken": "an id token",
+  "scope": "openid",
+  "state": "a random state for auth",
+}
+`;
+
+exports[`auth code exchange for native social should send correct payload 1`] = `
+Array [
+  "https://samples.auth0.com/oauth/token",
+  Object {
+    "body": "{\\"subject_token\\":\\"a subject token\\",\\"subject_token_type\\":\\"a subject token type\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\",\\"grant_type\\":\\"urn:ietf:params:oauth:grant-type:token-exchange\\"}",
+    "headers": Object {
+      "Accept": "application/json",
+      "Auth0-Client": "eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0=",
+      "Content-Type": "application/json",
+    },
+    "method": "POST",
+  },
+]
+`;
+
+exports[`auth code exchange for native social should send correct payload with optional parameters 1`] = `
+Array [
+  "https://samples.auth0.com/oauth/token",
+  Object {
+    "body": "{\\"subject_token\\":\\"a subject token\\",\\"subject_token_type\\":\\"a subject token type\\",\\"user_profile\\":{\\"name\\":{\\"firstName\\":\\"John\\",\\"lastName\\":\\"Smith\\"}},\\"audience\\":\\"http://myapi.com\\",\\"scope\\":\\"openid\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\",\\"grant_type\\":\\"urn:ietf:params:oauth:grant-type:token-exchange\\"}",
+    "headers": Object {
+      "Accept": "application/json",
+      "Auth0-Client": "eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0=",
+      "Content-Type": "application/json",
+    },
+    "method": "POST",
+  },
+]
+`;
+
 exports[`auth code exchange should handle oauth error 1`] = `[invalid_request: Invalid grant]`;
 
 exports[`auth code exchange should handle unexpected error 1`] = `[a0.response.invalid: Internal Server Error]`;

--- a/src/auth/__tests__/index.spec.js
+++ b/src/auth/__tests__/index.spec.js
@@ -160,6 +160,95 @@ describe('auth', () => {
     });
   });
 
+  describe('code exchange for native social', () => {
+    it('should send correct payload', async () => {
+      fetchMock.postOnce('https://samples.auth0.com/oauth/token', tokens);
+      expect.assertions(1);
+      await auth.exchangeNativeSocial({
+        subjectToken: 'a subject token',
+        subjectTokenType: 'a subject token type',
+      });
+      expect(fetchMock.lastCall()).toMatchSnapshot();
+    });
+
+    it('should send correct payload with optional parameters', async () => {
+      fetchMock.postOnce('https://samples.auth0.com/oauth/token', tokens);
+      expect.assertions(1);
+      await auth.exchangeNativeSocial({
+        subjectToken: 'a subject token',
+        subjectTokenType: 'a subject token type',
+        userProfile: {
+          name: {
+            firstName: 'John',
+            lastName: 'Smith',
+          },
+        },
+        audience: 'http://myapi.com',
+        scope: 'openid',
+      });
+      expect(fetchMock.lastCall()).toMatchSnapshot();
+    });
+
+    it('should return successful response', async () => {
+      fetchMock.postOnce('https://samples.auth0.com/oauth/token', tokens);
+      expect.assertions(1);
+      const parameters = {
+        subjectToken: 'a subject token',
+        subjectTokenType: 'a subject token type',
+      };
+      await expect(
+        auth.exchangeNativeSocial(parameters),
+      ).resolves.toMatchSnapshot();
+    });
+
+    it('should return successful response with optional parameters', async () => {
+      fetchMock.postOnce('https://samples.auth0.com/oauth/token', tokens);
+      expect.assertions(1);
+      const parameters = {
+        subjectToken: 'a subject token',
+        subjectTokenType: 'a subject token type',
+        userProfile: {
+          name: {
+            firstName: 'John',
+            lastName: 'Smith',
+          },
+        },
+        audience: 'http://myapi.com',
+        scope: 'openid',
+      };
+      await expect(
+        auth.exchangeNativeSocial(parameters),
+      ).resolves.toMatchSnapshot();
+    });
+
+    it('should handle oauth error', async () => {
+      fetchMock.postOnce('https://samples.auth0.com/oauth/token', oauthError);
+      expect.assertions(1);
+      const parameters = {
+        subjectToken: 'a subject token',
+        subjectTokenType: 'a subject token type',
+      };
+      await expect(
+        auth.exchangeNativeSocial(parameters),
+      ).rejects.toMatchSnapshot();
+    });
+
+    it('should handle unexpected error', async () => {
+      fetchMock.postOnce(
+        'https://samples.auth0.com/oauth/token',
+        unexpectedError,
+      );
+      expect.assertions(1);
+      const parameters = {
+        subjectToken: 'a subject token',
+        subjectTokenType: 'a subject token type',
+      };
+      await expect(
+        auth.exchangeNativeSocial(parameters),
+      ).rejects.toMatchSnapshot();
+    });
+  });
+
   describe('passwordless flow', () => {
     describe('with email connection', () => {
       it('should begin with code', async () => {

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -122,7 +122,7 @@ export default class Auth {
    * Exchanges an external token obtained via a native social authentication solution for the user's tokens
    *
    * @param {Object} parameters parameters used to obtain user tokens from an external provider's token
-   * @param {String} parameters.subjectToken code returned by the native social authentication solution
+   * @param {String} parameters.subjectToken token returned by the native social authentication solution
    * @param {String} parameters.subjectTokenType identifier that indicates the type of `subjectToken`
    * @param {String} parameters.userProfile optional element used for native iOS interactions for which profile updates can occur. Only for `APPLE-AUTHZ-CODE`
    * @param {String} parameters.audience optional API audience to request

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -126,7 +126,7 @@ export default class Auth {
    * @param {String} parameters.subjectTokenType identifier that indicates the native social authentication solution
    * @param {Object} [parameters.userProfile] additional profile attributes to set or override, only on select native social authentication solutions
    * @param {String} [parameters.audience] API audience to request
-   * @param {String} [parameters.scope] scopes to request
+   * @param {String} [parameters.scope] scopes requested for the issued tokens. e.g. `openid profile`
    * @returns {Promise}
    *
    * @see https://auth0.com/docs/api/authentication#token-exchange-for-native-social

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -119,6 +119,41 @@ export default class Auth {
   }
 
   /**
+   * Exchanges a code obtained via a native social authentication solution for the user's tokens
+   *
+   * @param {Object} parameters parameters used to obtain tokens from a code
+   * @param {String} parameters.subjectToken code returned by the native social authentication solution
+   * @param {String} parameters.subjectTokenType identifier that indicates the type of `subjectToken`
+   * @param {String} parameters.userProfile optional element used for native iOS interactions for which profile updates can occur. Only for `APPLE-AUTHZ-CODE`
+   * @param {String} parameters.audience optional API audience to request
+   * @param {String} parameters.scope optional scopes to request
+   * @returns {Promise}
+   *
+   * @memberof Auth
+   */
+  exchangeNativeSocial(parameters = {}) {
+    const payload = apply(
+      {
+        parameters: {
+          subjectToken: {required: true, toName: 'subject_token'},
+          subjectTokenType: {required: true, toName: 'subject_token_type'},
+          userProfile: {required: false, toName: 'user_profile'},
+          audience: {required: false},
+          scope: {required: false},
+        },
+      },
+      parameters,
+    );
+    return this.client
+      .post('/oauth/token', {
+        ...payload,
+        client_id: this.clientId,
+        grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+      })
+      .then(responseHandler);
+  }
+
+  /**
    * Performs Auth with user credentials using the Password Realm Grant
    *
    * @param {Object} parameters password realm parameters

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -123,7 +123,7 @@ export default class Auth {
    *
    * @param {Object} parameters parameters used to obtain user tokens from an external provider's token
    * @param {String} parameters.subjectToken token returned by the native social authentication solution
-   * @param {String} parameters.subjectTokenType identifier that indicates the type of `subjectToken`
+   * @param {String} parameters.subjectTokenType identifier that indicates the native social authentication solution
    * @param {String} parameters.userProfile optional element used for native iOS interactions for which profile updates can occur. Only for `APPLE-AUTHZ-CODE`
    * @param {String} parameters.audience optional API audience to request
    * @param {String} parameters.scope optional scopes to request

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -121,7 +121,7 @@ export default class Auth {
   /**
    * Exchanges an external token obtained via a native social authentication solution for the user's tokens
    *
-   * @param {Object} parameters parameters used to obtain tokens from a code
+   * @param {Object} parameters parameters used to obtain user tokens from an external provider's token
    * @param {String} parameters.subjectToken code returned by the native social authentication solution
    * @param {String} parameters.subjectTokenType identifier that indicates the type of `subjectToken`
    * @param {String} parameters.userProfile optional element used for native iOS interactions for which profile updates can occur. Only for `APPLE-AUTHZ-CODE`

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -119,7 +119,7 @@ export default class Auth {
   }
 
   /**
-   * Exchanges a code obtained via a native social authentication solution for the user's tokens
+   * Exchanges an external token obtained via a native social authentication solution for the user's tokens
    *
    * @param {Object} parameters parameters used to obtain tokens from a code
    * @param {String} parameters.subjectToken code returned by the native social authentication solution

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -124,9 +124,9 @@ export default class Auth {
    * @param {Object} parameters parameters used to obtain user tokens from an external provider's token
    * @param {String} parameters.subjectToken token returned by the native social authentication solution
    * @param {String} parameters.subjectTokenType identifier that indicates the native social authentication solution
-   * @param {Object} parameters.userProfile additional profile attributes to set or override, only on select native social authentication solutions
-   * @param {String} parameters.audience optional API audience to request
-   * @param {String} parameters.scope optional scopes to request
+   * @param {Object} [parameters.userProfile] additional profile attributes to set or override, only on select native social authentication solutions
+   * @param {String} [parameters.audience] API audience to request
+   * @param {String} [parameters.scope] scopes to request
    * @returns {Promise}
    *
    * @see https://auth0.com/docs/api/authentication#token-exchange-for-native-social

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -124,10 +124,12 @@ export default class Auth {
    * @param {Object} parameters parameters used to obtain user tokens from an external provider's token
    * @param {String} parameters.subjectToken token returned by the native social authentication solution
    * @param {String} parameters.subjectTokenType identifier that indicates the native social authentication solution
-   * @param {String} [parameters.userProfile] additional profile attributes to set or override, only on select native social authentication solutions
+   * @param {Object} parameters.userProfile additional profile attributes to set or override, only on select native social authentication solutions
    * @param {String} parameters.audience optional API audience to request
    * @param {String} parameters.scope optional scopes to request
    * @returns {Promise}
+   *
+   * @see https://auth0.com/docs/api/authentication#token-exchange-for-native-social
    *
    * @memberof Auth
    */

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -124,7 +124,7 @@ export default class Auth {
    * @param {Object} parameters parameters used to obtain user tokens from an external provider's token
    * @param {String} parameters.subjectToken token returned by the native social authentication solution
    * @param {String} parameters.subjectTokenType identifier that indicates the native social authentication solution
-   * @param {String} parameters.userProfile optional element used for native iOS interactions for which profile updates can occur. Only for `APPLE-AUTHZ-CODE`
+   * @param {String} [parameters.userProfile] additional profile attributes to set or override, only on select native social authentication solutions
    * @param {String} parameters.audience optional API audience to request
    * @param {String} parameters.scope optional scopes to request
    * @returns {Promise}


### PR DESCRIPTION
### Changes

- Added the [Token Exchange for Native Social](https://auth0.com/docs/api/authentication#token-exchange-for-native-social) endpoint to the Auth API

### References

- Closes https://github.com/auth0/react-native-auth0/issues/254

### Testing

- [X] This change adds unit test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [X] All active GitHub checks have passed
