### PR TITLE
Add language to fetch request

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "dependencies": {
     "base-64": "^0.1.0",
     "crypto-js": "^4.0.0",
+    "react-native-localize": "^2.2.3",
     "jsbn": "^1.1.0",
     "jwt-decode": "^2.2.0",
     "url": "^0.11.0"

--- a/src/language/agentLanguage.js
+++ b/src/language/agentLanguage.js
@@ -1,0 +1,5 @@
+import * as RNLocalize from "react-native-localize";
+
+function agentLanguage() {
+    RNLocalize.findBestAvailableLanguage();
+}

--- a/src/utils/fetchWithTimeout.js
+++ b/src/utils/fetchWithTimeout.js
@@ -29,6 +29,9 @@ function fetchWithTimeout(url, options, timeoutMs) {
     fetch(url, {
       ...options,
       signal: abortController.signal,
+      headers: {
+        'Accept-Language': agentLanguage()
+      }
     }),
     timeoutPromise,
   ])


### PR DESCRIPTION
### Changes

Added `Accept-Language` to the client.

### References

https://support.auth0.com/tickets/00785686

### Background

#### Objective
We need to localise email templates within Auth0

#### Our solution

1. Create a Flow Action to capture the device language
2. Save the device language in the `user_metadata` object withing Auth0
3. Use Liquid to localise emails

#### Issues

We detected the following when testing this solution:

1. When testing on a real iOS device the language header is sent to the remote endpoint
2. When testing on an emulated iOS device the language header is sent to the remote endpoint
3. When testing on an emulated Android device the language header is sent to the remote endpoint
4. When testing on a real Android device the language header is **not** sent to the remote endpoint

#### Possible causes

Our theory is the following:

1. When the `fetch` method `src/utils/fetchWithTimeout.js:29` is handled by an iOS device, a language header is automatically attached by the native handler
2. When the `fetch` method is handled by a chrome browser in an emulated environment, a language header is automatically attached by the browser handler
3. When the `fetch` method is handled by the native Android handler a language header is **not** attached


#### Our solution

We propose to always attach the language header to every request.


### Notes

This code is not tested and only serves the purpose of helping Auth0 developers to fix this issue.


