### PR TITLE
[SDK-3458] Support RN version 69

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -91,8 +91,6 @@ afterEvaluate { project ->
     task androidJavadoc(type: Javadoc) {
         source = android.sourceSets.main.java.srcDirs
         classpath += files(android.bootClasspath)
-        project.getConfigurations().getByName('implementation').setCanBeResolved(true)
-        classpath += files(project.getConfigurations().getByName('implementation').asList())
         include '**/*.java'
     }
 


### PR DESCRIPTION
### Changes
React Native v0.69 has been released recently and it is breaking our build for Android due to unused documentation tasks. We are removing these tasks to avoid breakage while importing the library.

### References
https://github.com/auth0/react-native-auth0/issues/486

### Testing
We have tested it with sample application, newly initialized application and demo applications reported in the GH issue
