### PR TITLE
Fix android java doc task

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,7 +91,8 @@ afterEvaluate { project ->
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
-        classpath += files(project.getConfigurations().getByName('compile').asList())
+        project.getConfigurations().getByName('implementation').setCanBeResolved(true)
+        classpath += files(project.getConfigurations().getByName('implementation').asList())
         include '**/*.java'
     }
 


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

androidJavadoc task which isn't used in the project blocked users from integrating the SDK for Gradle 7. We have fixed this by replacing deprecated functionality

### References
https://docs.gradle.org/current/userguide/java_plugin.html#tab:configurations

### Testing
The SDK has been tested in the latest React Native and Gradle versions as well as the older ones ( RN 0.66.4 & Gradle 6~)

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
