### PR TITLE
Add compileOptions for JDK 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,6 +37,10 @@ android {
   lintOptions {
     abortOnError false
   }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_1_8
+    targetCompatibility JavaVersion.VERSION_1_8
+  }
 }
 
 repositories {


### PR DESCRIPTION
This fixes gradle builds with a minSdkVersion lower than 24

### Changes

Added `compileOptions` entry to `android/build.gradle`.

### References

#322

### Testing

See reproduction guide in #322 

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
