### PR TITLE
provider passes params

### DIFF
--- a/src/hooks/__tests__/use-auth0.spec.js
+++ b/src/hooks/__tests__/use-auth0.spec.js
@@ -132,7 +132,7 @@ describe('The useAuth0 hook', () => {
     await waitForNextUpdate();
 
     expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith(
-      {},
+      {scope: 'openid profile email'},
       {ephemeralSession: true},
     );
   });

--- a/src/hooks/__tests__/use-auth0.spec.js
+++ b/src/hooks/__tests__/use-auth0.spec.js
@@ -124,6 +124,19 @@ describe('The useAuth0 hook', () => {
     expect(mockAuth0.credentialsManager.saveCredentials).toBeCalled();
   });
 
+  it('can authorize with ephemeralSession', async () => {
+    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+
+    result.current.authorize({}, {ephemeralSession: true});
+
+    await waitForNextUpdate();
+
+    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith(
+      {},
+      {ephemeralSession: true},
+    );
+  });
+
   it('can authorize, passing through all parameters', async () => {
     const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
 

--- a/src/hooks/__tests__/use-auth0.spec.js
+++ b/src/hooks/__tests__/use-auth0.spec.js
@@ -232,6 +232,15 @@ describe('The useAuth0 hook', () => {
     expect(mockAuth0.credentialsManager.clearCredentials).toHaveBeenCalled();
   });
 
+  it('can clear the credentials', async () => {
+    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+
+    result.current.clearCredentials();
+    await waitForNextUpdate();
+    expect(result.current.user).toBeNull();
+    expect(mockAuth0.credentialsManager.clearCredentials).toHaveBeenCalled();
+  });
+
   it('can clear the session and pass parameters', async () => {
     const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
 

--- a/src/hooks/__tests__/use-auth0.spec.js
+++ b/src/hooks/__tests__/use-auth0.spec.js
@@ -135,11 +135,14 @@ describe('The useAuth0 hook', () => {
 
     await waitForNextUpdate();
 
-    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith({
-      scope: 'custom-scope openid profile email',
-      audience: 'http://my-api',
-      customParam: '1234',
-    });
+    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith(
+      {
+        scope: 'custom-scope openid profile email',
+        audience: 'http://my-api',
+        customParam: '1234',
+      },
+      {},
+    );
   });
 
   it('adds the default scopes when none are specified', async () => {
@@ -149,9 +152,12 @@ describe('The useAuth0 hook', () => {
 
     await waitForNextUpdate();
 
-    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith({
-      scope: 'openid profile email',
-    });
+    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith(
+      {
+        scope: 'openid profile email',
+      },
+      {},
+    );
   });
 
   it('adds the default scopes when some are specified with custom scope', async () => {
@@ -161,9 +167,12 @@ describe('The useAuth0 hook', () => {
 
     await waitForNextUpdate();
 
-    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith({
-      scope: 'custom-scope openid profile email',
-    });
+    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith(
+      {
+        scope: 'custom-scope openid profile email',
+      },
+      {},
+    );
   });
 
   it('does not duplicate default scopes', async () => {
@@ -177,11 +186,14 @@ describe('The useAuth0 hook', () => {
 
     await waitForNextUpdate();
 
-    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith({
-      scope: 'openid profile email',
-      audience: 'http://my-api',
-      customParam: '1234',
-    });
+    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith(
+      {
+        scope: 'openid profile email',
+        audience: 'http://my-api',
+        customParam: '1234',
+      },
+      {},
+    );
   });
 
   it('sets the user prop after authorizing', async () => {

--- a/src/hooks/auth0-context.js
+++ b/src/hooks/auth0-context.js
@@ -10,6 +10,7 @@ const initialContext = {
   authorize: stub,
   clearSession: stub,
   getCredentials: stub,
+  clearCredentials: stub,
   requireLocalAuthentication: stub,
 };
 

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -115,7 +115,9 @@ const Auth0Provider = ({domain, clientId, children}) => {
   const clearCredentials = useCallback(
     async (...options) => {
       try {
-        return await client.credentialsManager.clearCredentials(...options);
+        await client.credentialsManager.clearCredentials(...options);
+        dispatch({type: 'LOGOUT_COMPLETE'});
+        return;
       } catch (error) {
         dispatch({type: 'ERROR', error});
         return;

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -63,6 +63,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
     async (...options) => {
       try {
         const opts = options.length ? options[0] : {};
+        const params = options.length > 1 ? options[1] : {};
         const specifiedScopes =
           opts?.scope?.split(' ').map(s => s.trim()) || [];
         const scopeSet = new Set([
@@ -72,7 +73,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
 
         opts.scope = Array.from(scopeSet).join(' ');
 
-        const credentials = await client.webAuth.authorize(opts);
+        const credentials = await client.webAuth.authorize(opts, params);
         const user = getIdTokenProfileClaims(credentials.idToken);
 
         await client.credentialsManager.saveCredentials(credentials);

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -112,6 +112,18 @@ const Auth0Provider = ({domain, clientId, children}) => {
     [client],
   );
 
+  const clearCredentials = useCallback(
+    async (...options) => {
+      try {
+        return await client.credentialsManager.clearCredentials(...options);
+      } catch (error) {
+        dispatch({type: 'ERROR', error});
+        return;
+      }
+    },
+    [client],
+  );
+
   const requireLocalAuthentication = useCallback(async (...options) => {
     try {
       await client.credentialsManager.requireLocalAuthentication(...options);
@@ -127,6 +139,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
       authorize,
       clearSession,
       getCredentials,
+      clearCredentials,
       requireLocalAuthentication,
     }),
     [
@@ -134,6 +147,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
       authorize,
       clearSession,
       getCredentials,
+      clearCredentials,
       requireLocalAuthentication,
     ],
   );

--- a/src/hooks/use-auth0.js
+++ b/src/hooks/use-auth0.js
@@ -8,6 +8,8 @@ import Auth0Context from './auth0-context';
  * @property {Function} authorize Authorize the user using Auth0 Universal Login. See {@link WebAuth#authorize}
  * @property {Function} clearSession Clears the user's session and logs them out. See {@link WebAuth#clearSession}
  * @property {Function} getCredentials Gets the user's credentials from the native credential store. See {@link CredentialsManager#getCredentials}
+ * @property {Function} clearCredentials Clears the user's credentials from the native credential store. See {@link CredentialsManager#clearCredentials}
+
  * @property {Function} requireLocalAuthentication Enables Local Authentication (PIN, Biometric, Swipe etc) to get the credentials. See {@link CredentialsManager#requireLocalAuthentication}
  */
 
@@ -23,6 +25,7 @@ import Auth0Context from './auth0-context';
  *   authorize,
  *   clearSession,
  *   getCredentials,
+ *   clearCredentials,
  *   requireLocalAuthentication
  * } = useAuth0();
  */


### PR DESCRIPTION
### Changes

Fixes issue in hooks that prevents passing params to authorize()

### References

https://github.com/auth0/react-native-auth0/issues/539


### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [none] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
