### PR TITLE
[SDK-3738] Option to clear session only in Credentials Manager

### DIFF
--- a/src/hooks/auth0-context.js
+++ b/src/hooks/auth0-context.js
@@ -10,6 +10,7 @@ const initialContext = {
   authorize: stub,
   clearSession: stub,
   getCredentials: stub,
+  clearCredentials: stub,
   requireLocalAuthentication: stub,
 };
 

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -89,16 +89,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
   const clearSession = useCallback(
     async (...options) => {
       try {
-        const {federated} = options.length ? options[0] : {};
-        const {credentialsManagerOnly} = options.length > 1 ? options[1] : {};
-        if (credentialsManagerOnly && federated) {
-          throw new Error(
-            'It is invalid to set both the `federated` and `credentialsManagerOnly` options to `true`',
-          );
-        }
-        if (!credentialsManagerOnly) {
-          await client.webAuth.clearSession(...options);
-        }
+        await client.webAuth.clearSession(...options);
         await client.credentialsManager.clearCredentials();
         dispatch({type: 'LOGOUT_COMPLETE'});
       } catch (error) {
@@ -121,6 +112,16 @@ const Auth0Provider = ({domain, clientId, children}) => {
     [client],
   );
 
+  const clearCredentials = useCallback(async () => {
+    try {
+      await client.credentialsManager.clearCredentials();
+      dispatch({type: 'LOGOUT_COMPLETE'});
+    } catch (error) {
+      dispatch({type: 'ERROR', error});
+      return;
+    }
+  }, [client]);
+
   const requireLocalAuthentication = useCallback(async (...options) => {
     try {
       await client.credentialsManager.requireLocalAuthentication(...options);
@@ -136,6 +137,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
       authorize,
       clearSession,
       getCredentials,
+      clearCredentials,
       requireLocalAuthentication,
     }),
     [
@@ -143,6 +145,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
       authorize,
       clearSession,
       getCredentials,
+      clearCredentials,
       requireLocalAuthentication,
     ],
   );

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -89,7 +89,16 @@ const Auth0Provider = ({domain, clientId, children}) => {
   const clearSession = useCallback(
     async (...options) => {
       try {
-        await client.webAuth.clearSession(...options);
+        const {federated} = options.length ? options[0] : {};
+        const {credentialsManagerOnly} = options.length > 1 ? options[1] : {};
+        if (credentialsManagerOnly && federated) {
+          throw new Error(
+            'It is invalid to set both the `federated` and `credentialsManagerOnly` options to `true`',
+          );
+        }
+        if (!credentialsManagerOnly) {
+          await client.webAuth.clearSession(...options);
+        }
         await client.credentialsManager.clearCredentials();
         dispatch({type: 'LOGOUT_COMPLETE'});
       } catch (error) {

--- a/src/hooks/use-auth0.js
+++ b/src/hooks/use-auth0.js
@@ -6,8 +6,9 @@ import Auth0Context from './auth0-context';
  * @property {Object} user The user profile as decoded from the ID token after authentication
  * @property {Object} error An object representing the last exception
  * @property {Function} authorize Authorize the user using Auth0 Universal Login. See {@link WebAuth#authorize}
- * @property {Function} clearSession Clears the user's session and logs them out. See {@link WebAuth#clearSession}. `options.credentialsManagerOnly` can be set to true to clear the credentials in the Credential Manager without clearing the web session.
+ * @property {Function} clearSession Clears the user's web session, credentials and logs them out. See {@link WebAuth#clearSession}.
  * @property {Function} getCredentials Gets the user's credentials from the native credential store. See {@link CredentialsManager#getCredentials}
+ * @property {Function} clearCredentials Clears the user's credentials without clearing their web session and logs them out.
  * @property {Function} requireLocalAuthentication Enables Local Authentication (PIN, Biometric, Swipe etc) to get the credentials. See {@link CredentialsManager#requireLocalAuthentication}
  */
 
@@ -23,6 +24,7 @@ import Auth0Context from './auth0-context';
  *   authorize,
  *   clearSession,
  *   getCredentials,
+ *   clearCredentials,
  *   requireLocalAuthentication
  * } = useAuth0();
  */

--- a/src/hooks/use-auth0.js
+++ b/src/hooks/use-auth0.js
@@ -6,7 +6,7 @@ import Auth0Context from './auth0-context';
  * @property {Object} user The user profile as decoded from the ID token after authentication
  * @property {Object} error An object representing the last exception
  * @property {Function} authorize Authorize the user using Auth0 Universal Login. See {@link WebAuth#authorize}
- * @property {Function} clearSession Clears the user's session and logs them out. See {@link WebAuth#clearSession}
+ * @property {Function} clearSession Clears the user's session and logs them out. See {@link WebAuth#clearSession}. `options.credentialsManagerOnly` can be set to true to clear the credentials in the Credential Manager without clearing the web session.
  * @property {Function} getCredentials Gets the user's credentials from the native credential store. See {@link CredentialsManager#getCredentials}
  * @property {Function} requireLocalAuthentication Enables Local Authentication (PIN, Biometric, Swipe etc) to get the credentials. See {@link CredentialsManager#requireLocalAuthentication}
  */


### PR DESCRIPTION
### Changes

Added an option in Hooks `clearSession` to clear credentials only in Credential Manager and not in the web session. It throws an error if both `federated` and `credentialsManagerOnly`  is enabled

The JS Doc handling for this is a not quite great after trying multiple ways. Any suggestion on improving this would be great.

### References

This is a feature request from this PR - https://github.com/auth0/react-native-auth0/pull/540

### Testing

We have added unit tests

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not
