### PR TITLE
[SDK-3537] Credential manager for React Native

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'React-Core'
+  s.dependency 'Auth0', '~> 2.3'
 end

--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -9,10 +9,10 @@ Pod::Spec.new do |s|
   s.homepage     = package['repository']['baseUrl']
   s.license      = package['license']
   s.authors      = package['author']
-  s.platforms    = { :ios => '9.0' }
+  s.platforms    = { :ios => '12.0' }
   s.source       = { :git => 'https://github.com/auth0/react-native-auth0.git', :tag => "v#{s.version}" }
 
-  s.source_files = ['ios/A0Auth0.h', 'ios/A0Auth0.m']
+  s.source_files = 'ios/**/*.{h,m,mm,swift}'
   s.requires_arc = true
 
   s.dependency 'React-Core'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,6 +56,7 @@ repositories {
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactnativeVersion', '+')}"
     implementation "androidx.browser:browser:1.2.0"
+    implementation 'com.auth0.android:auth0:2.8.0'
 }
 
 def configureReactNativePom(def pom) {

--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -7,12 +7,20 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import android.util.Base64;
 
+import com.auth0.android.Auth0;
+import com.auth0.android.authentication.AuthenticationAPIClient;
+import com.auth0.android.authentication.storage.CredentialsManagerException;
+import com.auth0.android.authentication.storage.SecureCredentialsManager;
+import com.auth0.android.authentication.storage.SharedPreferencesStorage;
+import com.auth0.android.result.Credentials;
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 
 import java.io.UnsupportedEncodingException;
@@ -28,14 +36,91 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
 
     private static final String US_ASCII = "US-ASCII";
     private static final String SHA_256 = "SHA-256";
+    private static final String ERROR_CODE = "a0.invalid_state.credential_manager_exception";
+    private static final int LOCAL_AUTH_REQUEST_CODE = 150;
 
     private final ReactApplicationContext reactContext;
     private Callback callback;
 
+    private SecureCredentialsManager secureCredentialsManager;
     public A0Auth0Module(ReactApplicationContext reactContext) {
         super(reactContext);
         this.reactContext = reactContext;
         this.reactContext.addActivityEventListener(this);
+    }
+
+    @ReactMethod
+    public void initializeCredentialManager(String clientId, String domain) {
+        Auth0 auth0 = new Auth0(clientId, domain);
+        AuthenticationAPIClient authenticationAPIClient = new AuthenticationAPIClient(auth0);
+        this.secureCredentialsManager = new SecureCredentialsManager(
+                reactContext,
+                authenticationAPIClient,
+                new SharedPreferencesStorage(reactContext)
+        );
+    }
+
+    @ReactMethod
+    public void hasValidCredentialManagerInstance(Promise promise) {
+        promise.resolve(this.secureCredentialsManager != null);
+    }
+
+    @ReactMethod
+    public void getCredentials(String scope, double minTtl, ReadableMap parameters, Promise promise) {
+        Map<String,String> cleanedParameters = new HashMap<>();
+        for (Map.Entry<String, Object> entry : parameters.toHashMap().entrySet()) {
+            if (entry.getValue() != null) {
+                cleanedParameters.put(entry.getKey(), entry.getValue().toString());
+            }
+        }
+
+        this.secureCredentialsManager.getCredentials(scope, (int) minTtl, cleanedParameters, new com.auth0.android.callback.Callback<Credentials, CredentialsManagerException>() {
+            @Override
+            public void onSuccess(Credentials credentials) {
+                ReadableMap map = CredentialsParser.toMap(credentials);
+                promise.resolve(map);
+            }
+
+            @Override
+            public void onFailure(@NonNull CredentialsManagerException e) {
+                promise.reject(ERROR_CODE, e.getMessage());
+            }
+        });
+    }
+
+    @ReactMethod
+    public void saveCredentials(ReadableMap credentials, Promise promise) {
+        try {
+            this.secureCredentialsManager.saveCredentials(CredentialsParser.fromMap(credentials));
+            promise.resolve(true);
+        } catch (CredentialsManagerException e) {
+            promise.reject(ERROR_CODE, e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void enableLocalAuthentication(String title, String description, Promise promise) {
+        Activity activity = reactContext.getCurrentActivity();
+        if (activity == null) {
+            promise.reject(ERROR_CODE, "No current activity present");
+            return;
+        }
+        try {
+            this.secureCredentialsManager.requireAuthentication(activity, LOCAL_AUTH_REQUEST_CODE, title, description);
+            promise.resolve(true);
+        } catch (CredentialsManagerException e){
+            promise.reject(ERROR_CODE, e.getMessage());
+        }
+    }
+
+    @ReactMethod
+    public void clearCredentials() {
+        this.secureCredentialsManager.clearCredentials();
+    }
+
+    @ReactMethod
+    public void hasValidCredentials(double minTtl, Promise promise) {
+        promise.resolve(this.secureCredentialsManager.hasValidCredentials((long) minTtl));
     }
 
     @Override
@@ -132,6 +217,11 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         Callback cb = A0Auth0Module.this.callback;
+
+        if(requestCode == LOCAL_AUTH_REQUEST_CODE) {
+            secureCredentialsManager.checkAuthenticationResult(requestCode, resultCode);
+            return;
+        }
 
         if (cb == null) {
             return;

--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -114,8 +114,9 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
     }
 
     @ReactMethod
-    public void clearCredentials() {
+    public void clearCredentials(Promise promise) {
         this.secureCredentialsManager.clearCredentials();
+        promise.resolve(true);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/auth0/react/CredentialsParser.java
+++ b/android/src/main/java/com/auth0/react/CredentialsParser.java
@@ -1,0 +1,68 @@
+package com.auth0.react;
+
+import com.auth0.android.authentication.storage.CredentialsManagerException;
+import com.auth0.android.result.Credentials;
+import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.bridge.WritableNativeMap;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+
+public class CredentialsParser {
+
+    private static final String ACCESS_TOKEN_KEY = "accessToken";
+    private static final String ID_TOKEN_KEY = "idToken";
+    private static final String EXPIRES_AT_KEY = "expiresAt";
+    private static final String SCOPE = "scope";
+    private static final String REFRESH_TOKEN_KEY = "refreshToken";
+    private static final String TYPE_KEY = "type";
+    private static final String TOKEN_TYPE_KEY = "tokenType";
+    private static final String EXPIRES_IN_KEY = "expiresIn";
+    private static final String DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+
+    public static ReadableMap toMap(Credentials credentials) {
+        WritableNativeMap map = new WritableNativeMap();
+        map.putString(ACCESS_TOKEN_KEY, credentials.getAccessToken());
+        map.putDouble(EXPIRES_AT_KEY, credentials.getExpiresAt().getTime());
+        map.putString(ID_TOKEN_KEY, credentials.getIdToken());
+        map.putString(SCOPE, credentials.getScope());
+        map.putString(REFRESH_TOKEN_KEY, credentials.getRefreshToken());
+        map.putString(TYPE_KEY, credentials.getType());
+        return map;
+    }
+
+    public static Credentials fromMap(ReadableMap map) {
+        String idToken = map.getString(ID_TOKEN_KEY);
+        String accessToken = map.getString(ACCESS_TOKEN_KEY);
+        String tokenType = map.getString(TOKEN_TYPE_KEY);
+        String refreshToken = map.getString(REFRESH_TOKEN_KEY);
+        String scope = map.getString(SCOPE);
+        SimpleDateFormat sdf = new SimpleDateFormat(DATE_FORMAT, Locale.US);
+        Date expiresAt = null;
+        String expiresAtText = map.getString(EXPIRES_AT_KEY);
+        if(expiresAtText != null) {
+            try {
+                expiresAt = sdf.parse(expiresAtText);
+            } catch (ParseException e) {
+                throw new CredentialsManagerException("Invalid date format - "+expiresAtText, e);
+            }
+        }
+        double expiresIn = 0;
+        if(map.hasKey(EXPIRES_IN_KEY)) {
+            expiresIn = map.getDouble(EXPIRES_IN_KEY);
+        }
+        if (expiresAt == null && expiresIn != 0) {
+            expiresAt = new Date((long) (System.currentTimeMillis() + expiresIn * 1000));
+        }
+        return new Credentials(
+                idToken,
+                accessToken,
+                tokenType,
+                refreshToken,
+                expiresAt,
+                scope
+        );
+    }
+}

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ export default class Auth0 {
     const {domain, clientId, ...extras} = options;
     this.auth = new Auth({baseUrl: domain, clientId, ...extras});
     this.webAuth = new WebAuth(this.auth);
-    this.credentialsManager = new CredentialsManager(clientId, domain);
+    this.credentialsManager = new CredentialsManager(this.auth);
     this.options = options;
   }
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ export default class Auth0 {
     const {domain, clientId, ...extras} = options;
     this.auth = new Auth({baseUrl: domain, clientId, ...extras});
     this.webAuth = new WebAuth(this.auth);
-    this.credentialsManager = new CredentialsManager(this.auth);
+    this.credentialsManager = new CredentialsManager(domain, clientId);
     this.options = options;
   }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 import Auth from './src/auth';
+import CredentialsManager from './src/credentials-manager';
 import Users from './src/management/users';
 import WebAuth from './src/webauth';
 export {TimeoutError} from './src/utils/fetchWithTimeout';
@@ -22,6 +23,7 @@ export default class Auth0 {
     const {domain, clientId, ...extras} = options;
     this.auth = new Auth({baseUrl: domain, clientId, ...extras});
     this.webAuth = new WebAuth(this.auth);
+    this.credentialsManager = new CredentialsManager(clientId, domain);
     this.options = options;
   }
 

--- a/ios/A0Auth0-Bridging-Header.h
+++ b/ios/A0Auth0-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import <React/RCTBridgeModule.h>

--- a/ios/A0Auth0.h
+++ b/ios/A0Auth0.h
@@ -3,3 +3,5 @@
 @interface A0Auth0 : NSObject <RCTBridgeModule>
 
 @end
+
+@class CredentialsManagerBridge;

--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -52,6 +52,26 @@ RCT_EXPORT_METHOD(initializeCredentialManager:(NSString *)clientId domain:(NSStr
     [self tryAndInitializeCredentialManager:clientId domain:domain];
 }
 
+RCT_EXPORT_METHOD(saveCredentials:(NSDictionary *)credentials resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.credentialsManagerBridge saveCredentialsWithCredentialsMap:credentials resolve:resolve reject:reject];
+}
+
+RCT_EXPORT_METHOD(getCredentials:(NSString *)scope minTTL:(NSInteger)minTTL parameters:(NSDictionary *)parameters resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.credentialsManagerBridge getCredentialsWithScope:scope minTTL:minTTL parameters:parameters resolve:resolve reject:reject];
+}
+
+RCT_EXPORT_METHOD(hasValidCredentials:(NSInteger)minTTL resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.credentialsManagerBridge hasValidCredentialsWithMinTTL:minTTL resolve:resolve];
+}
+
+RCT_EXPORT_METHOD(clearCredentials:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.credentialsManagerBridge clearCredentialsWithResolve:resolve reject:reject];
+}
+
+RCT_EXPORT_METHOD(enableLocalAuthentication:(NSString *)title cancelTitle:(NSString *)cancelTitle fallbackTitle:(NSString *)fallbackTitle) {
+    [self.credentialsManagerBridge enableLocalAuthenticationWithTitle:title cancelTitle:title fallbackTitle:title];
+}
+
 RCT_EXPORT_METHOD(showUrl:(NSString *)urlString
                   usingEphemeralSession:(BOOL)ephemeralSession
                   closeOnLoad:(BOOL)closeOnLoad

--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -8,6 +8,7 @@
 
 #import <React/RCTUtils.h>
 
+#import "A0Auth0-Swift.h"
 #define ERROR_CANCELLED @{@"error": @"a0.session.user_cancelled",@"error_description": @"User cancelled the Auth"}
 #define ERROR_FAILED_TO_LOAD @{@"error": @"a0.session.failed_load",@"error_description": @"Failed to load url"}
 
@@ -22,6 +23,7 @@
 @interface A0Auth0 () <SFSafariViewControllerDelegate>
 @property (weak, nonatomic) SFSafariViewController *last;
 @property (strong, nonatomic) NSObject *authenticationSession;
+@property (strong, nonatomic) CredentialsManagerBridge *credentialsManagerBridge;
 @property (copy, nonatomic) RCTResponseSenderBlock sessionCallback;
 @property (assign, nonatomic) BOOL closeOnLoad;
 @end
@@ -37,6 +39,17 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(hide) {
     [self terminateWithError:nil dismissing:YES animated:YES];
+}
+
+RCT_EXPORT_METHOD(hasValidCredentialManagerInstance:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject) {
+    BOOL valid = [self checkHasValidCredentialManagerInstance];
+    resolve(@(valid));
+}
+
+
+RCT_EXPORT_METHOD(initializeCredentialManager:(NSString *)clientId domain:(NSString *)domain) {
+    [self tryAndInitializeCredentialManager:clientId domain:domain];
 }
 
 RCT_EXPORT_METHOD(showUrl:(NSString *)urlString
@@ -69,6 +82,16 @@ RCT_EXPORT_METHOD(oauthParameters:(RCTResponseSenderBlock)callback) {
 #pragma mark - Internal methods
 
 UIBackgroundTaskIdentifier taskId;
+
+- (BOOL)checkHasValidCredentialManagerInstance {
+    BOOL valid = self.credentialsManagerBridge != nil;
+    return valid;
+}
+
+- (void)tryAndInitializeCredentialManager:(NSString *)clientId domain:(NSString *)domain {
+    CredentialsManagerBridge *bridge = [[CredentialsManagerBridge alloc] initWithClientId: clientId domain: domain];
+    self.credentialsManagerBridge = bridge;
+}
 
 - (void)presentSafariWithURL:(NSURL *)url {
     UIWindow *window = [[UIApplication sharedApplication] keyWindow];

--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -53,7 +53,7 @@ RCT_EXPORT_METHOD(initializeCredentialManager:(NSString *)clientId domain:(NSStr
 }
 
 RCT_EXPORT_METHOD(saveCredentials:(NSDictionary *)credentials resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-    [self.credentialsManagerBridge saveCredentialsWithCredentialsMap:credentials resolve:resolve reject:reject];
+    [self.credentialsManagerBridge saveCredentialsWithCredentialsDict:credentials resolve:resolve reject:reject];
 }
 
 RCT_EXPORT_METHOD(getCredentials:(NSString *)scope minTTL:(NSInteger)minTTL parameters:(NSDictionary *)parameters resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {

--- a/ios/A0Auth0.xcodeproj/project.pbxproj
+++ b/ios/A0Auth0.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A7107F0428A30FF7003A6450 /* CredentialsManagerBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7107F0328A30FF7003A6450 /* CredentialsManagerBridge.swift */; };
 		B3E7B58A1CC2AC0600A0062D /* A0Auth0.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* A0Auth0.m */; };
 /* End PBXBuildFile section */
 
@@ -24,6 +25,8 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libA0Auth0.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libA0Auth0.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		A7107F0228A30FF7003A6450 /* A0Auth0-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "A0Auth0-Bridging-Header.h"; sourceTree = "<group>"; };
+		A7107F0328A30FF7003A6450 /* CredentialsManagerBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialsManagerBridge.swift; sourceTree = "<group>"; };
 		B3E7B5881CC2AC0600A0062D /* A0Auth0.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = A0Auth0.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* A0Auth0.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = A0Auth0.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -50,9 +53,11 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
+				A7107F0328A30FF7003A6450 /* CredentialsManagerBridge.swift */,
 				B3E7B5881CC2AC0600A0062D /* A0Auth0.h */,
 				B3E7B5891CC2AC0600A0062D /* A0Auth0.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
+				A7107F0228A30FF7003A6450 /* A0Auth0-Bridging-Header.h */,
 			);
 			sourceTree = "<group>";
 		};
@@ -87,6 +92,7 @@
 				TargetAttributes = {
 					58B511DA1A9E6C8500147676 = {
 						CreatedOnToolsVersion = 6.1.1;
+						LastSwiftMigration = 1340;
 					};
 				};
 			};
@@ -114,6 +120,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B3E7B58A1CC2AC0600A0062D /* A0Auth0.m in Sources */,
+				A7107F0428A30FF7003A6450 /* CredentialsManagerBridge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -146,6 +153,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
+				DEFINES_MODULE = YES;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -196,6 +204,7 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = YES;
+				DEFINES_MODULE = YES;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -216,32 +225,41 @@
 		58B511F01A9E6C8500147676 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = A0Auth0;
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "A0Auth0-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
 		58B511F11A9E6C8500147676 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../../React/**",
 					"$(SRCROOT)/../../react-native/React/**",
 				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = A0Auth0;
 				SKIP_INSTALL = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "A0Auth0-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/ios/CredentialsManagerBridge.swift
+++ b/ios/CredentialsManagerBridge.swift
@@ -6,6 +6,7 @@
 //
 
 import Auth0
+import Foundation
 
 @objc
 public class CredentialsManagerBridge: NSObject {
@@ -25,23 +26,48 @@ public class CredentialsManagerBridge: NSObject {
     
     var credentialsManager: CredentialsManager
     
-    @objc public init(clientId: NSString, domain: NSString) {
+    @objc public init(clientId: String, domain: String) {
         let auth0 = Auth0
-            .authentication(clientId: clientId as String, domain: domain as String)
+            .authentication(clientId: clientId, domain: domain)
         self.credentialsManager = CredentialsManager(authentication: auth0)
         super.init()
    }
     
-    @objc public func saveCredentials(credentialsMap: NSDictionary, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
-        let credentials = Credentials.fromNSDictionary(credentialsMap: credentialsMap)
+    @objc public func saveCredentials(credentialsDict: [String: Any], resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        
+        guard let accessToken = credentialsDict[CredentialsManagerBridge.accessTokenKey] as? String, let tokenType = credentialsDict[CredentialsManagerBridge.tokenTypeKey] as? String, let idToken = credentialsDict[CredentialsManagerBridge.idTokenKey] as? String else { reject(CredentialsManagerBridge.errorCode, "Incomplete information provided for credentials", NSError.init(domain: CredentialsManagerBridge.errorCode, code: -99999, userInfo: nil)); return; }
+        
+        let refreshToken = credentialsDict[CredentialsManagerBridge.refreshTokenKey] as? String
+        let scope = credentialsDict[CredentialsManagerBridge.scopeKey] as? String
+        var expiresIn: Date?
+         if let string = credentialsDict[CredentialsManagerBridge.expiresInKey] as? String, let double = Double(string) {
+             expiresIn = Date(timeIntervalSinceNow: double)
+         } else if let double = credentialsDict[CredentialsManagerBridge.expiresInKey] as? Double {
+             expiresIn = Date(timeIntervalSinceNow: double)
+         } else if let dateStr = credentialsDict[CredentialsManagerBridge.expiresInKey] as? String {
+             let dateFormatter = DateFormatter()
+             dateFormatter.dateFormat = CredentialsManagerBridge.dateFormat
+             expiresIn = dateFormatter.date(from: dateStr)
+         }
+     
+        
+        let credentials =  Credentials(
+            accessToken: accessToken,
+            tokenType: tokenType,
+            idToken:  idToken,
+            refreshToken: refreshToken,
+            expiresIn: expiresIn ?? Date(),
+            scope: scope,
+            recoveryCode: nil
+        )
         resolve(credentialsManager.store(credentials: credentials))
     }
     
-    @objc public func getCredentials(scope: NSString?, minTTL: NSInteger, parameters: NSDictionary?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-        credentialsManager.credentials(withScope: scope as String?, minTTL: minTTL, parameters: parameters as! [String : Any]) { result in
+    @objc public func getCredentials(scope: String?, minTTL: Int, parameters: [String: Any], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        credentialsManager.credentials(withScope: scope, minTTL: minTTL, parameters: parameters) { result in
             switch result {
             case .success(let credentials):
-                resolve(credentials.toNSDictionary())
+                resolve(credentials.asDictionary())
             case .failure(let error):
                 reject(CredentialsManagerBridge.errorCode, error.errorDescription, error)
             }
@@ -49,58 +75,29 @@ public class CredentialsManagerBridge: NSObject {
     }
     
     @objc public func hasValidCredentials(minTTL: Int, resolve: RCTPromiseResolveBlock) {
-        resolve(credentialsManager.hasValid(minTTL: minTTL))
+        resolve(credentialsManager.canRenew() || credentialsManager.hasValid(minTTL: minTTL))
     }
     
     @objc public func clearCredentials(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
         resolve(credentialsManager.clear())
     }
     
-    @objc public func enableLocalAuthentication(title: NSString?, cancelTitle: NSString?, fallbackTitle: NSString?) {
-        let titleValue: NSString = title ?? "Please authenticate to continue"
-        self.credentialsManager.enableBiometrics(withTitle: titleValue as String, cancelTitle: cancelTitle as String?, fallbackTitle: fallbackTitle as String?)
+    @objc public func enableLocalAuthentication(title: String?, cancelTitle: String?, fallbackTitle: String?) {
+        let titleValue = title ?? "Please authenticate to continue"
+        self.credentialsManager.enableBiometrics(withTitle: titleValue, cancelTitle: cancelTitle, fallbackTitle: fallbackTitle)
     }
 }
 
 
 extension Credentials {
-    static func fromNSDictionary(credentialsMap: NSDictionary) -> Credentials {
-        let accessToken = credentialsMap[CredentialsManagerBridge.accessTokenKey]
-        let idToken = credentialsMap[CredentialsManagerBridge.idTokenKey]
-        let tokenType = credentialsMap[CredentialsManagerBridge.tokenTypeKey]
-        let refreshToken = credentialsMap[CredentialsManagerBridge.refreshTokenKey] as? String
-        let scope = credentialsMap[CredentialsManagerBridge.scopeKey] as? String
-        
-        var expiresIn: Date?
-        if let string = credentialsMap[CredentialsManagerBridge.expiresInKey] as? String, let double = Double(string) {
-            expiresIn = Date(timeIntervalSinceNow: double)
-        } else if let double = credentialsMap[CredentialsManagerBridge.expiresInKey] as? Double {
-            expiresIn = Date(timeIntervalSinceNow: double)
-        } else if let dateStr = credentialsMap[CredentialsManagerBridge.expiresInKey] as? String {
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateFormat = CredentialsManagerBridge.dateFormat
-            expiresIn = dateFormatter.date(from: dateStr)
-        }
-        
-        return Credentials(
-            accessToken: accessToken as! String,
-            tokenType: tokenType as! String,
-            idToken: idToken as! String,
-            refreshToken: refreshToken,
-            expiresIn: expiresIn ?? Date(),
-            scope: scope,
-            recoveryCode: nil
-        )
-    }
-    
-    func toNSDictionary() -> NSDictionary {
-        return NSDictionary(dictionary: [
+    func asDictionary() -> [String: Any] {
+        return [
             CredentialsManagerBridge.accessTokenKey: self.accessToken,
             CredentialsManagerBridge.tokenTypeKey: self.tokenType,
             CredentialsManagerBridge.idTokenKey: self.idToken,
-            CredentialsManagerBridge.refreshTokenKey: self.refreshToken,
+            CredentialsManagerBridge.refreshTokenKey: self.refreshToken as Any,
             CredentialsManagerBridge.expiresInKey: self.expiresIn,
-            CredentialsManagerBridge.scopeKey: self.scope
-        ])
+            CredentialsManagerBridge.scopeKey: self.scope as Any
+        ]
     }
 }

--- a/ios/CredentialsManagerBridge.swift
+++ b/ios/CredentialsManagerBridge.swift
@@ -98,9 +98,9 @@ extension Credentials {
             CredentialsManagerBridge.accessTokenKey: self.accessToken,
             CredentialsManagerBridge.tokenTypeKey: self.tokenType,
             CredentialsManagerBridge.idTokenKey: self.idToken,
-            CredentialsManagerBridge.refreshTokenKey: self.refreshToken!,
+            CredentialsManagerBridge.refreshTokenKey: self.refreshToken,
             CredentialsManagerBridge.expiresInKey: self.expiresIn,
-            CredentialsManagerBridge.scopeKey: self.scope!
+            CredentialsManagerBridge.scopeKey: self.scope
         ])
     }
 }

--- a/ios/CredentialsManagerBridge.swift
+++ b/ios/CredentialsManagerBridge.swift
@@ -3,20 +3,104 @@
 //  A0Auth0
 //
 //  Created by Poovamraj Thanganadar Thiagarajan on 09.08.22.
-//  Copyright © 2022 Facebook. All rights reserved.
 //
 
 import Auth0
 
-@objc(CredentialsManagerBridge)
-class CredentialsManagerBridge: NSObject {
-    let clientId: NSString
+@objc
+public class CredentialsManagerBridge: NSObject {
     
-    let domain: NSString
+    
+    static let accessTokenKey = "accessToken";
+    static let idTokenKey = "idToken";
+    static let expiresAtKey = "expiresAt";
+    static let scopeKey = "scope";
+    static let refreshTokenKey = "refreshToken";
+    static let typeKey = "type";
+    static let tokenTypeKey = "tokenType";
+    static let expiresInKey = "expiresIn";
+    static let dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'";
+    
+    static let errorCode = "a0.invalid_state.credential_manager_exception"
+    
+    var credentialsManager: CredentialsManager
     
     @objc public init(clientId: NSString, domain: NSString) {
-        self.clientId = clientId
-        self.domain = domain
+        let auth0 = Auth0
+            .authentication(clientId: clientId as String, domain: domain as String)
+        self.credentialsManager = CredentialsManager(authentication: auth0)
         super.init()
    }
+    
+    @objc public func saveCredentials(credentialsMap: NSDictionary, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        let credentials = Credentials.fromNSDictionary(credentialsMap: credentialsMap)
+        resolve(credentialsManager.store(credentials: credentials))
+    }
+    
+    @objc public func getCredentials(scope: NSString?, minTTL: NSInteger, parameters: NSDictionary?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        credentialsManager.credentials(withScope: scope as String?, minTTL: minTTL, parameters: parameters as! [String : Any]) { result in
+            switch result {
+            case .success(let credentials):
+                resolve(credentials.toNSDictionary())
+            case .failure(let error):
+                reject(CredentialsManagerBridge.errorCode, error.errorDescription, error)
+            }
+        }
+    }
+    
+    @objc public func hasValidCredentials(minTTL: Int, resolve: RCTPromiseResolveBlock) {
+        resolve(credentialsManager.hasValid(minTTL: minTTL))
+    }
+    
+    @objc public func clearCredentials(resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) {
+        resolve(credentialsManager.clear())
+    }
+    
+    @objc public func enableLocalAuthentication(title: NSString?, cancelTitle: NSString?, fallbackTitle: NSString?) {
+        let titleValue: NSString = title ?? "Please authenticate to continue"
+        self.credentialsManager.enableBiometrics(withTitle: titleValue as String, cancelTitle: cancelTitle as String?, fallbackTitle: fallbackTitle as String?)
+    }
+}
+
+
+extension Credentials {
+    static func fromNSDictionary(credentialsMap: NSDictionary) -> Credentials {
+        let accessToken = credentialsMap[CredentialsManagerBridge.accessTokenKey]
+        let idToken = credentialsMap[CredentialsManagerBridge.idTokenKey]
+        let tokenType = credentialsMap[CredentialsManagerBridge.tokenTypeKey]
+        let refreshToken = credentialsMap[CredentialsManagerBridge.refreshTokenKey] as? String
+        let scope = credentialsMap[CredentialsManagerBridge.scopeKey] as? String
+        
+        var expiresIn: Date?
+        if let string = credentialsMap[CredentialsManagerBridge.expiresInKey] as? String, let double = Double(string) {
+            expiresIn = Date(timeIntervalSinceNow: double)
+        } else if let double = credentialsMap[CredentialsManagerBridge.expiresInKey] as? Double {
+            expiresIn = Date(timeIntervalSinceNow: double)
+        } else if let dateStr = credentialsMap[CredentialsManagerBridge.expiresInKey] as? String {
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = CredentialsManagerBridge.dateFormat
+            expiresIn = dateFormatter.date(from: dateStr)
+        }
+        
+        return Credentials(
+            accessToken: accessToken as! String,
+            tokenType: tokenType as! String,
+            idToken: idToken as! String,
+            refreshToken: refreshToken,
+            expiresIn: expiresIn ?? Date(),
+            scope: scope,
+            recoveryCode: nil
+        )
+    }
+    
+    func toNSDictionary() -> NSDictionary {
+        return NSDictionary(dictionary: [
+            CredentialsManagerBridge.accessTokenKey: self.accessToken,
+            CredentialsManagerBridge.tokenTypeKey: self.tokenType,
+            CredentialsManagerBridge.idTokenKey: self.idToken,
+            CredentialsManagerBridge.refreshTokenKey: self.refreshToken!,
+            CredentialsManagerBridge.expiresInKey: self.expiresIn,
+            CredentialsManagerBridge.scopeKey: self.scope!
+        ])
+    }
 }

--- a/ios/CredentialsManagerBridge.swift
+++ b/ios/CredentialsManagerBridge.swift
@@ -1,0 +1,22 @@
+//
+//  CredentialsManagerBridge.swift
+//  A0Auth0
+//
+//  Created by Poovamraj Thanganadar Thiagarajan on 09.08.22.
+//  Copyright © 2022 Facebook. All rights reserved.
+//
+
+import Auth0
+
+@objc(CredentialsManagerBridge)
+class CredentialsManagerBridge: NSObject {
+    let clientId: NSString
+    
+    let domain: NSString
+    
+    @objc public init(clientId: NSString, domain: NSString) {
+        self.clientId = clientId
+        self.domain = domain
+        super.init()
+   }
+}

--- a/src/credentials-manager/__tests__/credentials-manager.spec.js
+++ b/src/credentials-manager/__tests__/credentials-manager.spec.js
@@ -3,8 +3,10 @@ import Auth from '../../auth';
 import {Platform} from 'react-native';
 
 describe('credentials manager tests', () => {
-  const auth = new Auth({baseUrl: 'https://auth0.com', clientId: 'abc123'});
-  const credentialsManager = new CredentialsManager(auth);
+  const credentialsManager = new CredentialsManager(
+    'https://auth0.com',
+    'abc123',
+  );
 
   credentialsManager.Auth0Module.hasValidCredentialManagerInstance = () =>
     Promise.resolve(true);

--- a/src/credentials-manager/__tests__/credentials-manager.spec.js
+++ b/src/credentials-manager/__tests__/credentials-manager.spec.js
@@ -5,6 +5,13 @@ describe('credentials manager tests', () => {
   const auth = new Auth({baseUrl: 'https://auth0.com', clientId: 'abc123'});
   const credentialsManager = new CredentialsManager(auth);
 
+  credentialsManager.Auth0Module.hasValidCredentialManagerInstance = () =>
+    Promise.resolve(true);
+  credentialsManager.Auth0Module.saveCredentials = () => {};
+  credentialsManager.Auth0Module.getCredentials = () => {};
+  credentialsManager.Auth0Module.hasValidCredentials = () => {};
+  credentialsManager.Auth0Module.clearCredentials = () => {};
+
   const validToken = {
     idToken: '1234',
     accessToken: '1234',
@@ -51,6 +58,97 @@ describe('credentials manager tests', () => {
       await expect(
         credentialsManager.saveCredentials(testToken),
       ).rejects.toThrow();
+    });
+
+    it('proper error is thrown for exception', async () => {
+      const newNativeModule = jest
+        .spyOn(
+          credentialsManager.Auth0Module,
+          'hasValidCredentialManagerInstance',
+        )
+        .mockImplementation(() => {
+          throw Error('123123');
+        });
+      await expect(
+        credentialsManager.saveCredentials(validToken),
+      ).rejects.toThrow();
+      newNativeModule.mockRestore();
+    });
+
+    it('succeeds for proper token', async () => {
+      const newNativeModule = jest
+        .spyOn(credentialsManager.Auth0Module, 'saveCredentials')
+        .mockImplementation(() => Promise.resolve(true));
+      await expect(
+        credentialsManager.saveCredentials(validToken),
+      ).resolves.toEqual(true);
+      newNativeModule.mockRestore();
+    });
+  });
+
+  describe('test getting credentials', () => {
+    it('proper error is thrown for exception', async () => {
+      const newNativeModule = jest
+        .spyOn(credentialsManager.Auth0Module, 'getCredentials')
+        .mockImplementation(() => {
+          throw Error('123123');
+        });
+      await expect(credentialsManager.getCredentials()).rejects.toThrow();
+      newNativeModule.mockRestore();
+    });
+
+    it('succeedsfully returns credentials', async () => {
+      const newNativeModule = jest
+        .spyOn(credentialsManager.Auth0Module, 'getCredentials')
+        .mockImplementation(() => Promise.resolve(validToken));
+      await expect(credentialsManager.getCredentials()).resolves.toEqual(
+        validToken,
+      );
+      newNativeModule.mockRestore();
+    });
+  });
+
+  describe('test hasValidCredentials', () => {
+    it('returns false', async () => {
+      const newNativeModule = jest
+        .spyOn(credentialsManager.Auth0Module, 'hasValidCredentials')
+        .mockImplementation(() => Promise.resolve(true));
+      await expect(credentialsManager.hasValidCredentials()).resolves.toEqual(
+        true,
+      );
+      newNativeModule.mockRestore();
+    });
+
+    it('returns true', async () => {
+      const newNativeModule = jest
+        .spyOn(credentialsManager.Auth0Module, 'hasValidCredentials')
+        .mockImplementation(() => Promise.resolve(true));
+      await expect(credentialsManager.hasValidCredentials()).resolves.toEqual(
+        true,
+      );
+      newNativeModule.mockRestore();
+    });
+  });
+
+  describe('test clearing credentials', () => {
+    it('returns false', async () => {
+      const newNativeModule = jest
+        .spyOn(credentialsManager.Auth0Module, 'clearCredentials')
+        .mockImplementation(() => Promise.resolve(true));
+      await expect(credentialsManager.clearCredentials()).resolves.toEqual(
+        true,
+      );
+      newNativeModule.mockRestore();
+    });
+
+    it('returns true', async () => {
+      const newNativeModule = jest
+        .spyOn(credentialsManager.Auth0Module, 'clearCredentials')
+        .mockImplementation(() => Promise.resolve(true));
+      await expect(credentialsManager.clearCredentials()).resolves.toEqual(
+        true,
+      );
+      newNativeModule.mockRestore();
     });
   });
 });

--- a/src/credentials-manager/__tests__/credentials-manager.spec.js
+++ b/src/credentials-manager/__tests__/credentials-manager.spec.js
@@ -1,0 +1,56 @@
+import CredentialsManager from '../index';
+import Auth from '../../auth';
+
+describe('credentials manager tests', () => {
+  const auth = new Auth({baseUrl: 'https://auth0.com', clientId: 'abc123'});
+  const credentialsManager = new CredentialsManager(auth);
+
+  const validToken = {
+    idToken: '1234',
+    accessToken: '1234',
+    tokenType: 'Bearer',
+    expiresIn: 86000,
+  };
+
+  describe('test saving credentials', () => {
+    it('throws when access token is empty', async () => {
+      const testToken = Object.assign({}, validToken);
+      testToken.idToken = undefined;
+      await expect(
+        credentialsManager.saveCredentials(testToken),
+      ).rejects.toThrow();
+    });
+
+    it('throws when token type is empty', async () => {
+      const testToken = Object.assign({}, validToken);
+      testToken.tokenType = undefined;
+      await expect(
+        credentialsManager.saveCredentials(testToken),
+      ).rejects.toThrow();
+    });
+
+    it('throws when access type is empty', async () => {
+      const testToken = Object.assign({}, validToken);
+      testToken.accessToken = undefined;
+      await expect(
+        credentialsManager.saveCredentials(testToken),
+      ).rejects.toThrow();
+    });
+
+    it('throws when expiresIn type is empty', async () => {
+      const testToken = Object.assign({}, validToken);
+      testToken.expiresIn = undefined;
+      await expect(
+        credentialsManager.saveCredentials(testToken),
+      ).rejects.toThrow();
+    });
+
+    it('throws when expiresIn type is zero', async () => {
+      const testToken = Object.assign({}, validToken);
+      testToken.expiresIn = 0;
+      await expect(
+        credentialsManager.saveCredentials(testToken),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/src/credentials-manager/__tests__/credentials-manager.spec.js
+++ b/src/credentials-manager/__tests__/credentials-manager.spec.js
@@ -1,5 +1,6 @@
 import CredentialsManager from '../index';
 import Auth from '../../auth';
+import {Platform} from 'react-native';
 
 describe('credentials manager tests', () => {
   const auth = new Auth({baseUrl: 'https://auth0.com', clientId: 'abc123'});
@@ -11,6 +12,7 @@ describe('credentials manager tests', () => {
   credentialsManager.Auth0Module.getCredentials = () => {};
   credentialsManager.Auth0Module.hasValidCredentials = () => {};
   credentialsManager.Auth0Module.clearCredentials = () => {};
+  credentialsManager.Auth0Module.enableLocalAuthentication = () => {};
 
   const validToken = {
     idToken: '1234',
@@ -148,6 +150,26 @@ describe('credentials manager tests', () => {
       await expect(credentialsManager.clearCredentials()).resolves.toEqual(
         true,
       );
+      newNativeModule.mockRestore();
+    });
+  });
+
+  describe('test enabling local authentication', () => {
+    it('enable local authentication for iOS', async () => {
+      Platform.OS = 'ios';
+      const newNativeModule = jest
+        .spyOn(credentialsManager.Auth0Module, 'enableLocalAuthentication')
+        .mockImplementation(() => {});
+      await expect(credentialsManager.requireLocalAuthentication()).resolves;
+      newNativeModule.mockRestore();
+    });
+
+    it('enable local authentication for Android', async () => {
+      Platform.OS = 'android';
+      const newNativeModule = jest
+        .spyOn(credentialsManager.Auth0Module, 'enableLocalAuthentication')
+        .mockImplementation(() => {});
+      await expect(credentialsManager.requireLocalAuthentication()).resolves;
       newNativeModule.mockRestore();
     });
   });

--- a/src/credentials-manager/credentialsManagerError.js
+++ b/src/credentials-manager/credentialsManagerError.js
@@ -1,0 +1,17 @@
+import BaseError from '../utils/baseError';
+
+export default class CredentialsManagerError extends BaseError {
+  constructor(response) {
+    const {status, json = {}, text} = response;
+    const {error, error_description: description, invalid_parameter} = json;
+    super(
+      error || 'a0.response.invalid',
+      description || text || handleInvalidToken(response) || 'unknown error',
+    );
+    this.json = json;
+    this.status = status;
+    if (invalid_parameter) {
+      this.invalid_parameter = invalid_parameter;
+    }
+  }
+}

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -3,13 +3,12 @@ import CredentialsManagerError from './credentialsManagerError';
 
 export default class CredentialsManager {
   /**
-   * Construct an instance of CredentialsManager which can be used to
-   * store, retrieve and manage credentials.
+   * Construct an instance of CredentialsManager
    *
-   * @param {*} auth - required - instance of Auth0 Auth API
+   * @param {String} domain - required - the domain of the credentials to be managed
+   * @param {String} clientId - required - clientId of the credentials to be managed
    */
-  constructor(auth) {
-    const {clientId, domain} = auth;
+  constructor(domain, clientId) {
     this.domain = domain;
     this.clientId = clientId;
     this.Auth0Module = NativeModules.A0Auth0;

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -37,7 +37,7 @@ export default class CredentialsManager {
     });
     try {
       await this.ensureCredentialManagerIsInitialized();
-      await this.Auth0Module.saveCredentials(credentials);
+      return await this.Auth0Module.saveCredentials(credentials);
     } catch (e) {
       const json = {
         error: 'a0.credential_manager.invalid',

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -36,7 +36,7 @@ export default class CredentialsManager {
       }
     });
     try {
-      await this.ensureCredentialManagerIsInitialized();
+      await this._ensureCredentialManagerIsInitialized();
       return await this.Auth0Module.saveCredentials(credentials);
     } catch (e) {
       const json = {
@@ -48,7 +48,7 @@ export default class CredentialsManager {
   }
 
   /**
-   * Gets the credential that has already been saved
+   * Gets the credentials that has already been saved
    *
    * @param {String} scope optional - the scope to request for the access token. If null is passed, the previous scope will be kept.
    * @param {String} minTtl optional - the minimum time in seconds that the access token should last before expiration.
@@ -59,7 +59,7 @@ export default class CredentialsManager {
    */
   async getCredentials(scope, minTtl = 0, parameters = {}) {
     try {
-      await this.ensureCredentialManagerIsInitialized();
+      await this._ensureCredentialManagerIsInitialized();
       const credentials = await this.Auth0Module.getCredentials(
         scope,
         minTtl,
@@ -76,7 +76,7 @@ export default class CredentialsManager {
   }
 
   /**
-   * Gets the credential that has already been saved
+   * Enables Local Authentication (PIN, Biometric, Swipe etc) to get the credentials
    *
    * @param {String} title optional - the text to use as title in the authentication screen. Passing null will result in using the OS's default value in Android and "Please authenticate to continue" in iOS.
    * @param {String} description Android Only - optional - the text to use as description in the authentication screen. On some Android versions it might not be shown. Passing null will result in using the OS's default value.
@@ -93,7 +93,7 @@ export default class CredentialsManager {
     fallbackTitle,
   ) {
     try {
-      await this.ensureCredentialManagerIsInitialized();
+      await this._ensureCredentialManagerIsInitialized();
       if (Platform.OS === 'ios') {
         await this.Auth0Module.enableLocalAuthentication(
           title,
@@ -120,7 +120,7 @@ export default class CredentialsManager {
    * @memberof CredentialsManager
    */
   async hasValidCredentials(minTtl = 0) {
-    await this.ensureCredentialManagerIsInitialized();
+    await this._ensureCredentialManagerIsInitialized();
     return await this.Auth0Module.hasValidCredentials(minTtl);
   }
 
@@ -130,12 +130,12 @@ export default class CredentialsManager {
    * @memberof CredentialsManager
    */
   async clearCredentials() {
-    await this.ensureCredentialManagerIsInitialized();
+    await this._ensureCredentialManagerIsInitialized();
     return await this.Auth0Module.clearCredentials();
   }
 
   //private
-  async ensureCredentialManagerIsInitialized() {
+  async _ensureCredentialManagerIsInitialized() {
     const hasValid = await this.Auth0Module.hasValidCredentialManagerInstance();
     if (!hasValid) {
       await this.Auth0Module.initializeCredentialManager(

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -141,7 +141,7 @@ export default class CredentialsManager {
    */
   async clearCredentials() {
     await this.ensureCredentialManagerIsInitialized();
-    await this.Auth0Module.clearCredentials();
+    return await this.Auth0Module.clearCredentials();
   }
 
   //private

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -2,7 +2,8 @@ import {Platform, NativeModules} from 'react-native';
 import CredentialsManagerError from './credentialsManagerError';
 
 export default class CredentialsManager {
-  constructor(clientId, domain) {
+  constructor(auth) {
+    const {clientId, domain} = auth;
     this.domain = domain;
     this.clientId = clientId;
     this.Auth0Module = NativeModules.A0Auth0;

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -2,6 +2,12 @@ import {Platform, NativeModules} from 'react-native';
 import CredentialsManagerError from './credentialsManagerError';
 
 export default class CredentialsManager {
+  /**
+   * Construct an instance of CredentialsManager which can be used to
+   * store, retrieve and manage credentials.
+   *
+   * @param {*} auth - required - instance of Auth0 Auth API
+   */
   constructor(auth) {
     const {clientId, domain} = auth;
     this.domain = domain;

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -16,8 +16,7 @@ export default class CredentialsManager {
    * @param {String} credentials.idToken required - JWT token that has user claims
    * @param {String} credentials.accessToken required - token used for API calls
    * @param {String} credentials.tokenType required - type of the token, ex - Bearer
-   * @param {Number} credentials.expiresIn optional - `expiresAt` should not be empty if this is. Used to denote when the token will expire from the issued time
-   * @param {String} credentials.expiresAt optional - `expiresIn` should not be empty if this is. Used to denote when the token will expire. Has precendence over `expiresIn`.
+   * @param {Number} credentials.expiresIn required - Used to denote when the token will expire from the issued time
    * @param {String} credentials.refreshToken optional - used to refresh access token
    * @param {String} credentials.scope optional - represents the scope of the current token
    * @returns {Promise}
@@ -25,7 +24,7 @@ export default class CredentialsManager {
    * @memberof CredentialsManager
    */
   async saveCredentials(credentials = {}) {
-    const validateKeys = ['idToken', 'accessToken', 'tokenType'];
+    const validateKeys = ['idToken', 'accessToken', 'tokenType', 'expiresIn'];
     validateKeys.forEach(key => {
       if (!credentials[key]) {
         const json = {
@@ -36,16 +35,6 @@ export default class CredentialsManager {
         throw new CredentialsManagerError({json, status: 0});
       }
     });
-    if (
-      (!credentials.expiresIn || !credentials.expiresIn > 0) &&
-      !credentials.expiresAt
-    ) {
-      const json = {
-        error: 'a0.credential_manager.invalid_input',
-        error_description: `expiresIn or expiresAt should be set`,
-      };
-      throw new CredentialsManagerError({json, status: 0});
-    }
     try {
       await this.ensureCredentialManagerIsInitialized();
       await this.Auth0Module.saveCredentials(credentials);

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -1,0 +1,145 @@
+import {NativeModules} from 'react-native';
+import CredentialsManagerError from './credentialsManagerError';
+
+export default class CredentialsManager {
+  constructor(clientId, domain) {
+    this.domain = domain;
+    this.clientId = clientId;
+    this.Auth0Module = NativeModules.A0Auth0;
+  }
+
+  /**
+   * Saves the provided credentials
+   *
+   * @param {Object} credentials credential values
+   * @param {String} credentials.idToken required - JWT token that has user claims
+   * @param {String} credentials.accessToken required - token used for API calls
+   * @param {String} credentials.tokenType required - type of the token, ex - Bearer
+   * @param {Number} credentials.expiresIn optional - `expiresAt` should not be empty if this is. Used to denote when the token will expire from the issued time
+   * @param {String} credentials.expiresAt optional - `expiresIn` should not be empty if this is. Used to denote when the token will expire. Has precendence over `expiresIn`.
+   * @param {String} credentials.refreshToken optional - used to refresh access token
+   * @param {String} credentials.scope optional - represents the scope of the current token
+   * @returns {Promise}
+   *
+   * @memberof CredentialsManager
+   */
+  async saveCredentials(credentials = {}) {
+    const validateKeys = ['idToken', 'accessToken', 'tokenType'];
+    validateKeys.forEach(key => {
+      if (!credentials[key]) {
+        const json = {
+          error: 'a0.credential_manager.invalid_input',
+          error_description: `${key} cannot be empty`,
+          invalid_parameter: key,
+        };
+        throw new CredentialsManagerError({json, status: 0});
+      }
+    });
+    if (
+      (!credentials.expiresIn || !credentials.expiresIn > 0) &&
+      !credentials.expiresAt
+    ) {
+      const json = {
+        error: 'a0.credential_manager.invalid_input',
+        error_description: `expiresIn or expiresAt should be set`,
+      };
+      throw new CredentialsManagerError({json, status: 0});
+    }
+    try {
+      await this.ensureCredentialManagerIsInitialized();
+      await this.Auth0Module.saveCredentials(credentials);
+    } catch (e) {
+      const json = {
+        error: 'a0.credential_manager.invalid',
+        error_description: e.message,
+      };
+      throw new CredentialsManagerError({json, status: 0});
+    }
+  }
+
+  /**
+   * Gets the credential that has already been saved
+   *
+   * @param {String} scope optional - the scope to request for the access token. If null is passed, the previous scope will be kept.
+   * @param {String} minTtl optional - the minimum time in seconds that the access token should last before expiration.
+   * @param {Object} parameters optional - additional parameters to send in the request to refresh expired credentials.
+   * @returns {Promise}
+   *
+   * @memberof CredentialsManager
+   */
+  async getCredentials(scope, minTtl = 0, parameters = {}) {
+    try {
+      await this.ensureCredentialManagerIsInitialized();
+      const credentials = await this.Auth0Module.getCredentials(
+        scope,
+        minTtl,
+        parameters,
+      );
+      return credentials;
+    } catch (e) {
+      const json = {
+        error: 'a0.credential_manager.invalid',
+        error_description: e.message,
+      };
+      throw new CredentialsManagerError({json, status: 0});
+    }
+  }
+
+  /**
+   * Gets the credential that has already been saved
+   *
+   * @param {String} title optional - the text to use as title in the authentication screen. Passing null will result in using the OS's default value.
+   * @param {String} description optional - the text to use as description in the authentication screen. On some Android versions it might not be shown. Passing null will result in using the OS's default value.
+   * @returns {Promise}
+   *
+   * @memberof CredentialsManager
+   */
+  async requireLocalAuthentication(title, description) {
+    try {
+      await this.ensureCredentialManagerIsInitialized();
+      const cred = await this.Auth0Module.enableLocalAuthentication(
+        title,
+        description,
+      );
+    } catch (e) {
+      const json = {
+        error: 'a0.credential_manager.invalid',
+        error_description: e.message,
+      };
+      throw new CredentialsManagerError({json, status: 0});
+    }
+  }
+
+  /**
+   * Returns whether this manager contains a valid non-expired pair of credentials.
+   *
+   * @param {Number} minTtl optional - the minimum time in seconds that the access token should last before expiration
+   *
+   * @memberof CredentialsManager
+   */
+  async hasValidCredentials(minTtl = 0) {
+    await this.ensureCredentialManagerIsInitialized();
+    return await this.Auth0Module.hasValidCredentials(minTtl);
+  }
+
+  /**
+   * Delete the stored credentials
+   *
+   * @memberof CredentialsManager
+   */
+  async clearCredentials() {
+    await this.ensureCredentialManagerIsInitialized();
+    await this.Auth0Module.clearCredentials();
+  }
+
+  //private
+  async ensureCredentialManagerIsInitialized() {
+    const hasValid = await this.Auth0Module.hasValidCredentialManagerInstance();
+    if (!hasValid) {
+      await this.Auth0Module.initializeCredentialManager(
+        this.clientId,
+        this.domain,
+      );
+    }
+  }
+}

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -1,4 +1,4 @@
-import {NativeModules} from 'react-native';
+import {Platform, NativeModules} from 'react-native';
 import CredentialsManagerError from './credentialsManagerError';
 
 export default class CredentialsManager {
@@ -88,19 +88,31 @@ export default class CredentialsManager {
   /**
    * Gets the credential that has already been saved
    *
-   * @param {String} title optional - the text to use as title in the authentication screen. Passing null will result in using the OS's default value.
-   * @param {String} description optional - the text to use as description in the authentication screen. On some Android versions it might not be shown. Passing null will result in using the OS's default value.
+   * @param {String} title optional - the text to use as title in the authentication screen. Passing null will result in using the OS's default value in Android and "Please authenticate to continue" in iOS.
+   * @param {String} description Android Only - optional - the text to use as description in the authentication screen. On some Android versions it might not be shown. Passing null will result in using the OS's default value.
+   * @param {String} cancelTitle iOS Only - optional - the cancel message to display on the local authentication prompt.
+   * @param {String} fallbackTitle iOS Only - optional - the fallback message to display on the local authentication prompt after a failed match.
    * @returns {Promise}
    *
    * @memberof CredentialsManager
    */
-  async requireLocalAuthentication(title, description) {
+  async requireLocalAuthentication(
+    title,
+    description,
+    cancelTitle,
+    fallbackTitle,
+  ) {
     try {
       await this.ensureCredentialManagerIsInitialized();
-      const cred = await this.Auth0Module.enableLocalAuthentication(
-        title,
-        description,
-      );
+      if (Platform.OS === 'ios') {
+        await this.Auth0Module.enableLocalAuthentication(
+          title,
+          cancelTitle,
+          fallbackTitle,
+        );
+      } else {
+        await this.Auth0Module.enableLocalAuthentication(title, description);
+      }
     } catch (e) {
       const json = {
         error: 'a0.credential_manager.invalid',


### PR DESCRIPTION
### Changes
We have provided Credentials Manager support for Android and iOS in React Native. The following methods are added

- getCredentials
- saveCredentials
- hasValidCredentials
- clearCredentials

We also return a boolean value from Android API for `clearCredentials`. This is to be same to our iOS API and Flutter API

This PR is a superset of https://github.com/auth0/react-native-auth0/pull/497 and will have all the changes and reviews from there implemented.

### References
https://github.com/auth0/react-native-auth0/issues/476

### Testing

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
