### PR TITLE
Return the auth0 client from the hook

### DIFF
--- a/src/hooks/__tests__/use-auth0.spec.js
+++ b/src/hooks/__tests__/use-auth0.spec.js
@@ -99,6 +99,15 @@ describe('The useAuth0 hook', () => {
     expect(result.current.user).not.toBeNull();
   });
 
+  it('initializes the client on start up with valid credentials', async () => {
+    mockAuth0.credentialsManager.hasValidCredentials.mockResolvedValue(true);
+
+    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+
+    await waitForNextUpdate();
+    expect(result.current.client).toBe(mockAuth0);
+  });
+
   it('throws an error when login is called without a wrapper', () => {
     const {result} = renderHook(() => useAuth0());
 

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -134,6 +134,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
   const contextValue = useMemo(
     () => ({
       ...state,
+      client,
       authorize,
       clearSession,
       getCredentials,
@@ -142,6 +143,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
     }),
     [
       state,
+      client,
       authorize,
       clearSession,
       getCredentials,

--- a/src/hooks/use-auth0.js
+++ b/src/hooks/use-auth0.js
@@ -5,6 +5,7 @@ import Auth0Context from './auth0-context';
  * @typedef {Object} Auth0ContextInterface
  * @property {Object} user The user profile as decoded from the ID token after authentication
  * @property {Object} error An object representing the last exception
+ * @property {Object} client The Auth0 client
  * @property {Function} authorize Authorize the user using Auth0 Universal Login. See {@link WebAuth#authorize}
  * @property {Function} clearSession Clears the user's web session, credentials and logs them out. See {@link WebAuth#clearSession}.
  * @property {Function} getCredentials Gets the user's credentials from the native credential store. See {@link CredentialsManager#getCredentials}
@@ -20,6 +21,7 @@ import Auth0Context from './auth0-context';
  *   // State
  *   error,
  *   user,
+ *   client,
  *   // Methods
  *   authorize,
  *   clearSession,


### PR DESCRIPTION
### Changes

Return the auth0 client form the hook

```js
const Component = () => {
  const { client } = useAuth0();
  
```

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
