### PR TITLE
Disable whitelist on auth refreshToken call (#385)

### DIFF
--- a/src/auth/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/auth/__tests__/__snapshots__/index.spec.js.snap
@@ -375,7 +375,7 @@ exports[`auth refresh token should send correct payload 1`] = `
 Array [
   "https://samples.auth0.com/oauth/token",
   Object {
-    "body": "{\\"refresh_token\\":\\"a refresh token of a user\\",\\"scope\\":\\"openid\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\",\\"grant_type\\":\\"refresh_token\\"}",
+    "body": "{\\"refresh_token\\":\\"a refresh token of a user\\",\\"scope\\":\\"openid\\",\\"customParam\\":\\"a custom value which should not be filtered out\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\",\\"grant_type\\":\\"refresh_token\\"}",
     "headers": Object {
       "Accept": "application/json",
       "Auth0-Client": "eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0=",

--- a/src/auth/__tests__/index.spec.js
+++ b/src/auth/__tests__/index.spec.js
@@ -424,6 +424,7 @@ describe('auth', () => {
     const parameters = {
       refreshToken: 'a refresh token of a user',
       scope: 'openid',
+      customParam: 'a custom value which should not be filtered out',
     };
     it('should send correct payload', async () => {
       fetchMock.postOnce('https://samples.auth0.com/oauth/token', tokens);

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -209,6 +209,7 @@ export default class Auth {
           refreshToken: {required: true, toName: 'refresh_token'},
           scope: {required: false},
         },
+        whitelist: false,
       },
       parameters,
     );


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- modify the auth refreshToken call to allow custom parameters

### References

Please include relevant links supporting this change such as a:

- from Issue #385 

Please note any links that are not publicly accessible.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
