### PR TITLE
Fix error type provided to showUrl callback on iOS

### DIFF
--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -108,7 +108,7 @@ UIBackgroundTaskIdentifier taskId;
                                               [error code] == ASWebAuthenticationSessionErrorCodeCanceledLogin) {
                                               callback(@[ERROR_CANCELLED, [NSNull null]]);
                                           } else if(error) {
-                                              callback(@[error, [NSNull null]]);
+                                              callback(@[[self generateErrorParameters:error], [NSNull null]]);
                                           } else if(callbackURL) {
                                               callback(@[[NSNull null], callbackURL.absoluteString]);
                                           }
@@ -137,7 +137,7 @@ UIBackgroundTaskIdentifier taskId;
                                               [error code] == SFAuthenticationErrorCanceledLogin) {
                                               callback(@[ERROR_CANCELLED, [NSNull null]]);
                                           } else if(error) {
-                                              callback(@[error, [NSNull null]]);
+                                              callback(@[[self generateErrorParameters:error], [NSNull null]]);
                                           } else if(callbackURL) {
                                               callback(@[[NSNull null], callbackURL.absoluteString]);
                                           }
@@ -207,6 +207,13 @@ UIBackgroundTaskIdentifier taskId;
              @"code_challenge": [self sign:verifier],
              @"code_challenge_method": @"S256",
              @"state": [self randomValue]
+             };
+}
+
+- (NSDictionary *)generateErrorParameters:(NSError *)error {
+    return @{
+             @"error": [error localizedDescription],
+             @"error_code": [NSNumber numberWithInt:[error code]]
              };
 }
 


### PR DESCRIPTION
The existing code was providing an `NSError` to the callback for
`showUrl`. This ends up being `null` in the calling Javascript code
which results in an incomplete Promise that should have been
rejected.

This change simply creates a dictionary with the error information
so the Javascript code recognizes the error.

### Changes

Please describe both what is changing and why this is important. Include:

- The changes are limited to the type of object provided to the callback for `showUrl`. No change is required to integrating code. This simply fixes a situation where errors are not currently recognized.

### References

issue #380 

### Testing

This was tested in an environment where I am currently getting an error on `authorize` on an iPhone device. Previously the Promise for `showUrl` would not be completed but now it is rejected with the proper error data coming through.

- [ ] This change adds unit test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [X] All active GitHub checks have passed
