### PR TITLE
Add Bot Protection guidance to README [SDK-1898]

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,6 @@ const scope = 'openid profile';
 
 auth0.auth
   .passwordRealm({
-    // Or createUser for signup
     username: email,
     password: 'secret-password',
     realm: realm,

--- a/README.md
+++ b/README.md
@@ -395,12 +395,13 @@ auth0.auth
 In the case of signup, you can add [an additional parameter](https://auth0.com/docs/universal-login/new-experience#signup) to make the user land directly on the signup page:
 
 ```js
-auth0.webAuth.authorize({
-  connection: realm,
-  scope: scope,
-  login_hint: email,
-  screen_hint: 'signup', // 👈🏻
-});
+auth0.webAuth
+  .authorize({
+    connection: realm,
+    scope: scope,
+    login_hint: email,
+    screen_hint: 'signup', // 👈🏻
+  });
 ```
 
 Check out how to set up Universal Login in the [Getting Started](#getting-started) section.

--- a/README.md
+++ b/README.md
@@ -355,6 +355,53 @@ auth0
 
 For more info please check our generated [documentation](http://auth0.github.io/react-native-auth0/index.html)
 
+### Bot Protection
+
+If you are using the [Bot Protection](https://auth0.com/docs/anomaly-detection/bot-protection) feature and performing database login/signup via the Authentication API, you need to handle the `requires_verification` error. It indicates that the request was flagged as suspicious and an additional verification step is necessary to log the user in. That verification step is web-based, so you need to use Universal Login to complete it.
+
+```js
+const email = 'support@auth0.com';
+const realm = 'Username-Password-Authentication';
+const scope = 'openid profile';
+
+auth0.auth
+  .passwordRealm({
+    // Or createUser for signup
+    username: email,
+    password: 'secret-password',
+    realm: realm,
+    scope: scope,
+  })
+  .then(console.log)
+  .catch(error => {
+    if (error.name === 'requires_verification') {
+      auth0.webAuth
+        .authorize({
+          connection: realm,
+          scope: scope,
+          login_hint: email, // So the user doesn't have to type it again
+        })
+        .then(console.log)
+        .catch(console.error);
+    } else {
+      console.error(error);
+    }
+  });
+```
+
+In the case of signup, you can add [an additional parameter](https://auth0.com/docs/universal-login/new-experience#signup) to make the user land directly on the signup page:
+
+```js
+authorize({
+  connection: realm,
+  scope: scope,
+  login_hint: email,
+  screen_hint: 'signup', // 👈🏻
+});
+```
+
+Check out how to set up Universal Login in the [Getting Started](#getting-started) section.
+
 ## Contributing
 
 We appreciate feedback and contribution to this repo! Before you get started, please see the following:

--- a/README.md
+++ b/README.md
@@ -371,7 +371,9 @@ auth0.auth
     realm: realm,
     scope: scope,
   })
-  .then(console.log)
+  .then(credentials => {
+    // Logged in!
+  })
   .catch(error => {
     if (error.name === 'requires_verification') {
       auth0.webAuth
@@ -380,7 +382,9 @@ auth0.auth
           scope: scope,
           login_hint: email, // So the user doesn't have to type it again
         })
-        .then(console.log)
+        .then(credentials => {
+          // Logged in!
+        })
         .catch(console.error);
     } else {
       console.error(error);
@@ -391,7 +395,7 @@ auth0.auth
 In the case of signup, you can add [an additional parameter](https://auth0.com/docs/universal-login/new-experience#signup) to make the user land directly on the signup page:
 
 ```js
-authorize({
+auth0.webAuth.authorize({
   connection: realm,
   scope: scope,
   login_hint: email,


### PR DESCRIPTION
### Changes

This PR adds guidance was added to the README regarding how to handle the `requires_verification` error returned when the [Bot Protection](https://auth0.com/docs/anomaly-detection/bot-protection) feature is enabled and a login/sign up request is flagged as suspicious.

### Testing

The code snippet was tested manually for both login and signup on the React Native [sample app](https://github.com/auth0-samples/auth0-react-native-sample).

- [ ] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [X] All active GitHub checks have passed
