### PR TITLE
Fixed `useAuth0:authorize` parameter names

### DIFF
--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -62,18 +62,18 @@ const Auth0Provider = ({domain, clientId, children}) => {
   const authorize = useCallback(
     async (...options) => {
       try {
-        const opts = options.length ? options[0] : {};
-        const params = options.length > 1 ? options[1] : {};
+        const params = options.length ? options[0] : {};
+        const opts = options.length > 1 ? options[1] : {};
         const specifiedScopes =
-          opts?.scope?.split(' ').map(s => s.trim()) || [];
+          params?.scope?.split(' ').map(s => s.trim()) || [];
         const scopeSet = new Set([
           ...specifiedScopes,
           ...['openid', 'profile', 'email'],
         ]);
 
-        opts.scope = Array.from(scopeSet).join(' ');
+        params.scope = Array.from(scopeSet).join(' ');
 
-        const credentials = await client.webAuth.authorize(opts, params);
+        const credentials = await client.webAuth.authorize(params, opts);
         const user = getIdTokenProfileClaims(credentials.idToken);
 
         await client.credentialsManager.saveCredentials(credentials);


### PR DESCRIPTION
### Changes

[WebAuth:authorize](https://github.com/auth0/react-native-auth0/blob/master/src/webauth/index.js#L70) expects `(parameters, options)`. [useAuth0:authorize](https://github.com/auth0/react-native-auth0/blob/master/src/hooks/auth0-provider.js#L65) expects `(options, parameters)`

Confusingly `useAuth0:authorize` passes the variables flipped to `WebAuth:authorize`

```javascript
// Function is paraphrased to make the point clear
authorize = (options, parameters) => {
  client.webAuth.authorize(options, parameters);
};
```

This PR fixes this confusion by renaming the variables to their proper names.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] ~This change adds unit test coverage~ This change is covered by existing unit tests
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
