### PR TITLE
handle invalid token error

### DIFF
--- a/src/auth/authError.js
+++ b/src/auth/authError.js
@@ -2,13 +2,18 @@ import BaseError from '../utils/baseError';
 
 export default class AuthError extends BaseError {
   constructor(response) {
-    const { status, json = {}, text } = response;
-    const { error, error_description: description } = json;
+    const {status, json = {}, text} = response;
+    const {error, error_description: description} = json;
     super(
       error || 'a0.response.invalid',
-      description || text || 'unknown error'
+      description || text || handleInvalidToken(response) || 'unknown error',
     );
     this.json = json;
     this.status = status;
   }
 }
+
+const handleInvalidToken = response =>
+  response?.headers?.map['www-authenticate'].match(/error="invalid_token"/g)
+    ? 'invalid_token'
+    : null;


### PR DESCRIPTION
### Changes

Updated ```AuthError``` class to return invalid_token error from www-authenticate header. Error caused when using an expired token.

### References

issue #241  

### Testing

Manual testing only

- [ ] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed

This was just a quick fix to get it working for my project, happy to take feedback and change my approach to this.
