### PR TITLE
Fix promise that never completes [SDK-3216]

### DIFF
--- a/src/webauth/__tests__/agent.spec.js
+++ b/src/webauth/__tests__/agent.spec.js
@@ -105,6 +105,20 @@ describe('Agent', () => {
         A0Auth0.error = new Error('failed to load');
         await expect(agent.show('https://auth0.com')).rejects.toMatchSnapshot();
       });
+
+      it('should reject with error when both error and redirectURL are missing', async () => {
+        NativeModules.A0Auth0.showUrl = (...args) => {
+          const callback = args[args.length - 1];
+          callback(null, null);
+        };
+        expect.assertions(1);
+        try {
+          await agent.show('https://auth0.com');
+          fail('should have thrown error');
+        } catch (e) {
+          expect(e).toEqual(new Error('Unknown WebAuth error'));
+        }
+      });
     });
   });
 

--- a/src/webauth/__tests__/agent.spec.js
+++ b/src/webauth/__tests__/agent.spec.js
@@ -114,7 +114,6 @@ describe('Agent', () => {
         expect.assertions(1);
         try {
           await agent.show('https://auth0.com');
-          fail('should have thrown error');
         } catch (e) {
           expect(e).toEqual(new Error('Unknown WebAuth error'));
         }

--- a/src/webauth/agent.js
+++ b/src/webauth/agent.js
@@ -47,6 +47,8 @@ export default class Agent {
           resolve(redirectURL);
         } else if (closeOnLoad) {
           resolve();
+        } else {
+          reject(new Error('Unknown WebAuth error'));
         }
       });
     });


### PR DESCRIPTION
### Changes

When using Web Auth, after the native code calls the RN callback with an error or the redirect URL, the javascript code checks those values and either rejects or resolves a promise. But the code was not handling the case when both error and redirect URL are null, which can happen on iOS under particular circumstances (e.g. retrying the Web Auth login immediately after it failed).

This PR handles that case by rejecting the promise with an error.

### References

Fixes https://github.com/auth0/react-native-auth0/issues/460

### Testing

A unit test was added for this scenario, and also it was tested manually on iOS 15.4 (iPhone simulator), using React Native `0.66.4`.

- [X] This change adds unit test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
