### PR TITLE
Return a unix timestamp for expiresIn

### DIFF
--- a/ios/CredentialsManagerBridge.swift
+++ b/ios/CredentialsManagerBridge.swift
@@ -96,7 +96,7 @@ extension Credentials {
             CredentialsManagerBridge.tokenTypeKey: self.tokenType,
             CredentialsManagerBridge.idTokenKey: self.idToken,
             CredentialsManagerBridge.refreshTokenKey: self.refreshToken as Any,
-            CredentialsManagerBridge.expiresInKey: self.expiresIn,
+            CredentialsManagerBridge.expiresInKey: self.expiresIn.timeIntervalSince1970,
             CredentialsManagerBridge.scopeKey: self.scope as Any
         ]
     }

--- a/ios/CredentialsManagerBridge.swift
+++ b/ios/CredentialsManagerBridge.swift
@@ -96,7 +96,7 @@ extension Credentials {
             CredentialsManagerBridge.tokenTypeKey: self.tokenType,
             CredentialsManagerBridge.idTokenKey: self.idToken,
             CredentialsManagerBridge.refreshTokenKey: self.refreshToken as Any,
-            CredentialsManagerBridge.expiresInKey: self.expiresIn.timeIntervalSince1970,
+            CredentialsManagerBridge.expiresInKey: floor(self.expiresIn.timeIntervalSince1970),
             CredentialsManagerBridge.scopeKey: self.scope as Any
         ]
     }


### PR DESCRIPTION
### Changes
You can only return JSON primitives over the bridge, the Foundation Date comes back as `null` for this reason.


### Testing

Look at the credentials returned from `CredentialsManager` via the bridge.

```js
const auth = new Auth0(...) 

auth.credentialsManager.getCredentials().then(console.log)
```

- [ ] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
