### PR TITLE
Enable custom params for login methods

### DIFF
--- a/src/auth/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/auth/__tests__/__snapshots__/index.spec.js.snap
@@ -28,6 +28,43 @@ exports[`auth Multifactor Challenge Flow should require MFA Token 1`] = `
 
 exports[`auth OOB flow binding code should be optional 1`] = `Object {}`;
 
+exports[`auth OOB flow should handle custom parameter 1`] = `
+Array [
+  "https://samples.auth0.com/oauth/token",
+  Object {
+    "body": "{\\"mfa_token\\":\\"1234\\",\\"oob_code\\":\\"123\\",\\"binding_code\\":\\"1234\\",\\"custom\\":\\"should not be filtered\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\",\\"grant_type\\":\\"http://auth0.com/oauth/grant-type/mfa-oob\\"}",
+    "headers": Object {
+      "Accept": "application/json",
+      "Auth0-Client": "eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0=",
+      "Content-Type": "application/json",
+    },
+    "method": "POST",
+    "signal": AbortSignal {
+      Symbol(kEvents): Map {
+        "abort" => Object {
+          "next": Listener {
+            "callback": [Function],
+            "capture": false,
+            "isNodeStyleListener": false,
+            "listener": [Function],
+            "next": undefined,
+            "once": false,
+            "passive": false,
+            "previous": [Circular],
+            "removed": false,
+            "weak": false,
+          },
+          "size": 1,
+        },
+      },
+      Symbol(events.maxEventTargetListeners): 10,
+      Symbol(events.maxEventTargetListenersWarned): false,
+      Symbol(kAborted): false,
+    },
+  },
+]
+`;
+
 exports[`auth OOB flow should handle malformed OOB code 1`] = `[invalid_grant: Malformed oob_code]`;
 
 exports[`auth OOB flow should handle success with binding code 1`] = `
@@ -59,6 +96,43 @@ exports[`auth OOB flow should require MFA Token and OOB Code 1`] = `
 ]"
 `;
 
+exports[`auth OTP flow should handle custom parameters 1`] = `
+Array [
+  "https://samples.auth0.com/oauth/token",
+  Object {
+    "body": "{\\"mfa_token\\":\\"1234\\",\\"otp\\":\\"1234\\",\\"custom\\":\\"should not be filtered\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\",\\"grant_type\\":\\"http://auth0.com/oauth/grant-type/mfa-otp\\"}",
+    "headers": Object {
+      "Accept": "application/json",
+      "Auth0-Client": "eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0=",
+      "Content-Type": "application/json",
+    },
+    "method": "POST",
+    "signal": AbortSignal {
+      Symbol(kEvents): Map {
+        "abort" => Object {
+          "next": Listener {
+            "callback": [Function],
+            "capture": false,
+            "isNodeStyleListener": false,
+            "listener": [Function],
+            "next": undefined,
+            "once": false,
+            "passive": false,
+            "previous": [Circular],
+            "removed": false,
+            "weak": false,
+          },
+          "size": 1,
+        },
+      },
+      Symbol(events.maxEventTargetListeners): 10,
+      Symbol(events.maxEventTargetListenersWarned): false,
+      Symbol(kAborted): false,
+    },
+  },
+]
+`;
+
 exports[`auth OTP flow should handle unexpected error 1`] = `[a0.response.invalid: Internal Server Error]`;
 
 exports[`auth OTP flow should require MFA Token and OTP 1`] = `
@@ -81,6 +155,43 @@ Object {
 `;
 
 exports[`auth OTP flow when OTP Code is invalid 1`] = `[invalid_grant: Invalid otp_code.]`;
+
+exports[`auth Recovery Code flow should handle custom parameter 1`] = `
+Array [
+  "https://samples.auth0.com/oauth/token",
+  Object {
+    "body": "{\\"mfa_token\\":\\"123\\",\\"recovery_code\\":\\"123\\",\\"custom\\":\\"should not be filtered\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\",\\"grant_type\\":\\"http://auth0.com/oauth/grant-type/mfa-recovery-code\\"}",
+    "headers": Object {
+      "Accept": "application/json",
+      "Auth0-Client": "eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0=",
+      "Content-Type": "application/json",
+    },
+    "method": "POST",
+    "signal": AbortSignal {
+      Symbol(kEvents): Map {
+        "abort" => Object {
+          "next": Listener {
+            "callback": [Function],
+            "capture": false,
+            "isNodeStyleListener": false,
+            "listener": [Function],
+            "next": undefined,
+            "once": false,
+            "passive": false,
+            "previous": [Circular],
+            "removed": false,
+            "weak": false,
+          },
+          "size": 1,
+        },
+      },
+      Symbol(events.maxEventTargetListeners): 10,
+      Symbol(events.maxEventTargetListenersWarned): false,
+      Symbol(kAborted): false,
+    },
+  },
+]
+`;
 
 exports[`auth Recovery Code flow should handle unexpected error 1`] = `[a0.response.invalid: Internal Server Error]`;
 

