### PR TITLE
Test latest version of Ship orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  ship: auth0/ship@0.2.0
+  ship: auth0/ship@0.7.1
   codecov: codecov/codecov@3
 
 jobs:
@@ -37,7 +37,7 @@ workflows:
       - build
       - ship/node-publish:
           pkg-manager: yarn
-          publish-command: npm publish --tag next
+          publish-command: npm publish --tag next --dry-run
           requires:
             - build
           context:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-auth0",
   "title": "React Native Auth0",
-  "version": "2.14.0-fa.0",
+  "version": "2.14.0-fa.0-test",
   "description": "React Native toolkit for Auth0 API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We will use this PR to test whether the latest version of Ship Orb avoids the breakage in CI.

We are adding `dry-run` argument to avoid uploading to the NPM registry.

The version is updated so that the CI will not fail because similar version already exists in NPM.

If this succeeds, we will clean up and remove the `vnext` job and run this only on master