### PR TITLE
ci: publish vnext with tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,4 +32,18 @@ workflows:
             branches:
               only:
                 - master
+  build-and-test-vnext:
+    jobs:
+      - build
+      - ship/node-publish:
+          pkg-manager: yarn
+          publish-command: yarn publish --tag next
+          requires:
+            - build
+          context:
+            - publish-npm
+            - publish-gh
+          filters:
+            branches:
+              only:
                 - vnext


### PR DESCRIPTION
Created a new build job for the `vnext` branch and override `publish-command` so that it uses a tag.