### PR TITLE
Feature: Implemented MFA APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,22 @@ auth0.auth
   .catch(console.error);
 ```
 
+#### Login using MFA with One Time Password code
+
+This call requires the client to have the _MFA_ Client Grant Type enabled. Check [this article](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
+
+When you sign in to a multifactor authentication enabled connection using the `passwordRealm` method, you receive an error stating that MFA is required for that user along with an `mfa_token` value. Use this value to call `loginWithOTP` and complete the MFA flow passing the One Time Password from the enrolled MFA code generator app.
+
+```js
+auth0.auth
+  .loginWithOTP({
+    mfaToken: error.json.mfa_token,
+    otp: '{user entered OTP}',
+  })
+  .then(console.log)
+  .catch(console.error);
+```
+
 #### Login with Passwordless
 
 Passwordless is a two-step authentication flow that makes use of this type of connection. The **Passwordless OTP** grant is required to be enabled in your Auth0 application beforehand. Check [our guide](https://auth0.com/docs/dashboard/guides/applications/update-grant-types) to learn how to enable it.

--- a/src/auth/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/auth/__tests__/__snapshots__/index.spec.js.snap
@@ -1,5 +1,108 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`auth Multifactor Challenge Flow should handle success 1`] = `
+Object {
+  "bindingMethod": "prompt",
+  "challengeType": "oob",
+  "oobCode": "oob-code",
+}
+`;
+
+exports[`auth Multifactor Challenge Flow should handle success with optional parameters Challenge Type and Authenticator Id 1`] = `
+Object {
+  "bindingMethod": "prompt",
+  "challengeType": "oob",
+  "oobCode": "oob-code",
+}
+`;
+
+exports[`auth Multifactor Challenge Flow should handle Challenge Type and Authenticator ID as optional 1`] = `Object {}`;
+
+exports[`auth Multifactor Challenge Flow should handle unexpected error 1`] = `[a0.response.invalid: Internal Server Error]`;
+
+exports[`auth Multifactor Challenge Flow should require MFA Token 1`] = `
+"Missing required parameters: [
+  \\"mfa_token\\"
+]"
+`;
+
+exports[`auth OOB flow binding code should be optional 1`] = `Object {}`;
+
+exports[`auth OOB flow should handle malformed OOB code 1`] = `[invalid_grant: Malformed oob_code]`;
+
+exports[`auth OOB flow should handle success with binding code 1`] = `
+Object {
+  "accessToken": "1234",
+  "expiresIn": 86400,
+  "idToken": "id-123",
+  "scope": "openid profile email address phone",
+  "tokenType": "Bearer",
+}
+`;
+
+exports[`auth OOB flow should handle success without binding code 1`] = `
+Object {
+  "accessToken": "1234",
+  "expiresIn": 86400,
+  "idToken": "id-123",
+  "scope": "openid profile email address phone",
+  "tokenType": "Bearer",
+}
+`;
+
+exports[`auth OOB flow should handle unexpected error 1`] = `[a0.response.invalid: Internal Server Error]`;
+
+exports[`auth OOB flow should require MFA Token and OOB Code 1`] = `
+"Missing required parameters: [
+  \\"mfa_token\\",
+  \\"oob_code\\"
+]"
+`;
+
+exports[`auth OTP flow should handle unexpected error 1`] = `[a0.response.invalid: Internal Server Error]`;
+
+exports[`auth OTP flow should require MFA Token and OTP 1`] = `
+"Missing required parameters: [
+  \\"mfa_token\\",
+  \\"otp\\"
+]"
+`;
+
+exports[`auth OTP flow when MFA is not associated 1`] = `[unsupported_challenge_type: User is not enrolled. You can use /mfa/associate endpoint to enroll the first authenticator.]`;
+
+exports[`auth OTP flow when MFA succeeds 1`] = `
+Object {
+  "accessToken": "1234",
+  "expiresIn": 86400,
+  "idToken": "id-123",
+  "scope": "openid profile email address phone",
+  "tokenType": "Bearer",
+}
+`;
+
+exports[`auth OTP flow when OTP Code is invalid 1`] = `[invalid_grant: Invalid otp_code.]`;
+
+exports[`auth Recovery Code flow should handle unexpected error 1`] = `[a0.response.invalid: Internal Server Error]`;
+
+exports[`auth Recovery Code flow should require MFA Token and Recovery Code 1`] = `
+"Missing required parameters: [
+  \\"mfa_token\\",
+  \\"recovery_code\\"
+]"
+`;
+
+exports[`auth Recovery Code flow when Recovery code succeeds 1`] = `
+Object {
+  "accessToken": "1234",
+  "expiresIn": 86400,
+  "idToken": "id-123",
+  "scope": "openid profile email address phone",
+  "tokenType": "Bearer",
+}
+`;
+
+exports[`auth Recovery Code flow when user does not have Recovery Code 1`] = `[unsupported_challenge_type: User does not have a recovery-code.]`;
+
 exports[`auth authorizeUrl should return default authorize url 1`] = `"https://samples.auth0.com/authorize?response_type=code&redirect_uri=https%3A%2F%2Fmysite.com%2Fcallback&state=a_random_state&client_id=A_CLIENT_ID_OF_YOUR_ACCOUNT&auth0Client=eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0%3D"`;
 
 exports[`auth authorizeUrl should return default authorize url with extra parameters 1`] = `"https://samples.auth0.com/authorize?response_type=code&redirect_uri=https%3A%2F%2Fmysite.com%2Fcallback&state=a_random_state&connection=facebook&client_id=A_CLIENT_ID_OF_YOUR_ACCOUNT&auth0Client=eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0%3D"`;

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -351,6 +351,142 @@ export default class Auth {
   }
 
   /**
+   * Log in a user using the One Time Password code after they have received the 'mfa_required' error.
+   * The MFA token tells the server the username or email, password, and realm values sent on the first request.
+   *
+   * Requires your client to have the **MFA OTP** Grant Type enabled.
+   * See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
+   *
+   * @param {Object} parameters login with OTP parameters
+   * @param {String} parameters.mfaToken the token received in the previous login response
+   * @param {String} parameters.otp the one time password code provided by the resource owner, typically obtained from an MFA application such as Google Authenticator or Guardian.
+   * @returns {Promise}
+   *
+   * @memberof Auth
+   */
+  loginWithOTP(parameters = {}) {
+    const payload = apply(
+      {
+        parameters: {
+          mfaToken: {required: true, toName: 'mfa_token'},
+          otp: {required: true, toName: 'otp'},
+        },
+      },
+      parameters,
+    );
+    return this.client
+      .post('/oauth/token', {
+        ...payload,
+        client_id: this.clientId,
+        grant_type: 'http://auth0.com/oauth/grant-type/mfa-otp',
+      })
+      .then(responseHandler);
+  }
+
+  /**
+   * Log in a user using an Out Of Band authentication code after they have received the 'mfa_required' error.
+   * The MFA token tells the server the username or email, password, and realm values sent on the first request.
+   *
+   * Requires your client to have the **MFA OOB** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
+   *
+   * @param {Object} parameters login with Recovery Code parameters
+   * @param {String} parameters.mfaToken the token received in the previous login response
+   * @param {String} parameters.oobCode the out of band code received in the challenge response.
+   * @param {String} parameters.bindingCode [Optional] the code used to bind the side channel (used to deliver the challenge) with the main channel you are using to authenticate. This is usually an OTP-like code delivered as part of the challenge message.
+   *
+   * @returns {Promise}
+   *
+   * @memberof Auth
+   */
+
+  loginWithOOB(parameters = {}) {
+    const payload = apply(
+      {
+        parameters: {
+          mfaToken: {required: true, toName: 'mfa_token'},
+          oobCode: {required: true, toName: 'oob_code'},
+          bindingCode: {required: false, toName: 'binding_code'},
+        },
+      },
+      parameters,
+    );
+
+    return this.client
+      .post('/oauth/token', {
+        ...payload,
+        client_id: this.clientId,
+        grant_type: 'http://auth0.com/oauth/grant-type/mfa-oob',
+      })
+      .then(responseHandler);
+  }
+
+  /**
+   * Log in a user using a multi-factor authentication Recovery Code after they have received the 'mfa_required' error.
+   * The MFA token tells the server the username or email, password, and realm values sent on the first request.
+   *
+   * Requires your client to have the **MFA** Grant Type enabled. See [Client Grant Types](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
+   *
+   * @param {Object} parameters login with Recovery Code parameters
+   * @param {String} parameters.mfaToken the token received in the previous login response
+   * @param {String} parameters.recoveryCode the recovery code provided by the end-user.
+   * @returns {Promise}
+   *
+   * @memberof Auth
+   */
+  loginWithRecoveryCode(parameters = {}) {
+    const payload = apply(
+      {
+        parameters: {
+          mfaToken: {required: true, toName: 'mfa_token'},
+          recoveryCode: {required: true, toName: 'recovery_code'},
+        },
+      },
+      parameters,
+    );
+
+    return this.client
+      .post('/oauth/token', {
+        ...payload,
+        client_id: this.clientId,
+        grant_type: 'http://auth0.com/oauth/grant-type/mfa-recovery-code',
+      })
+      .then(responseHandler);
+  }
+
+  /**
+   * Request a challenge for multi-factor authentication (MFA) based on the challenge types supported by the application and user.
+   * The challenge type is how the user will get the challenge and prove possession. Supported challenge types include: "otp" and "oob".
+   *
+   * @param {Object} parameters challenge request parameters
+   * @param {String} parameters.mfaToken the token received in the previous login response
+   * @param {String} parameters.challengeType A whitespace-separated list of the challenges types accepted by your application.
+   * Accepted challenge types are oob or otp. Excluding this parameter means that your client application
+   * accepts all supported challenge types.
+   * @param {String} parameters.authenticatorId The ID of the authenticator to challenge.
+   * @returns {Promise}
+   *
+   * @memberof Auth
+   */
+  multifactorChallenge(parameters = {}) {
+    const payload = apply(
+      {
+        parameters: {
+          mfaToken: {required: true, toName: 'mfa_token'},
+          challengeType: {required: false, toName: 'challenge_type'},
+          authenticatorId: {required: false, toName: 'authenticator_id'},
+        },
+      },
+      parameters,
+    );
+    return this.client
+      .post('/mfa/challenge', {
+        ...payload,
+        client_id: this.clientId,
+      })
+      .then(responseHandler);
+  }
+
+  /**
    * Revoke an issued refresh token
    *
    * @param {Object} parameters revoke token parameters


### PR DESCRIPTION
### Changes

Implemented APIs to use MFA Login with OTP, OOB, Using recovery code and requesting MFA Challenge

New methods added to the public API - loginWithOTP, loginWithOOB, loginWithRecoveryCode, multifactorChallenge

Information on how to use this has been added to the README file as well

### References


### Testing

I have added required unit tests and did manual testing to all the features as well. I have tested this with Android platform. Since this runs on JS, the iOS platform behaviour should be same. But never the less manual testing will be done for iOS as well

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
