### PR TITLE
[SDK-3659] Fix CI to latest version of Ship Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,18 +32,3 @@ workflows:
             branches:
               only:
                 - master
-  build-and-test-vnext:
-    jobs:
-      - build
-      - ship/node-publish:
-          pkg-manager: yarn
-          publish-command: npm publish --tag next --dry-run
-          requires:
-            - build
-          context:
-            - publish-npm
-            - publish-gh
-          filters:
-            branches:
-              only:
-                - vnext

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-auth0",
   "title": "React Native Auth0",
-  "version": "2.14.0-fa.0-test",
+  "version": "2.14.0-fa.0",
   "description": "React Native toolkit for Auth0 API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Changes

As tested in PR #520 

The version of Ship Orb used did not work for custom publish commands. Though we are not using custom publish command now, this caused an issue when we were releasing beta. To avoid this we have updated the version of Ship Orb used.

### References

https://github.com/auth0/react-native-auth0/pull/520

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
