### PR TITLE
Fix for Xcode 12.5 [SDK-2545]

### DIFF
--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -92,7 +92,7 @@ UIBackgroundTaskIdentifier taskId;
     NSURLQueryItem *queryItem = [[queryItems
                                   filteredArrayUsingPredicate:predicate]
                                  firstObject];
-    NSString *callbackURLScheme = queryItem.value;
+    NSString *callbackURLScheme = [[NSURL URLWithString: queryItem.value] scheme];
     RCTResponseSenderBlock callback = self.sessionCallback ? self.sessionCallback : ^void(NSArray *_unused) {};
 
     if (@available(iOS 12.0, *)) {


### PR DESCRIPTION
### Changes

Since version 12.5 (released on 26 Apr 2021), Xcode no longer accepts an entire URL for the `ASWebAuthenticationSession` scheme value. This PR extracts the scheme from the URL and uses just that, instead of the whole `/authorize` URL.

### References

Fixes #360

### Testing

- [ ] This change adds unit test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