--- a/src/auth/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/auth/__tests__/__snapshots__/index.spec.js.snap
@@ -556,6 +556,43 @@ Array [
 ]
 `;
 
+exports[`auth passwordless flow with SMS connection should begin with custom parameters 1`] = `
+Array [
+  "https://samples.auth0.com/passwordless/start",
+  Object {
+    "body": "{\\"phone_number\\":\\"+5491159991000\\",\\"send\\":\\"code\\",\\"authParams\\":{\\"scope\\":\\"openid profile\\"},\\"custom\\":\\"should not be filtered\\",\\"connection\\":\\"sms\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\"}",
+    "headers": Object {
+      "Accept": "application/json",
+      "Auth0-Client": "eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0=",
+      "Content-Type": "application/json",
+    },
+    "method": "POST",
+    "signal": AbortSignal {
+      Symbol(kEvents): Map {
+        "abort" => Object {
+          "next": Listener {
+            "callback": [Function],
+            "capture": false,
+            "isNodeStyleListener": false,
+            "listener": [Function],
+            "next": undefined,
+            "once": false,
+            "passive": false,
+            "previous": [Circular],
+            "removed": false,
+            "weak": false,
+          },
+          "size": 1,
+        },
+      },
+      Symbol(events.maxEventTargetListeners): 10,
+      Symbol(events.maxEventTargetListenersWarned): false,
+      Symbol(kAborted): false,
+    },
+  },
+]
+`;
+
 exports[`auth passwordless flow with SMS connection should begin with link 1`] = `
 Array [
   "https://samples.auth0.com/passwordless/start",
@@ -667,6 +704,43 @@ Array [
 ]
 `;
 
+exports[`auth passwordless flow with SMS connection should continue with custom parameters 1`] = `
+Array [
+  "https://samples.auth0.com/oauth/token",
+  Object {
+    "body": "{\\"username\\":\\"+5491159991000\\",\\"otp\\":\\"123456\\",\\"audience\\":\\"http://myapi.com\\",\\"scope\\":\\"openid\\",\\"custom\\":\\"should not be filtered\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\",\\"realm\\":\\"sms\\",\\"grant_type\\":\\"http://auth0.com/oauth/grant-type/passwordless/otp\\"}",
+    "headers": Object {
+      "Accept": "application/json",
+      "Auth0-Client": "eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0=",
+      "Content-Type": "application/json",
+    },
+    "method": "POST",
+    "signal": AbortSignal {
+      Symbol(kEvents): Map {
+        "abort" => Object {
+          "next": Listener {
+            "callback": [Function],
+            "capture": false,
+            "isNodeStyleListener": false,
+            "listener": [Function],
+            "next": undefined,
+            "once": false,
+            "passive": false,
+            "previous": [Circular],
+            "removed": false,
+            "weak": false,
+          },
+          "size": 1,
+        },
+      },
+      Symbol(events.maxEventTargetListeners): 10,
+      Symbol(events.maxEventTargetListenersWarned): false,
+      Symbol(kAborted): false,
+    },
+  },
+]
+`;
+
 exports[`auth passwordless flow with SMS connection should continue with optional parameters 1`] = `
 Array [
   "https://samples.auth0.com/oauth/token",
@@ -709,6 +783,43 @@ Array [
   "https://samples.auth0.com/passwordless/start",
   Object {
     "body": "{\\"email\\":\\"info@auth0.com\\",\\"send\\":\\"link\\",\\"connection\\":\\"email\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\"}",
+    "headers": Object {
+      "Accept": "application/json",
+      "Auth0-Client": "eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0=",
+      "Content-Type": "application/json",
+    },
+    "method": "POST",
+    "signal": AbortSignal {
+      Symbol(kEvents): Map {
+        "abort" => Object {
+          "next": Listener {
+            "callback": [Function],
+            "capture": false,
+            "isNodeStyleListener": false,
+            "listener": [Function],
+            "next": undefined,
+            "once": false,
+            "passive": false,
+            "previous": [Circular],
+            "removed": false,
+            "weak": false,
+          },
+          "size": 1,
+        },
+      },
+      Symbol(events.maxEventTargetListeners): 10,
+      Symbol(events.maxEventTargetListenersWarned): false,
+      Symbol(kAborted): false,
+    },
+  },
+]
+`;
+
+exports[`auth passwordless flow with email connection should begin with custom parameters 1`] = `
+Array [
+  "https://samples.auth0.com/passwordless/start",
+  Object {
+    "body": "{\\"email\\":\\"info@auth0.com\\",\\"send\\":\\"code\\",\\"authParams\\":{\\"scope\\":\\"openid profile\\"},\\"custom\\":\\"should not be filtered\\",\\"connection\\":\\"email\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\"}",
     "headers": Object {
       "Accept": "application/json",
       "Auth0-Client": "eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0=",
@@ -820,6 +931,43 @@ Array [
   "https://samples.auth0.com/oauth/token",
   Object {
     "body": "{\\"username\\":\\"info@auth0.com\\",\\"otp\\":\\"123456\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\",\\"realm\\":\\"email\\",\\"grant_type\\":\\"http://auth0.com/oauth/grant-type/passwordless/otp\\"}",
+    "headers": Object {
+      "Accept": "application/json",
+      "Auth0-Client": "eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0=",
+      "Content-Type": "application/json",
+    },
+    "method": "POST",
+    "signal": AbortSignal {
+      Symbol(kEvents): Map {
+        "abort" => Object {
+          "next": Listener {
+            "callback": [Function],
+            "capture": false,
+            "isNodeStyleListener": false,
+            "listener": [Function],
+            "next": undefined,
+            "once": false,
+            "passive": false,
+            "previous": [Circular],
+            "removed": false,
+            "weak": false,
+          },
+          "size": 1,
+        },
+      },
+      Symbol(events.maxEventTargetListeners): 10,
+      Symbol(events.maxEventTargetListenersWarned): false,
+      Symbol(kAborted): false,
+    },
+  },
+]
+`;
+
+exports[`auth passwordless flow with email connection should continue with custom parameters 1`] = `
+Array [
+  "https://samples.auth0.com/oauth/token",
+  Object {
+    "body": "{\\"username\\":\\"info@auth0.com\\",\\"otp\\":\\"123456\\",\\"audience\\":\\"http://myapi.com\\",\\"scope\\":\\"openid\\",\\"custom\\":\\"should not be filtered\\",\\"client_id\\":\\"A_CLIENT_ID_OF_YOUR_ACCOUNT\\",\\"realm\\":\\"email\\",\\"grant_type\\":\\"http://auth0.com/oauth/grant-type/passwordless/otp\\"}",
     "headers": Object {
       "Accept": "application/json",
       "Auth0-Client": "eyJuYW1lIjoicmVhY3QtbmF0aXZlLWF1dGgwIiwidmVyc2lvbiI6IjEuMC4wIn0=",

--- a/src/auth/__tests__/index.spec.js
+++ b/src/auth/__tests__/index.spec.js
@@ -833,6 +833,16 @@ describe('auth', () => {
       expect.assertions(1);
       await expect(auth.loginWithOTP(parameters)).resolves.toMatchSnapshot();
     });
+
+    it('should handle custom parameters', async () => {
+      fetchMock.postOnce('https://samples.auth0.com/oauth/token', success);
+      expect.assertions(1);
+      await auth.loginWithOTP({
+        ...parameters,
+        custom: 'should not be filtered',
+      });
+      expect(fetchMock.lastCall()).toMatchSnapshot();
+    });
   });
 
   describe('OOB flow', () => {
@@ -900,6 +910,16 @@ describe('auth', () => {
       expect.assertions(1);
       await expect(auth.loginWithOOB(parameters)).resolves.toMatchSnapshot();
     });
+
+    it('should handle custom parameter', async () => {
+      fetchMock.postOnce('https://samples.auth0.com/oauth/token', success);
+      expect.assertions(1);
+      await auth.loginWithOOB({
+        ...parameters,
+        custom: 'should not be filtered',
+      });
+      expect(fetchMock.lastCall()).toMatchSnapshot();
+    });
   });
 
   describe('Recovery Code flow', () => {
@@ -961,6 +981,16 @@ describe('auth', () => {
       await expect(
         auth.loginWithRecoveryCode(parameters),
       ).resolves.toMatchSnapshot();
+    });
+
+    it('should handle custom parameter', async () => {
+      fetchMock.postOnce('https://samples.auth0.com/oauth/token', success);
+      expect.assertions(1);
+      await auth.loginWithRecoveryCode({
+        ...parameters,
+        custom: 'should not be filtered',
+      });
+      expect(fetchMock.lastCall()).toMatchSnapshot();
     });
   });
 

--- a/src/auth/__tests__/index.spec.js
+++ b/src/auth/__tests__/index.spec.js
@@ -293,6 +293,23 @@ describe('auth', () => {
         expect(fetchMock.lastCall()).toMatchSnapshot();
       });
 
+      it('should begin with custom parameters', async () => {
+        fetchMock.postOnce(
+          'https://samples.auth0.com/passwordless/start',
+          emptySuccess,
+        );
+        expect.assertions(1);
+        await auth.passwordlessWithEmail({
+          email: 'info@auth0.com',
+          send: 'code',
+          authParams: {
+            scope: 'openid profile',
+          },
+          custom: 'should not be filtered',
+        });
+        expect(fetchMock.lastCall()).toMatchSnapshot();
+      });
+
       it('should continue', async () => {
         fetchMock.postOnce('https://samples.auth0.com/oauth/token', tokens);
         expect.assertions(1);
@@ -311,6 +328,19 @@ describe('auth', () => {
           code: '123456',
           audience: 'http://myapi.com',
           scope: 'openid',
+        });
+        expect(fetchMock.lastCall()).toMatchSnapshot();
+      });
+
+      it('should continue with custom parameters', async () => {
+        fetchMock.postOnce('https://samples.auth0.com/oauth/token', tokens);
+        expect.assertions(1);
+        await auth.loginWithEmail({
+          email: 'info@auth0.com',
+          code: '123456',
+          audience: 'http://myapi.com',
+          scope: 'openid',
+          custom: 'should not be filtered',
         });
         expect(fetchMock.lastCall()).toMatchSnapshot();
       });
@@ -359,6 +389,23 @@ describe('auth', () => {
         expect(fetchMock.lastCall()).toMatchSnapshot();
       });
 
+      it('should begin with custom parameters', async () => {
+        fetchMock.postOnce(
+          'https://samples.auth0.com/passwordless/start',
+          emptySuccess,
+        );
+        expect.assertions(1);
+        await auth.passwordlessWithSMS({
+          phoneNumber: '+5491159991000',
+          send: 'code',
+          authParams: {
+            scope: 'openid profile',
+          },
+          custom: 'should not be filtered',
+        });
+        expect(fetchMock.lastCall()).toMatchSnapshot();
+      });
+
       it('should continue', async () => {
         fetchMock.postOnce('https://samples.auth0.com/oauth/token', tokens);
         expect.assertions(1);
@@ -377,6 +424,19 @@ describe('auth', () => {
           code: '123456',
           audience: 'http://myapi.com',
           scope: 'openid',
+        });
+        expect(fetchMock.lastCall()).toMatchSnapshot();
+      });
+
+      it('should continue with custom parameters', async () => {
+        fetchMock.postOnce('https://samples.auth0.com/oauth/token', tokens);
+        expect.assertions(1);
+        await auth.loginWithSMS({
+          phoneNumber: '+5491159991000',
+          code: '123456',
+          audience: 'http://myapi.com',
+          scope: 'openid',
+          custom: 'should not be filtered',
         });
         expect(fetchMock.lastCall()).toMatchSnapshot();
       });

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -74,6 +74,7 @@ class Auth {
           clientId: {required: false, toName: 'client_id'},
           returnTo: {required: false},
         },
+        whitelist: false,
       },
       parameters,
     );
@@ -226,6 +227,7 @@ class Auth {
           send: {required: false},
           authParams: {required: false},
         },
+        whitelist: false,
       },
       parameters,
     );
@@ -253,6 +255,7 @@ class Auth {
           send: {required: false},
           authParams: {required: false},
         },
+        whitelist: false,
       },
       parameters,
     );
