### PR TITLE
Avoid config changes to handle authentication

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <application>
         <activity
             android:name="com.auth0.react.AuthenticationActivity"
+            android:configChanges="screenSize|smallestScreenSize|screenLayout|orientation|keyboard|keyboardHidden"
             android:exported="false"
             android:launchMode="singleTask"
             android:theme="@android:style/Theme.Translucent.NoTitleBar" />


### PR DESCRIPTION
### Changes
We have avoided config changes by locking them in the Manifest. The analysis for this is already done and the related Android ticket with PR is linked below

### References

How this fixed issue in Android - https://github.com/auth0/Auth0.Android/issues/530
Issue reported in RNA - https://github.com/auth0/Auth0.Android/issues/530

### Testing
We have tested this manually as Unit test is not really possible here
