### PR TITLE
[SDK-3534] Credential manager support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,7 @@ repositories {
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactnativeVersion', '+')}"
     implementation "androidx.browser:browser:1.2.0"
+    implementation 'com.auth0.android:auth0:2.8.0'
 }
 
 def configureReactNativePom(def pom) {

--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -7,12 +7,20 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import android.util.Base64;
 
+import com.auth0.android.Auth0;
+import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.authentication.storage.CredentialsManagerException;
+import com.auth0.android.authentication.storage.SecureCredentialsManager;
+import com.auth0.android.authentication.storage.SharedPreferencesStorage;
+import com.auth0.android.result.Credentials;
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
 import java.io.UnsupportedEncodingException;
@@ -28,14 +36,91 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
 
     private static final String US_ASCII = "US-ASCII";
     private static final String SHA_256 = "SHA-256";
+    private static final String ERROR_CODE = "a0.invalid_state.credential_manager_exception";
+    private static final int LOCAL_AUTH_REQUEST_CODE = 150;
 
     private final ReactApplicationContext reactContext;
     private Callback callback;
 
+    private SecureCredentialsManager secureCredentialsManager;
     public A0Auth0Module(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
         this.reactContext.addActivityEventListener(this);
+    }
+
+    @ReactMethod
+    public void initializeCredentialManager(String clientId, String domain) {
+        Auth0 auth0 = new Auth0(clientId, domain);
+        AuthenticationAPIClient authenticationAPIClient = new AuthenticationAPIClient(auth0);
+        this.secureCredentialsManager = new SecureCredentialsManager(
+                reactContext,
+                authenticationAPIClient,
+                new SharedPreferencesStorage(reactContext)
+        );
+    }
+
+    @ReactMethod
+    public void hasValidCredentialManagerInstance(Promise promise) {
+        promise.resolve(this.secureCredentialsManager != null);
+    }
+
+    @ReactMethod
+    public void getCredentials(String scope, double minTtl, ReadableMap parameters, Promise promise) {
+        Map<String,String> cleanedParameters = new HashMap<>();
+        for (Map.Entry<String, Object> entry : parameters.toHashMap().entrySet()) {
+            if (entry.getValue() != null) {
+                cleanedParameters.put(entry.getKey(), entry.getValue().toString());
+            }
+        }
+
+        this.secureCredentialsManager.getCredentials(scope, (int) minTtl, cleanedParameters, new com.auth0.android.callback.Callback<Credentials, CredentialsManagerException>() {
+            @Override
+            public void onSuccess(Credentials credentials) {
+                ReadableMap map = CredentialsParser.toMap(credentials);
+                promise.resolve(map);
+            }
+
+            @Override
+            public void onFailure(@NonNull CredentialsManagerException e) {
+                promise.reject(ERROR_CODE, e.getMessage());
+            }
+        });
+    }
+
+    @ReactMethod
+    public void saveCredentials(ReadableMap credentials, Promise promise) {
+        try {
+            this.secureCredentialsManager.saveCredentials(CredentialsParser.fromMap(credentials));
+            promise.resolve(true);
+        } catch (CredentialsManagerException e) {
+            promise.reject(ERROR_CODE, e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void enableLocalAuthentication(String title, String description, Promise promise) {
+        Activity activity = reactContext.getCurrentActivity();
+        if (activity == null) {
+            promise.reject(ERROR_CODE, "No current activity present");
+            return;
+        }
+        try {
+            this.secureCredentialsManager.requireAuthentication(activity, LOCAL_AUTH_REQUEST_CODE, title, description);
+            promise.resolve(true);
+        } catch (CredentialsManagerException e){
+            promise.reject(ERROR_CODE, e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void clearCredentials() {
+        this.secureCredentialsManager.clearCredentials();
+    }
+
+    @ReactMethod
+    public void hasValidCredentials(double minTtl, Promise promise) {
+        promise.resolve(this.secureCredentialsManager.hasValidCredentials((long) minTtl));
     }
 
     @Override
@@ -132,6 +217,11 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         Callback cb = A0Auth0Module.this.callback;
+
+        if(requestCode == LOCAL_AUTH_REQUEST_CODE) {
+            secureCredentialsManager.checkAuthenticationResult(requestCode, resultCode);
+            return;
+        }
 
         if (cb == null) {
             return;

--- a/android/src/main/java/com/auth0/react/CredentialsParser.java
+++ b/android/src/main/java/com/auth0/react/CredentialsParser.java
@@ -1,0 +1,68 @@
+package com.auth0.react;
+
+import com.auth0.android.authentication.storage.CredentialsManagerException;
+import com.auth0.android.result.Credentials;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class CredentialsParser {
+
+    private static final String ACCESS_TOKEN_KEY = "accessToken";
+    private static final String ID_TOKEN_KEY = "idToken";
+    private static final String EXPIRES_AT_KEY = "expiresAt";
+    private static final String SCOPE = "scope";
+    private static final String REFRESH_TOKEN_KEY = "refreshToken";
+    private static final String TYPE_KEY = "type";
+    private static final String TOKEN_TYPE_KEY = "tokenType";
+    private static final String EXPIRES_IN_KEY = "expiresIn";
+    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+
+    public static ReadableMap toMap(Credentials credentials) {
+        WritableNativeMap map = new WritableNativeMap();
+        map.putString(ACCESS_TOKEN_KEY, credentials.getAccessToken());
+        map.putDouble(EXPIRES_AT_KEY, credentials.getExpiresAt().getTime());
+        map.putString(ID_TOKEN_KEY, credentials.getIdToken());
+        map.putString(SCOPE, credentials.getScope());
+        map.putString(REFRESH_TOKEN_KEY, credentials.getRefreshToken());
+        map.putString(TYPE_KEY, credentials.getType());
+        return map;
+    }
+
+    public static Credentials fromMap(ReadableMap map) {
+        String idToken = map.getString(ID_TOKEN_KEY);
+        String accessToken = map.getString(ACCESS_TOKEN_KEY);
+        String tokenType = map.getString(TOKEN_TYPE_KEY);
+        String refreshToken = map.getString(REFRESH_TOKEN_KEY);
+        String scope = map.getString(SCOPE);
+        SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT, Locale.US);
+        Date expiresAt = null;
+        String expiresAtText = map.getString(EXPIRES_AT_KEY);
+        if(expiresAtText != null) {
+            try {
+                expiresAt = sdf.parse(expiresAtText);
+            } catch (ParseException e) {
+                throw new CredentialsManagerException("Invalid date format - "+expiresAtText, e);
+            }
+        }
+        double expiresIn = 0;
+        if(map.hasKey(EXPIRES_IN_KEY)) {
+            expiresIn = map.getDouble(EXPIRES_IN_KEY);
+        }
+        if (expiresAt == null && expiresIn != 0) {
+            expiresAt = new Date((long) (System.currentTimeMillis() + expiresIn * 1000));
+        }
+        return new Credentials(
+                idToken,
+                accessToken,
+                tokenType,
+                refreshToken,
+                expiresAt,
+                scope
+        );
+    }
+}

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import Auth from './src/auth';
+import CredentialsManager from './src/credentials-manager';
 import Users from './src/management/users';
 import WebAuth from './src/webauth';
 export {TimeoutError} from './src/utils/fetchWithTimeout';
@@ -22,6 +23,7 @@ export default class Auth0 {
     const {domain, clientId, ...extras} = options;
     this.auth = new Auth({baseUrl: domain, clientId, ...extras});
     this.webAuth = new WebAuth(this.auth);
+    this.credentialsManager = new CredentialsManager(clientId, domain);
     this.options = options;
   }
 

--- a/src/credentials-manager/credentialsManagerError.js
+++ b/src/credentials-manager/credentialsManagerError.js
@@ -1,0 +1,17 @@
+import BaseError from '../utils/baseError';
+
+export default class CredentialsManagerError extends BaseError {
+  constructor(response) {
+    const {status, json = {}, text} = response;
+    const {error, error_description: description, invalid_parameter} = json;
+    super(
+      error || 'a0.response.invalid',
+      description || text || handleInvalidToken(response) || 'unknown error',
+    );
+    this.json = json;
+    this.status = status;
+    if (invalid_parameter) {
+      this.invalid_parameter = invalid_parameter;
+    }
+  }
+}

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -86,7 +86,7 @@ export default class CredentialsManager {
   }
 
   /**
-   * Gets the credential that has already been saved
+   * Gets the credentials that has already been saved
    *
    * @param {String} title optional - the text to use as title in the authentication screen. Passing null will result in using the OS's default value.
    * @param {String} description optional - the text to use as description in the authentication screen. On some Android versions it might not be shown. Passing null will result in using the OS's default value.

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -58,7 +58,7 @@ export default class CredentialsManager {
   }
 
   /**
-   * Gets the credential that has already been saved
+   * Gets the credentials that has already been saved
    *
    * @param {String} scope optional - the scope to request for the access token. If null is passed, the previous scope will be kept.
    * @param {String} minTtl optional - the minimum time in seconds that the access token should last before expiration.

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -1,0 +1,145 @@
+import {NativeModules} from 'react-native';
+import CredentialsManagerError from './credentialsManagerError';
+
+export default class CredentialsManager {
+  constructor(clientId, domain) {
+    this.domain = domain;
+    this.clientId = clientId;
+    this.Auth0Module = NativeModules.A0Auth0;
+  }
+
+  /**
+   * Saves the provided credentials
+   *
+   * @param {Object} credentials credential values
+   * @param {String} credentials.idToken required - JWT token that has user claims
+   * @param {String} credentials.accessToken required - token used for API calls
+   * @param {String} credentials.tokenType required - type of the token, ex - Bearer
+   * @param {Number} credentials.expiresIn optional - `expiresAt` should not be empty if this is. Used to denote when the token will expire from the issued time
+   * @param {String} credentials.expiresAt optional - `expiresIn` should not be empty if this is. Used to denote when the token will expire. Has precendence over `expiresIn`.
+   * @param {String} credentials.refreshToken optional - used to refresh access token
+   * @param {String} credentials.scope optional - represents the scope of the current token
+   * @returns {Promise}
+   *
+   * @memberof CredentialsManager
+   */
+  async saveCredentials(credentials = {}) {
+    const validateKeys = ['idToken', 'accessToken', 'tokenType'];
+    validateKeys.forEach(key => {
+      if (!credentials[key]) {
+        const json = {
+          error: 'a0.credential_manager.invalid_input',
+          error_description: `${key} cannot be empty`,
+          invalid_parameter: key,
+        };
+        throw new CredentialsManagerError({json, status: 0});
+      }
+    });
+    if (
+      (!credentials.expiresIn || !credentials.expiresIn > 0) &&
+      !credentials.expiresAt
+    ) {
+      const json = {
+        error: 'a0.credential_manager.invalid_input',
+        error_description: `expiresIn or expiresAt should be set`,
+      };
+      throw new CredentialsManagerError({json, status: 0});
+    }
+    try {
+      await this.ensureCredentialManagerIsInitialized();
+      await this.Auth0Module.saveCredentials(credentials);
+    } catch (e) {
+      const json = {
+        error: 'a0.credential_manager.invalid',
+        error_description: e.message,
+      };
+      throw new CredentialsManagerError({json, status: 0});
+    }
+  }
+
+  /**
+   * Gets the credential that has already been saved
+   *
+   * @param {String} scope optional - the scope to request for the access token. If null is passed, the previous scope will be kept.
+   * @param {String} minTtl optional - the minimum time in seconds that the access token should last before expiration.
+   * @param {Object} parameters optional - additional parameters to send in the request to refresh expired credentials.
+   * @returns {Promise}
+   *
+   * @memberof CredentialsManager
+   */
+  async getCredentials(scope, minTtl = 0, parameters = {}) {
+    try {
+      await this.ensureCredentialManagerIsInitialized();
+      const credentials = await this.Auth0Module.getCredentials(
+        scope,
+        minTtl,
+        parameters,
+      );
+      return credentials;
+    } catch (e) {
+      const json = {
+        error: 'a0.credential_manager.invalid',
+        error_description: e.message,
+      };
+      throw new CredentialsManagerError({json, status: 0});
+    }
+  }
+
+  /**
+   * Gets the credential that has already been saved
+   *
+   * @param {String} title optional - the text to use as title in the authentication screen. Passing null will result in using the OS's default value.
+   * @param {String} description optional - the text to use as description in the authentication screen. On some Android versions it might not be shown. Passing null will result in using the OS's default value.
+   * @returns {Promise}
+   *
+   * @memberof CredentialsManager
+   */
+  async requireLocalAuthentication(title, description) {
+    try {
+      await this.ensureCredentialManagerIsInitialized();
+      const cred = await this.Auth0Module.enableLocalAuthentication(
+        title,
+        description,
+      );
+    } catch (e) {
+      const json = {
+        error: 'a0.credential_manager.invalid',
+        error_description: e.message,
+      };
+      throw new CredentialsManagerError({json, status: 0});
+    }
+  }
+
+  /**
+   * Returns whether this manager contains a valid non-expired pair of credentials.
+   *
+   * @param {Number} minTtl optional - the minimum time in seconds that the access token should last before expiration
+   *
+   * @memberof CredentialsManager
+   */
+  async hasValidCredentials(minTtl = 0) {
+    await this.ensureCredentialManagerIsInitialized();
+    return await this.Auth0Module.hasValidCredentials(minTtl);
+  }
+
+  /**
+   * Delete the stored credentials
+   *
+   * @memberof CredentialsManager
+   */
+  async clearCredentials() {
+    await this.ensureCredentialManagerIsInitialized();
+    await this.Auth0Module.clearCredentials();
+  }
+
+  //private
+  async ensureCredentialManagerIsInitialized() {
+    const hasValid = await this.Auth0Module.hasValidCredentialManagerInstance();
+    if (!hasValid) {
+      await this.Auth0Module.initializeCredentialManager(
+        this.clientId,
+        this.domain,
+      );
+    }
+  }
+}


### PR DESCRIPTION
### Changes
We have provided Credentials Manager support for Android in React Native. The following methods are added

- getCredentials
- saveCredentials
- hasValidCredentials
- clearCredentials

### References
https://github.com/auth0/react-native-auth0/issues/476

### Testing
- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist
- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