@@ -284,6 +287,7 @@ class Auth {
           audience: {required: false},
           scope: {required: false},
         },
+        whitelist: false,
       },
       parameters,
     );
@@ -316,6 +320,7 @@ class Auth {
           audience: {required: false},
           scope: {required: false},
         },
+        whitelist: false,
       },
       parameters,
     );
@@ -348,6 +353,7 @@ class Auth {
           mfaToken: {required: true, toName: 'mfa_token'},
           otp: {required: true, toName: 'otp'},
         },
+        whitelist: false,
       },
       parameters,
     );
@@ -382,6 +388,7 @@ class Auth {
           oobCode: {required: true, toName: 'oob_code'},
           bindingCode: {required: false, toName: 'binding_code'},
         },
+        whitelist: false,
       },
       parameters,
     );
@@ -413,6 +420,7 @@ class Auth {
           mfaToken: {required: true, toName: 'mfa_token'},
           recoveryCode: {required: true, toName: 'recovery_code'},
         },
+        whitelist: false,
       },
       parameters,
     );

--- a/src/auth/index.js
+++ b/src/auth/index.js
@@ -74,7 +74,6 @@ class Auth {
           clientId: {required: false, toName: 'client_id'},
           returnTo: {required: false},
         },
-        whitelist: false,
       },
       parameters,
     );


### PR DESCRIPTION
### Changes
Allows sending custom parameters in login methods

### References
This request has been raised internally many times. Other SDKs support custom parameters

Please note any links that are not publicly accessible.

### Testing
- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not
