### PR TITLE
Fix the www-authenticate header parsing logic

### DIFF
--- a/src/auth/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/auth/__tests__/__snapshots__/index.spec.js.snap
@@ -353,9 +353,13 @@ Array [
 ]
 `;
 
+exports[`auth refresh token should handle invalid token error 1`] = `[a0.response.invalid: invalid_token]`;
+
 exports[`auth refresh token should handle oauth error 1`] = `[invalid_request: Invalid grant]`;
 
 exports[`auth refresh token should handle unexpected error 1`] = `[a0.response.invalid: Internal Server Error]`;
+
+exports[`auth refresh token should handle unknown error 1`] = `[a0.response.invalid: unknown error]`;
 
 exports[`auth refresh token should return successful response 1`] = `
 Object {

--- a/src/auth/__tests__/index.spec.js
+++ b/src/auth/__tests__/index.spec.js
@@ -452,6 +452,26 @@ describe('auth', () => {
       expect.assertions(1);
       await expect(auth.refreshToken(parameters)).rejects.toMatchSnapshot();
     });
+
+    it('should handle invalid token error', async () => {
+      fetchMock.postOnce('https://samples.auth0.com/oauth/token', {
+        status: 401,
+        body: {},
+        headers: {'www-authenticate': 'Bearer error="invalid_token"'},
+      });
+      expect.assertions(1);
+      await expect(auth.refreshToken(parameters)).rejects.toMatchSnapshot();
+    });
+
+    it('should handle unknown error', async () => {
+      fetchMock.postOnce('https://samples.auth0.com/oauth/token', {
+        status: 401,
+        body: {},
+        headers: {},
+      });
+      expect.assertions(1);
+      await expect(auth.refreshToken(parameters)).rejects.toMatchSnapshot();
+    });
   });
 
   describe('revoke token', () => {

--- a/src/auth/authError.js
+++ b/src/auth/authError.js
@@ -14,6 +14,6 @@ export default class AuthError extends BaseError {
 }
 
 const handleInvalidToken = response =>
-  response?.headers?.map['www-authenticate'].match(/error="invalid_token"/g)
+  response?.headers?.get('www-authenticate')?.match(/error="invalid_token"/g)
     ? 'invalid_token'
     : null;


### PR DESCRIPTION
### Changes

The header object is a special list that must be accessed with `get(name)`, otherwise, there are certain `cors` [scenarios](https://developers.google.com/web/updates/2015/03/introduction-to-fetch#response_types) where not all the headers would be exposed.

This PR handles the possibility of that header not being set and ensures the last fallback is also test-covered.

### References

https://github.com/auth0/react-native-auth0/pull/285 introduced a change that wasn't properly tested

### Testing

- [x] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
