### PR TITLE
Add a note to the README about manifest placeholders when using flavors

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ android {
 
 The `applicationId` value will be auto-replaced on runtime with the package name or id of your application (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.
 
-> Note that if you're using [flavors](https://developer.android.com/studio/build/build-variants#product-flavors) with different application IDs, you'll need to set up the manifest placeholders for each flavor.
+> Note that if your Android application is using [product flavors](https://developer.android.com/studio/build/build-variants#product-flavors), you might need to specify different manifest placeholders for each flavor.
 
 If you use a value other than `applicationId` in `auth0Scheme` you will also need to pass it as the `customScheme` option parameter of the `authorize` and `clearSession` methods.
 

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ android {
 
 The `applicationId` value will be auto-replaced on runtime with the package name or id of your application (e.g. `com.example.app`). You can change this value from the `build.gradle` file. You can also check it at the top of your `AndroidManifest.xml` file.
 
+> Note that if you're using [flavors](https://developer.android.com/studio/build/build-variants#product-flavors) with different application IDs, you'll need to set up the manifest placeholders for each flavor.
+
 If you use a value other than `applicationId` in `auth0Scheme` you will also need to pass it as the `customScheme` option parameter of the `authorize` and `clearSession` methods.
 
 Take note of this value as you'll be requiring it to define the callback URLs below.


### PR DESCRIPTION
### Changes

This PR adds a note to the README about the need to set up the manifest placeholders differently when using flavors with different application ID values.

### References

From https://github.com/auth0/react-native-auth0/issues/392

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
