### PR TITLE
[SDK-3736] Fix: Options Parameter not being passed in Hooks `authorize` method

### DIFF
--- a/src/hooks/__tests__/use-auth0.spec.js
+++ b/src/hooks/__tests__/use-auth0.spec.js
@@ -135,11 +135,40 @@ describe('The useAuth0 hook', () => {
 
     await waitForNextUpdate();
 
-    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith({
-      scope: 'custom-scope openid profile email',
-      audience: 'http://my-api',
-      customParam: '1234',
-    });
+    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith(
+      {
+        scope: 'custom-scope openid profile email',
+        audience: 'http://my-api',
+        customParam: '1234',
+      },
+      {},
+    );
+  });
+
+  it('can authorize, passing through all options', async () => {
+    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+
+    result.current.authorize(
+      {},
+      {
+        ephemeralSession: true,
+        customScheme: 'demo',
+        leeway: 100,
+        skipLegacyListener: false,
+      },
+    );
+
+    await waitForNextUpdate();
+
+    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith(
+      {scope: 'openid profile email'},
+      {
+        ephemeralSession: true,
+        customScheme: 'demo',
+        leeway: 100,
+        skipLegacyListener: false,
+      },
+    );
   });
 
   it('adds the default scopes when none are specified', async () => {
@@ -149,9 +178,12 @@ describe('The useAuth0 hook', () => {
 
     await waitForNextUpdate();
 
-    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith({
-      scope: 'openid profile email',
-    });
+    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith(
+      {
+        scope: 'openid profile email',
+      },
+      {},
+    );
   });
 
   it('adds the default scopes when some are specified with custom scope', async () => {
@@ -161,9 +193,12 @@ describe('The useAuth0 hook', () => {
 
     await waitForNextUpdate();
 
-    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith({
-      scope: 'custom-scope openid profile email',
-    });
+    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith(
+      {
+        scope: 'custom-scope openid profile email',
+      },
+      {},
+    );
   });
 
   it('does not duplicate default scopes', async () => {
@@ -177,11 +212,14 @@ describe('The useAuth0 hook', () => {
 
     await waitForNextUpdate();
 
-    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith({
-      scope: 'openid profile email',
-      audience: 'http://my-api',
-      customParam: '1234',
-    });
+    expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith(
+      {
+        scope: 'openid profile email',
+        audience: 'http://my-api',
+        customParam: '1234',
+      },
+      {},
+    );
   });
 
   it('sets the user prop after authorizing', async () => {

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -63,6 +63,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
     async (...options) => {
       try {
         const opts = options.length ? options[0] : {};
+        const params = options.length > 1 ? options[1] : {};
         const specifiedScopes =
           opts?.scope?.split(' ').map(s => s.trim()) || [];
         const scopeSet = new Set([
@@ -72,7 +73,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
 
         opts.scope = Array.from(scopeSet).join(' ');
 
-        const credentials = await client.webAuth.authorize(opts);
+        const credentials = await client.webAuth.authorize(opts, params);
         const user = getIdTokenProfileClaims(credentials.idToken);
 
         await client.credentialsManager.saveCredentials(credentials);


### PR DESCRIPTION
### Changes
- We have passed the options parameter to underlying `authorize` call
- We have added tests to avoid this regression in future

### References
GH Issue - https://github.com/auth0/react-native-auth0/issues/539
PR - https://github.com/auth0/react-native-auth0/pull/540/

### Testing
- Added Unit tests
- Manually tested if ephemeral sessions are working

Thanks to [@ebg](https://github.com/ebg1223) for filing this issue and providing a fix through PR. We couldn't use that one due to additional changes which is something we will be considering adding as well.
