### PR TITLE
Added support for using a custom scheme in the callback URL [SDK-2223]

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,11 @@ android:windowSoftInputMode="adjustResize">
 </activity>
 ```
 
-The `applicationId` value will be auto-replaced on runtime with the package name or id of your application (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file. Take note of this value as you'll be requiring it to define the callback URLs below.
+The `applicationId` value will be auto-replaced on runtime with the package name or id of your application (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.
+
+If you use a value other than `applicationId` in `android:scheme` you will also need to pass it as the `customScheme` option parameter of the `authorize` and `clearSession` methods.
+
+Take note of this value as you'll be requiring it to define the callback URLs below.
 
 > For more info please read the [React Native docs](https://facebook.github.io/react-native/docs/linking.html).
 
@@ -155,6 +159,8 @@ If your application is generated using the React Native CLI, the default value o
 - Replace the **Product Bundle Identifier** value with your desired application's bundle identifier name (e.g. `com.example.app`).
 - If you've changed the project wide settings, make sure the same were applied to each of the targets your app has.
 
+If you use a value other than `$(PRODUCT_BUNDLE_IDENTIFIER)` in the `CFBundleURLSchemes` field of the `Info.plist` you will also need to pass it as the `customScheme` option parameter of the `authorize` and `clearSession` methods.
+
 > For more info please read the [React Native docs](https://facebook.github.io/react-native/docs/linking.html).
 
 ### Callback URL(s)
@@ -170,18 +176,18 @@ If in addition you plan to use the log out method, you must also add these URLs 
 #### Android
 
 ```text
-{YOUR_APP_PACKAGE_NAME}://{YOUR_AUTH0_DOMAIN}/android/{YOUR_APP_PACKAGE_NAME}/callback
+{YOUR_APP_PACKAGE_NAME_OR_CUSTOM_SCHEME}://{YOUR_AUTH0_DOMAIN}/android/{YOUR_APP_PACKAGE_NAME}/callback
 ```
 
-> Make sure to replace {YOUR_APP_PACKAGE_NAME} and {YOUR_AUTH0_DOMAIN} with the actual values for your application.
+> Make sure to replace {YOUR_APP_PACKAGE_NAME_OR_CUSTOM_SCHEME} and {YOUR_AUTH0_DOMAIN} with the actual values for your application.
 
 #### iOS
 
 ```text
