### PR TITLE
Removed Activity from Android library to avoid prompt

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -29,6 +29,14 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name="com.auth0.android.provider.RedirectActivity"
+            tools:node="remove"/>
+            
+        <activity
+            android:name="com.auth0.android.provider.AuthenticationActivity"
+            tools:node="remove"/>
+
     </application>
 
     <queries>


### PR DESCRIPTION
### Changes

We have removed Activities from Auth0.Android library being added to the RNA manifest. This being added caused to open a prompt with asking to choose the sample application twice. 

These activities are noted in the manifest to be removed

### References

There was an issue noting this here - https://github.com/auth0/react-native-auth0/issues/531

### Testing
We have manually tested this.

We used this command `adb shell dumpsys package r` which previously showed 2 activities registered to receive the intent. Now there will be just 1 which will avoid the above issue

