### PR TITLE
Add React 17 to the package.json semver range

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "licenseFilename": "LICENSE",
   "readmeFilename": "README.md",
   "peerDependencies": {
-    "react": "^16.11.0",
+    "react": "^16.11.0 || ^17",
     "react-native": ">=0.62.2 <1.0.x"
   },
   "devDependencies": {


### PR DESCRIPTION
### Changes

React is a peer dependency of this package. This PR adds React 17 to the semver range in the `package.json` so it can be used with the latest version of React Native without forcing install with `npm i --force`.

### Testing

- [ ] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [X] All active GitHub checks have passed
