### PR TITLE
Fix: Warning on RN 65. agent.js  

### DIFF
--- a/src/webauth/agent.js
+++ b/src/webauth/agent.js
@@ -11,14 +11,18 @@ export default class Agent {
     }
 
     return new Promise((resolve, reject) => {
+      //add variable to store Event
+      let eventURL;
       const urlHandler = event => {
         NativeModules.A0Auth0.hide();
         Linking.removeEventListener('url', urlHandler);
         resolve(event.url);
       };
-      Linking.addEventListener('url', urlHandler);
+      //set variable with new event
+      eventURL = Linking.addEventListener('url', urlHandler);
       NativeModules.A0Auth0.showUrl(url, closeOnLoad, (error, redirectURL) => {
-        Linking.removeEventListener('url', urlHandler);
+       //use event.remove() method instead of EventEmitter.removeListener('type',...)
+       eventURL.remove();
         if (error) {
           reject(error);
         } else if(redirectURL) {


### PR DESCRIPTION
Fix: Warning on RN 65 [#410](https://github.com/auth0/react-native-auth0/issues/410)

React Native version:
     "react-native": "0.65.1",
Warn:
      WARN  EventEmitter.removeListener('url', ...): Method has been deprecated. Please instead use `remove()` on the subscription returned by `EventEmitter.addListener`.

### Changes

add variable to store the Event
      `let eventURL;`

set variable with the new event
      `eventURL = Linking.addEventListener('url', urlHandler);`

use event.remove() method instead of EventEmitter.removeListener('type',...)
       `eventURL.remove();`


### References
[React Native Docs](https://reactnative.dev/docs/linking#removeeventlistener)

Please note any links that are not publicly accessible.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed

- [ ] 