### PR TITLE
Added support for ephemeral sessions [SDK-1412]

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ The contents of previous release can be found on the [branch v1](https://github.
 
 First install the native library module:
 
-Using [npm](https://www.npmjs.com)
+### With [npm](https://www.npmjs.com)
 
 `$ npm install react-native-auth0 --save`
 
-or [yarn](https://yarnpkg.com/en/)
+### With [Yarn](https://yarnpkg.com/en/)
 
 `$ yarn add react-native-auth0`
 
-Then, you need to run the following command to install the ios app pods with Cocoapods. That will auto-link the iOS library.
+Then, you need to run the following command to install the ios app pods with Cocoapods. That will auto-link the iOS library:
 
 `$ cd ios && pod install`
 
@@ -105,11 +105,11 @@ android:windowSoftInputMode="adjustResize">
 
 The `applicationId` value will be auto-replaced on runtime with the package name or id of your application (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file. Take note of this value as you'll be requiring it to define the callback URLs below.
 
-> For more info please read [react native docs](https://facebook.github.io/react-native/docs/linking.html)
+> For more info please read the [React Native docs](https://facebook.github.io/react-native/docs/linking.html).
 
 #### iOS
 
-Inside the `ios` folder find the file `AppDelegate.[swift|m]` add the following to it
+Inside the `ios` folder find the file `AppDelegate.[swift|m]` add the following to it:
 
 ```objc
 #import <React/RCTLinkingManager.h>
@@ -129,7 +129,7 @@ Inside the `ios` folder open the `Info.plist` and locate the value for `CFBundle
 <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 ```
 
-and then below it register a URL type entry using the value of `CFBundleIdentifier` as the value for `CFBundleURLSchemes`
+and then below it register a URL type entry using the value of `CFBundleIdentifier` as the value for `CFBundleURLSchemes`:
 
 ```xml
 <key>CFBundleURLTypes</key>
@@ -154,7 +154,7 @@ If your application is generated using the React Native CLI, the default value o
 - Replace the **Product Bundle Identifier** value with your desired application's bundle identifier name (e.g. `com.example.app`).
 - If you've changed the project wide settings, make sure the same were applied to each of the targets your app has.
 
-> For more info please read [react native docs](https://facebook.github.io/react-native/docs/linking.html)
+> For more info please read the [React Native docs](https://facebook.github.io/react-native/docs/linking.html).
 
 ### Callback URL(s)
 
@@ -199,7 +199,7 @@ const auth0 = new Auth0({
 
 ### Web Authentication
 
-#### Log in
+#### Login
 
 ```js
 auth0.webAuth
@@ -208,7 +208,18 @@ auth0.webAuth
   .catch(error => console.log(error));
 ```
 
-#### Log out
+##### Disable Single Sign On (iOS 13+ only)
+
+Use the `ephemeralSession` parameter to disable SSO on iOS 13+. This way iOS will not display the consent popup that otherwise shows up when SSO is enabled. It has no effect on older versions of iOS or Android.
+
+```js
+auth0.webAuth
+  .authorize({scope: 'openid email profile'}, {ephemeralSession: true})
+  .then(credentials => console.log(credentials))
+  .catch(error => console.log(error));
+```
+
+#### Logout
 
 ```js
 auth0.webAuth.clearSession().catch(error => console.log(error));

--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -43,11 +43,14 @@ RCT_EXPORT_METHOD(hide) {
     [self terminateWithError:nil dismissing:YES animated:YES];
 }
 
-RCT_EXPORT_METHOD(showUrl:(NSString *)urlString closeOnLoad:(BOOL)closeOnLoad callback:(RCTResponseSenderBlock)callback) {
+RCT_EXPORT_METHOD(showUrl:(NSString *)urlString
+                  usingEphemeralSession:(BOOL)ephemeralSession
+                  closeOnLoad:(BOOL)closeOnLoad
+                  callback:(RCTResponseSenderBlock)callback) {
     if (@available(iOS 11.0, *)) {
         self.sessionCallback = callback;
         self.closeOnLoad = closeOnLoad;
-        [self presentAuthenticationSession:[NSURL URLWithString:urlString]];
+        [self presentAuthenticationSession:[NSURL URLWithString:urlString] usingEphemeralSession:ephemeralSession];
     } else {
         [self presentSafariWithURL:[NSURL URLWithString:urlString]];
         self.sessionCallback = callback;
@@ -80,7 +83,7 @@ UIBackgroundTaskIdentifier taskId;
     self.last = controller;
 }
 
-- (void)presentAuthenticationSession:(NSURL *)url {
+- (void)presentAuthenticationSession:(NSURL *)url usingEphemeralSession:(BOOL)ephemeralSession {
     
     NSURLComponents *urlComponents = [NSURLComponents componentsWithURL:url
                                                 resolvingAgainstBaseURL:NO];
@@ -116,6 +119,7 @@ UIBackgroundTaskIdentifier taskId;
         #if __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000
         if (@available(iOS 13.0, *)) {
             authenticationSession.presentationContextProvider = self;
+            authenticationSession.prefersEphemeralWebBrowserSession = ephemeralSession;
         }
         #endif
         self.authenticationSession = authenticationSession;

--- a/src/webauth/__mocks__/auth0.js
+++ b/src/webauth/__mocks__/auth0.js
@@ -1,6 +1,16 @@
 export default class A0Auth0 {
-  showUrl(url, closeOnLoad, callback) {
-    this.url = url;
+  showUrl(...args) {
+    let closeOnLoad;
+    let callback;
+    this.url = args[0];
+    if (args.length == 3) {
+      closeOnLoad = args[1];
+      callback = args[2];
+    } else {
+      this.ephemeralSession = args[1];
+      closeOnLoad = args[2];
+      callback = args[3];
+    }
     this.hidden = false;
     if (this.error || closeOnLoad) {
       callback(this.error);

--- a/src/webauth/__tests__/agent.spec.js
+++ b/src/webauth/__tests__/agent.spec.js
@@ -1,6 +1,6 @@
 jest.mock('react-native');
 import Agent from '../agent';
-import {NativeModules, Linking} from 'react-native';
+import {NativeModules, Linking, Platform} from 'react-native';
 const A0Auth0 = NativeModules.A0Auth0;
 
 describe('Agent', () => {
@@ -37,6 +37,22 @@ describe('Agent', () => {
         const url = 'https://auth0.com/authorize';
         await agent.show(url);
         expect(A0Auth0.url).toEqual(url);
+      });
+
+      it('should not use ephemeral session by default', async () => {
+        Platform.OS = 'ios';
+        expect.assertions(1);
+        const url = 'https://auth0.com';
+        await agent.show(url);
+        expect(A0Auth0.ephemeralSession).toEqual(false);
+      });
+
+      it('should set ephemeral session', async () => {
+        Platform.OS = 'ios';
+        expect.assertions(1);
+        const url = 'https://auth0.com';
+        await agent.show(url, true);
+        expect(A0Auth0.ephemeralSession).toEqual(true);
       });
     });
 

--- a/src/webauth/__tests__/agent.spec.js
+++ b/src/webauth/__tests__/agent.spec.js
@@ -1,6 +1,6 @@
 jest.mock('react-native');
 import Agent from '../agent';
-import { NativeModules, Linking } from 'react-native';
+import {NativeModules, Linking} from 'react-native';
 const A0Auth0 = NativeModules.A0Auth0;
 
 describe('Agent', () => {
@@ -21,14 +21,14 @@ describe('Agent', () => {
     describe('complete web flow', () => {
       beforeEach(() => {
         A0Auth0.onUrl = () => {
-          Linking.emitter.emit('url', { url: 'https://auth0.com' });
+          Linking.emitter.emit('url', {url: 'https://auth0.com'});
         };
       });
 
       it('should resolve promise with url result', async () => {
         expect.assertions(1);
         await expect(
-          agent.show('https://auth0.com')
+          agent.show('https://auth0.com'),
         ).resolves.toMatchSnapshot();
       });
 
@@ -50,7 +50,7 @@ describe('Agent', () => {
 
       it('should remove url listeners when done', async () => {
         A0Auth0.onUrl = () => {
-          Linking.emitter.emit('url', { url: 'https://auth0.com' });
+          Linking.emitter.emit('url', {url: 'https://auth0.com'});
         };
         expect.assertions(1);
         const url = 'https://auth0.com/authorize';
@@ -69,7 +69,7 @@ describe('Agent', () => {
       it('should remove url listeners on first load', async () => {
         expect.assertions(1);
         const url = 'https://auth0.com/authorize';
-        await agent.show(url, true);
+        await agent.show(url, false, true);
         expect(Linking.emitter.listenerCount('url')).toEqual(0);
       });
     });
@@ -85,7 +85,7 @@ describe('Agent', () => {
 
   describe('newTransaction', () => {
     it('should call native integration', async () => {
-      const parameters = { state: 'state' };
+      const parameters = {state: 'state'};
       A0Auth0.parameters = parameters;
       expect.assertions(1);
       await expect(agent.newTransaction()).resolves.toMatchSnapshot();

--- a/src/webauth/__tests__/agent.spec.js
+++ b/src/webauth/__tests__/agent.spec.js
@@ -39,6 +39,13 @@ describe('Agent', () => {
         expect(A0Auth0.url).toEqual(url);
       });
 
+      it('should not pass ephemeral session parameter', async () => {
+        expect.assertions(1);
+        const url = 'https://auth0.com';
+        await agent.show(url);
+        expect(A0Auth0.ephemeralSession).toBeUndefined();
+      });
+
       it('should not use ephemeral session by default', async () => {
         Platform.OS = 'ios';
         expect.assertions(1);

--- a/src/webauth/agent.js
+++ b/src/webauth/agent.js
@@ -5,7 +5,7 @@ export default class Agent {
     if (!NativeModules.A0Auth0) {
       return Promise.reject(
         new Error(
-          'Missing NativeModule. React Native versions 0.60 and up perform auto-linking. Please see https://github.com/react-native-community/cli/blob/master/docs/autolinking.md.',
+          'Missing NativeModule. React Native versions 0.60 and up perform auto-linking. Please see https://github.com/react-native-community/cli/blob/master/docs/autolinking.md.'
         ),
       );
     }

--- a/src/webauth/agent.js
+++ b/src/webauth/agent.js
@@ -1,12 +1,12 @@
-import { NativeModules, Linking } from 'react-native';
+import {NativeModules, Linking, Platform} from 'react-native';
 
 export default class Agent {
-  show(url, closeOnLoad = false) {
+  show(url, ephemeralSession = false, closeOnLoad = false) {
     if (!NativeModules.A0Auth0) {
       return Promise.reject(
         new Error(
-          'Missing NativeModule. React Native versions 0.60 and up perform auto-linking. Please see https://github.com/react-native-community/cli/blob/master/docs/autolinking.md.'
-        )
+          'Missing NativeModule. React Native versions 0.60 and up perform auto-linking. Please see https://github.com/react-native-community/cli/blob/master/docs/autolinking.md.',
+        ),
       );
     }
 
@@ -16,14 +16,16 @@ export default class Agent {
         Linking.removeEventListener('url', urlHandler);
         resolve(event.url);
       };
+      const params =
+        Platform.OS === 'ios' ? [ephemeralSession, closeOnLoad] : [closeOnLoad];
       Linking.addEventListener('url', urlHandler);
-      NativeModules.A0Auth0.showUrl(url, closeOnLoad, (error, redirectURL) => {
+      NativeModules.A0Auth0.showUrl(url, ...params, (error, redirectURL) => {
         Linking.removeEventListener('url', urlHandler);
         if (error) {
           reject(error);
-        } else if(redirectURL) {
+        } else if (redirectURL) {
           resolve(redirectURL);
-        } else if(closeOnLoad) {
+        } else if (closeOnLoad) {
           resolve();
         }
       });
@@ -34,8 +36,8 @@ export default class Agent {
     if (!NativeModules.A0Auth0) {
       return Promise.reject(
         new Error(
-          'Missing NativeModule. React Native versions 0.60 and up perform auto-linking. Please see https://github.com/react-native-community/cli/blob/master/docs/autolinking.md.'
-        )
+          'Missing NativeModule. React Native versions 0.60 and up perform auto-linking. Please see https://github.com/react-native-community/cli/blob/master/docs/autolinking.md.',
+        ),
       );
     }
 

--- a/src/webauth/index.js
+++ b/src/webauth/index.js
@@ -50,7 +50,7 @@ export default class WebAuth {
    * @param {Number}  [parameters.max_age] The allowable elapsed time in seconds since the last time the user was authenticated (optional).
    * @param {Object}  options Other configuration options.
    * @param {Number}  [options.leeway] The amount of leeway, in seconds, to accommodate potential clock skew when validating an ID token's claims. Defaults to 60 seconds if not specified.
-   * @param {Boolean} [options.ephemeralSession] Disable SSO on iOS 13+. Has no effect on older versions of iOS.
+   * @param {Boolean} [options.ephemeralSession] Disable Single-Sign-On (SSO). It only affects iOS with versions 13 and above.
    * @returns {Promise}
    * @see https://auth0.com/docs/api/authentication#authorize-client
    *


### PR DESCRIPTION
### Changes

- Added a new boolean parameter called `ephemeralSession` to the `options` object that sets `prefersEphemeralWebBrowserSession` to `true` on iOS 13+. It has no effect on older versions of iOS, or on Android. **Usage of this method disables SSO.**

### References

Closes https://github.com/auth0/react-native-auth0/issues/294

### Testing

This change was tested manually by performing login and logout on iOS and Android.

- [X] This change adds unit test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [X] All active GitHub checks have passed