### PR TITLE
Add ephemeral session information to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ auth0.webAuth
 auth0.webAuth.clearSession().catch(error => console.log(error));
 ```
 
+If you're using the `ephemeralSession` parameter, you do not need to call `clearSession()` to perform logout on iOS, as there will be no cookies to remove. Just deleting the credentials will suffice. You will still need to call `clearSession()` on Android, though, as `ephemeralSession` is iOS-only.
+
 ### Authentication API
 
 ### Important: Database Connection Authentication


### PR DESCRIPTION
### Changes

This PR adds information to the README about performing logout on iOS when the `ephemeralSession` parameter is being used.

### Testing

- [ ] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
