### PR TITLE
Fix iOS module import for Expo SDK 44

### DIFF
--- a/ios/A0Auth0.h
+++ b/ios/A0Auth0.h
@@ -1,8 +1,4 @@
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#else
 #import <React/RCTBridgeModule.h>
-#endif
 
 @interface A0Auth0 : NSObject <RCTBridgeModule>
 

--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -6,11 +6,7 @@
 #endif
 #import <CommonCrypto/CommonCrypto.h>
 
-#if __has_include("RCTUtils.h")
-#import "RCTUtils.h"
-#else
 #import <React/RCTUtils.h>
-#endif
 
 #define ERROR_CANCELLED @{@"error": @"a0.session.user_cancelled",@"error_description": @"User cancelled the Auth"}
 #define ERROR_FAILED_TO_LOAD @{@"error": @"a0.session.failed_load",@"error_description": @"Failed to load url"}


### PR DESCRIPTION
>From https://github.com/expo/expo/issues/15622#issuecomment-997225774, the double-quoted react header imports will break building on Expo SDK 44. The double-quoted imports should be for react-native < 0.40. as nowadays react-native uses CocoaPods, it should be safe to use the angle-bracket import.