### PR TITLE
Add support for static linking on iOS

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => 'https://github.com/auth0/react-native-auth0.git', :tag => "v#{s.version}" }
 
   s.source_files = 'ios/**/*.{h,m,mm,swift}'
+  s.pod_target_xcconfig = { 'HEADER_SEARCH_PATHS' => "'${PODS_CONFIGURATION_BUILD_DIR}/#{s.name}/#{s.name}.framework/Headers'" }
   s.requires_arc = true
 
   s.dependency 'React-Core'


### PR DESCRIPTION
### Changes

This PR adds support for using the library with `use_frameworks! :linkage => :static` on iOS.

### References

Fixes #528

### Testing

The changes were tested manually with React Native 0.70.3, Xcode 14.1 (14B47b), using an iPhone 14 simulator running iOS 16.1.

- [ ] This change adds unit test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [X] All active GitHub checks have passed
