### PR TITLE
Warn when bundle identifier contains uppercase characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ If your application is generated using the React Native CLI, the default value o
 
 Callback URLs are the URLs that Auth0 invokes after the authentication process. Auth0 routes your application back to this URL and appends additional parameters to it, including a token. Since callback URLs can be manipulated, you will need to add this URL to your Application's **Allowed Callback URLs** for security. This will enable Auth0 to recognize these URLs as valid. If omitted, authentication will not be successful.
 
-> Callback URLs must have a valid scheme value as defined by the [specification](https://tools.ietf.org/html/rfc3986#page-17). Note however that platforms like Android don't follow this RFC and define the scheme and host values as case-sensitive. Since this SDK makes use of the Android's Package Name and its analogous iOS's Product Bundle Identifier to generate the redirect URL, it's advised to use lower case values for such. A "Redirect URI is not valid" error will raise if this format is not respected.
+On the Android platform this URL is case-sensitive. Because of that, this SDK will auto convert the Bundle Identifier (iOS) and Application ID (Android) values to lowercase in order to build the Callback URL with them. If any of these values contains uppercase characters a warning message will be printed in the console. Make sure to check that the right Callback URL is whitelisted in the Auth0 dashboard or the browser will not route succesfully back to your application.
 
 Go to the [Auth0 Dashboard](https://manage.auth0.com/#/applications), select your application and make sure that **Allowed Callback URLs** contains the URLs defined below.
 

--- a/src/webauth/index.js
+++ b/src/webauth/index.js
@@ -9,9 +9,13 @@ const {A0Auth0} = NativeModules;
 
 const callbackUri = domain => {
   const bundleIdentifier = A0Auth0.bundleIdentifier;
-  return `${bundleIdentifier.toLowerCase()}://${domain}/${
-    Platform.OS
-  }/${bundleIdentifier}/callback`;
+  const lowerCasedIdentifier = bundleIdentifier.toLowerCase();
+  if (bundleIdentifier !== lowerCasedIdentifier) {
+    console.warn(
+      'The Bundle Identifier or Application ID of your app contains uppercase characters and will be lowercased to build the Callback URL. Check the Auth0 dashboard to whitelist the right URL value.',
+    );
+  }
+  return `${lowerCasedIdentifier}://${domain}/${Platform.OS}/${bundleIdentifier}/callback`;
 };
 
 /**


### PR DESCRIPTION
### Changes

In order to improve DX when the Application ID (android) or Bundle Identifier (iOS) values have uppercase characters, a warning will be printed to the device console. This warning only appears on the non-production environment according to the react-native docs.

**This is just a warning! The authorize call will go through regardless of the bundle identifier value.**

The warning message is the following:

`
"The Bundle Identifier or Application ID of your app contains uppercase characters and will be lowercased to build the Callback URL. Check the Auth0 dashboard to whitelist the right URL value."
`

This PR also rephrases the callback URLs section of the README. (feedback?)

### References

React native docs about warnings https://reactnative.dev/docs/debugging#warnings
Resolves https://github.com/auth0/react-native-auth0/issues/130

### Testing
No unit tests, only manual.

![image](https://user-images.githubusercontent.com/3900123/84089727-1dfd9c00-a9c6-11ea-94f6-930c6b23d535.png)


![image](https://user-images.githubusercontent.com/3900123/84089438-5b155e80-a9c5-11ea-82c6-c3536a14748c.png)

![image](https://user-images.githubusercontent.com/3900123/84089429-56e94100-a9c5-11ea-9116-0eb1867b4df1.png)


- [ ] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