-{YOUR_BUNDLE_IDENTIFIER}://{YOUR_AUTH0_DOMAIN}/ios/{YOUR_BUNDLE_IDENTIFIER}/callback
+{YOUR_BUNDLE_IDENTIFIER_OR_CUSTOM_SCHEME}://{YOUR_AUTH0_DOMAIN}/ios/{YOUR_BUNDLE_IDENTIFIER}/callback
 ```
 
-> Make sure to replace {YOUR_BUNDLE_IDENTIFIER} and {YOUR_AUTH0_DOMAIN} with the actual values for your application.
+> Make sure to replace {YOUR_BUNDLE_IDENTIFIER_OR_CUSTOM_SCHEME} and {YOUR_AUTH0_DOMAIN} with the actual values for your application.
 
 ## Usage
 

--- a/src/webauth/__tests__/webauth.spec.js
+++ b/src/webauth/__tests__/webauth.spec.js
@@ -1,21 +1,21 @@
 jest.mock('react-native');
 import Auth from '../../auth';
 import WebAuth from '../index';
-import { NativeModules } from 'react-native';
-import { URL } from 'url';
+import {NativeModules} from 'react-native';
+import {URL} from 'url';
 
 const A0Auth0 = NativeModules.A0Auth0;
 
 describe('WebAuth', () => {
-  const auth = new Auth({ baseUrl: 'https://auth0.com', clientId: 'abc123' });
+  const auth = new Auth({baseUrl: 'https://auth0.com', clientId: 'abc123'});
   const webauth = new WebAuth(auth);
 
-  describe('clearSession', () => {
-    beforeEach(() => {
-      NativeModules.A0Auth0 = A0Auth0;
-      A0Auth0.reset();
-    });
+  beforeEach(() => {
+    NativeModules.A0Auth0 = A0Auth0;
+    A0Auth0.reset();
+  });
 
+  describe('clearSession', () => {
     it('should open log out URL', async () => {
       await webauth.clearSession();
 
@@ -24,7 +24,7 @@ describe('WebAuth', () => {
       expect(parsedUrl.hostname).toEqual('auth0.com');
       const urlQuery = parsedUrl.searchParams;
       expect(urlQuery.get('returnTo')).toEqual(
-        'com.my.app://auth0.com/test-os/com.My.App/callback'
+        'com.my.app://auth0.com/test-os/com.My.App/callback',
       );
       expect(urlQuery.get('client_id')).toEqual('abc123');
       expect(urlQuery.has('federated')).toEqual(false);
@@ -32,7 +32,7 @@ describe('WebAuth', () => {
     });
 
     it('should open log out URL with federated=true', async () => {
-      const options = { federated: true };
+      const options = {federated: true};
       await webauth.clearSession(options);
 
       const parsedUrl = new URL(A0Auth0.url);
@@ -40,11 +40,47 @@ describe('WebAuth', () => {
       expect(parsedUrl.hostname).toEqual('auth0.com');
       const urlQuery = parsedUrl.searchParams;
       expect(urlQuery.get('returnTo')).toEqual(
-        'com.my.app://auth0.com/test-os/com.My.App/callback'
+        'com.my.app://auth0.com/test-os/com.My.App/callback',
       );
       expect(urlQuery.get('client_id')).toEqual('abc123');
       expect(urlQuery.get('federated')).toEqual('true');
       expect(urlQuery.has('auth0Client')).toEqual(true);
+    });
+  });
+
+  describe('custom scheme', () => {
+    it('should build the callback URL with a custom scheme when logging in', async () => {
+      const newTransactionMock = jest
+        .spyOn(webauth.agent, 'newTransaction')
+        .mockImplementation(() =>
+          Promise.resolve({state: 'state', verifier: 'verifier'}),
+        );
+      const showMock = jest
+        .spyOn(webauth.agent, 'show')
+        .mockImplementation(authorizeUrl => ({
+          then: () => Promise.resolve(authorizeUrl),
+        }));
+      const options = {customScheme: 'custom-scheme'};
+      let url = await webauth.authorize({}, options);
+
+      const parsedUrl = new URL(url);
+      const urlQuery = parsedUrl.searchParams;
+      expect(urlQuery.get('redirect_uri')).toEqual(
+        'custom-scheme://auth0.com/test-os/com.My.App/callback',
+      );
+      newTransactionMock.mockRestore();
+      showMock.mockRestore();
+    });
+
+    it('should build the callback URL with a custom scheme when logging out', async () => {
+      const options = {customScheme: 'custom-scheme'};
+      await webauth.clearSession(options);
+
+      const parsedUrl = new URL(A0Auth0.url);
+      const urlQuery = parsedUrl.searchParams;
+      expect(urlQuery.get('returnTo')).toEqual(
+        'custom-scheme://auth0.com/test-os/com.My.App/callback',
+      );
     });
   });
 });

--- a/src/webauth/index.js
+++ b/src/webauth/index.js
@@ -57,6 +57,7 @@ export default class WebAuth {
    * @param {Object}  options Other configuration options.
    * @param {Number}  [options.leeway] The amount of leeway, in seconds, to accommodate potential clock skew when validating an ID token's claims. Defaults to 60 seconds if not specified.
    * @param {Boolean} [options.ephemeralSession] Disable Single-Sign-On (SSO). It only affects iOS with versions 13 and above.
+   * @param {String}  [options.customScheme] Custom scheme to build the callback URL with.
    * @returns {Promise}
    * @see https://auth0.com/docs/api/authentication#authorize-client
    *
@@ -126,6 +127,7 @@ export default class WebAuth {
    *
    * @param {Object} parameters Parameters to send
    * @param {Bool} [parameters.federated] Optionally remove the IdP session.
+   * @param {String} [parameters.customScheme] Custom scheme to build the callback URL with.
    * @returns {Promise}
    * @see https://auth0.com/docs/logout
    *


### PR DESCRIPTION
### Changes

The Bundle Identifier / Application ID might contain characters not allowed in a URL scheme. This PR adds support for specifying a custom scheme to be used instead.

### Testing

- [X] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [X] All active GitHub checks have passed
