### PR TITLE
Fix - Provide backward compatibility to remove event subscription

### DIFF
--- a/src/webauth/agent.js
+++ b/src/webauth/agent.js
@@ -17,10 +17,18 @@ export default class Agent {
 
     return new Promise((resolve, reject) => {
       let eventURL;
+      const removeListener = () => {
+        //This is done to handle backward compatibility with RN <= 0.64 which doesn't return EmitterSubscription on addEventListener
+        if (eventURL === undefined) {
+          Linking.removeEventListener('url', urlHandler);
+        } else {
+          eventURL.remove();
+        }
+      };
       const urlHandler = event => {
         NativeModules.A0Auth0.hide();
         if (!skipLegacyListener) {
-          eventURL.remove();
+          removeListener();
         }
         resolve(event.url);
       };
@@ -31,7 +39,7 @@ export default class Agent {
       }
       NativeModules.A0Auth0.showUrl(url, ...params, (error, redirectURL) => {
         if (!skipLegacyListener) {
-          eventURL.remove();
+          removeListener();
         }
         if (error) {
           reject(error);


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- We have added a null check to ensure if old versions of RN uses our library (which is incompatible) we still provide compatibility in removing the event listener

### Testing

Manually tested for older versions of RN just to be sure. The recent versions can be tested using the unit test

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
