### PR TITLE
Fixed tag in Podspec

### DIFF
--- a/ios/A0Auth0.podspec
+++ b/ios/A0Auth0.podspec
@@ -11,11 +11,10 @@ Pod::Spec.new do |s|
   s.license      = { :type => "MIT", :file => "../LICENSE" }
   s.authors      = { "Auth0" => "support@auth0.com" }
   s.platforms    = { :ios => "9.0" }
-  s.source       = { :git => "https://github.com/auth0/react-native-auth0.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/auth0/react-native-auth0.git", :tag => "v#{s.version}" }
 
   s.source_files = "*.{h,m,swift}"
   s.requires_arc = true
 
   s.dependency "React"
 end
-


### PR DESCRIPTION
### Changes

The `Podspec` was not referencing correctly the version tag, because the tags in this repo are prefixed with `v`.

### References

Closes https://github.com/auth0/react-native-auth0/issues/293

### Testing

- [ ] This change adds unit test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
