### PR TITLE
Fix: Warning on RN65 while linking from agent.js

### DIFF
--- a/src/webauth/__mocks__/linking.js
+++ b/src/webauth/__mocks__/linking.js
@@ -1,6 +1,10 @@
 import EventEmitter from 'events';
 
-class CustomEmitter extends EventEmitter {}
+class CustomEmitter extends EventEmitter {
+  remove() {
+    this.removeAllListeners();
+  }
+}
 
 export default class Linking {
   constructor() {
@@ -8,7 +12,7 @@ export default class Linking {
   }
 
   addEventListener(event, fn) {
-    this.emitter.addListener(event, fn);
+    return this.emitter.addListener(event, fn);
   }
 
   removeEventListener(event, fn) {

--- a/src/webauth/agent.js
+++ b/src/webauth/agent.js
@@ -16,16 +16,23 @@ export default class Agent {
     }
 
     return new Promise((resolve, reject) => {
+      let eventURL;
       const urlHandler = event => {
         NativeModules.A0Auth0.hide();
-        Linking.removeEventListener('url', urlHandler);
+        if (!skipLegacyListener) {
+          eventURL.remove();
+        }
         resolve(event.url);
       };
       const params =
         Platform.OS === 'ios' ? [ephemeralSession, closeOnLoad] : [closeOnLoad];
-      if (!skipLegacyListener) Linking.addEventListener('url', urlHandler);
+      if (!skipLegacyListener) {
+        eventURL = Linking.addEventListener('url', urlHandler);
+      }
       NativeModules.A0Auth0.showUrl(url, ...params, (error, redirectURL) => {
-        if (!skipLegacyListener) Linking.removeEventListener('url', urlHandler);
+        if (!skipLegacyListener) {
+          eventURL.remove();
+        }
         if (error) {
           reject(error);
         } else if (redirectURL) {


### PR DESCRIPTION
### Changes

Fixed the failing test in #411

### References

#410 Warning caused because of using removeListener method
#411 The test failed since the mock object didn't have the required methods

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
