### PR TITLE
Initialized flag on useAuth0 hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,22 +276,22 @@ import {useAuth0} from 'react-native-auth0';
 
 Use the `authorize` method to redirect the user to the Auth0 [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login) page for authentication. 
 
-- The `isInitializing` property is set to true once the authentication state of the user is known to the SDK.
+- The `isLoading` property is set to true once the authentication state of the user is known to the SDK.
 - The `user` property is populated with details about the authenticated user. If `user` is `null`, no user is currently authenticated. 
 - The `error` property is populated if any error occurs.
 
 ```js
 const Component = () => {
-  const {authorize, user, isInitializing, error} = useAuth0();
+  const {authorize, user, isLoading, error} = useAuth0();
 
   const login = async () => {
     await authorize();
   };
 
-  if(isInitializing) {
+  if(isLoading) {
     return (
       <View>
-        <Text>SDK is Initializing</Text>
+        <Text>SDK is Loading</Text>
       </View>
     )
   }

--- a/README.md
+++ b/README.md
@@ -274,22 +274,33 @@ import {useAuth0} from 'react-native-auth0';
 
 #### Login
 
-Use the `authorize` method to redirect the user to the Auth0 [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login) page for authentication. The `user` property is populated with details about the authenticated user.
+Use the `authorize` method to redirect the user to the Auth0 [Universal Login](https://auth0.com/docs/authenticate/login/auth0-universal-login) page for authentication. 
 
-If `user` is `null`, no user is currently authenticated.
+- The `isInitializing` property is set to true once the authentication state of the user is known to the SDK.
+- The `user` property is populated with details about the authenticated user. If `user` is `null`, no user is currently authenticated. 
+- The `error` property is populated if any error occurs.
 
 ```js
 const Component = () => {
-  const {authorize, user} = useAuth0();
+  const {authorize, user, isInitializing, error} = useAuth0();
 
   const login = async () => {
     await authorize();
   };
 
+  if(isInitializing) {
+    return (
+      <View>
+        <Text>SDK is Initializing</Text>
+      </View>
+    )
+  }
+
   return (
     <View>
       {!user && <Button onPress={login} title="Log in" />}
       {user && <Text>Logged in as {user.name}</Text>}
+      {error && <Text>{error.message}</Text>}
     </View>
   );
 };

--- a/src/hooks/__tests__/use-auth0.spec.js
+++ b/src/hooks/__tests__/use-auth0.spec.js
@@ -81,6 +81,28 @@ describe('The useAuth0 hook', () => {
     expect(result.current.clearSession).toBeDefined();
   });
 
+  it('initialized is false until initialization finishes', async () => {
+    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    expect(result.current.initialized).toBe(false);
+
+    await waitForNextUpdate();
+    expect(mockAuth0.credentialsManager.getCredentials).not.toBeCalled();
+    expect(mockAuth0.credentialsManager.hasValidCredentials).toBeCalledTimes(1);
+    expect(result.current.user).toBeNull();
+    expect(result.current.initialized).toBe(true);
+  });
+
+  it('initialize flag set on start up with valid credentials', async () => {
+    mockAuth0.credentialsManager.hasValidCredentials.mockResolvedValue(true);
+
+    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    expect(result.current.initialized).toBe(false);
+
+    await waitForNextUpdate();
+    expect(result.current.user).not.toBeNull();
+    expect(result.current.initialized).toBe(true);
+  });
+
   it('does not initialize the user on start up without valid credentials', async () => {
     const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
 

--- a/src/hooks/__tests__/use-auth0.spec.js
+++ b/src/hooks/__tests__/use-auth0.spec.js
@@ -81,39 +81,39 @@ describe('The useAuth0 hook', () => {
     expect(result.current.clearSession).toBeDefined();
   });
 
-  it('isInitializing is true until initialization finishes', async () => {
+  it('isLoading is true until initialization finishes', async () => {
     const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
-    expect(result.current.isInitializing).toBe(true);
+    expect(result.current.isLoading).toBe(true);
 
     await waitForNextUpdate();
     expect(mockAuth0.credentialsManager.getCredentials).not.toBeCalled();
     expect(mockAuth0.credentialsManager.hasValidCredentials).toBeCalledTimes(1);
     expect(result.current.user).toBeNull();
-    expect(result.current.isInitializing).toBe(false);
+    expect(result.current.isLoading).toBe(false);
   });
 
-  it('isInitializing flag set on start up with valid credentials', async () => {
+  it('isLoading flag set on start up with valid credentials', async () => {
     mockAuth0.credentialsManager.hasValidCredentials.mockResolvedValue(true);
 
     const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
-    expect(result.current.isInitializing).toBe(true);
+    expect(result.current.isLoading).toBe(true);
 
     await waitForNextUpdate();
     expect(result.current.user).not.toBeNull();
-    expect(result.current.isInitializing).toBe(false);
+    expect(result.current.isLoading).toBe(false);
   });
 
-  it('isInitializing flag set on when error is thrown while initializing', async () => {
+  it('isLoading flag set on when error is thrown while initializing', async () => {
     const errorToThrow = new Error('Error getting credentials');
     mockAuth0.credentialsManager.hasValidCredentials.mockResolvedValue(true);
     mockAuth0.credentialsManager.getCredentials.mockRejectedValue(errorToThrow);
 
     const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
-    expect(result.current.isInitializing).toBe(true);
+    expect(result.current.isLoading).toBe(true);
 
     await waitForNextUpdate();
     expect(result.current.error).toBe(errorToThrow);
-    expect(result.current.isInitializing).toBe(false);
+    expect(result.current.isLoading).toBe(false);
   });
 
   it('does not initialize the user on start up without valid credentials', async () => {

--- a/src/hooks/__tests__/use-auth0.spec.js
+++ b/src/hooks/__tests__/use-auth0.spec.js
@@ -81,26 +81,39 @@ describe('The useAuth0 hook', () => {
     expect(result.current.clearSession).toBeDefined();
   });
 
-  it('initialized is false until initialization finishes', async () => {
+  it('isInitializing is true until initialization finishes', async () => {
     const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
-    expect(result.current.initialized).toBe(false);
+    expect(result.current.isInitializing).toBe(true);
 
     await waitForNextUpdate();
     expect(mockAuth0.credentialsManager.getCredentials).not.toBeCalled();
     expect(mockAuth0.credentialsManager.hasValidCredentials).toBeCalledTimes(1);
     expect(result.current.user).toBeNull();
-    expect(result.current.initialized).toBe(true);
+    expect(result.current.isInitializing).toBe(false);
   });
 
-  it('initialize flag set on start up with valid credentials', async () => {
+  it('isInitializing flag set on start up with valid credentials', async () => {
     mockAuth0.credentialsManager.hasValidCredentials.mockResolvedValue(true);
 
     const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
-    expect(result.current.initialized).toBe(false);
+    expect(result.current.isInitializing).toBe(true);
 
     await waitForNextUpdate();
     expect(result.current.user).not.toBeNull();
-    expect(result.current.initialized).toBe(true);
+    expect(result.current.isInitializing).toBe(false);
+  });
+
+  it('isInitializing flag set on when error is thrown while initializing', async () => {
+    const errorToThrow = new Error('Error getting credentials');
+    mockAuth0.credentialsManager.hasValidCredentials.mockResolvedValue(true);
+    mockAuth0.credentialsManager.getCredentials.mockRejectedValue(errorToThrow);
+
+    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    expect(result.current.isInitializing).toBe(true);
+
+    await waitForNextUpdate();
+    expect(result.current.error).toBe(errorToThrow);
+    expect(result.current.isInitializing).toBe(false);
   });
 
   it('does not initialize the user on start up without valid credentials', async () => {
@@ -114,6 +127,7 @@ describe('The useAuth0 hook', () => {
 
   it('initializes the user on start up with valid credentials', async () => {
     mockAuth0.credentialsManager.hasValidCredentials.mockResolvedValue(true);
+    mockAuth0.credentialsManager.getCredentials.mockResolvedValue(mockCredentials);
 
     const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
 

--- a/src/hooks/auth0-context.js
+++ b/src/hooks/auth0-context.js
@@ -7,7 +7,7 @@ const stub = () => {
 const initialContext = {
   error: null,
   user: null,
-  isInitializing: true,
+  isLoading: true,
   authorize: stub,
   clearSession: stub,
   getCredentials: stub,

--- a/src/hooks/auth0-context.js
+++ b/src/hooks/auth0-context.js
@@ -7,7 +7,7 @@ const stub = () => {
 const initialContext = {
   error: null,
   user: null,
-  isInitialized: false,
+  isInitializing: true,
   authorize: stub,
   clearSession: stub,
   getCredentials: stub,

--- a/src/hooks/auth0-context.js
+++ b/src/hooks/auth0-context.js
@@ -7,6 +7,7 @@ const stub = () => {
 const initialContext = {
   error: null,
   user: null,
+  initialized: false,
   authorize: stub,
   clearSession: stub,
   getCredentials: stub,

--- a/src/hooks/auth0-context.js
+++ b/src/hooks/auth0-context.js
@@ -7,7 +7,7 @@ const stub = () => {
 const initialContext = {
   error: null,
   user: null,
-  initialized: false,
+  isInitialized: false,
   authorize: stub,
   clearSession: stub,
   getCredentials: stub,

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -10,7 +10,7 @@ import {idTokenNonProfileClaims} from '../jwt/utils';
 const initialState = {
   user: null,
   error: null,
-  initialized: false,
+  isInitializing: true,
 };
 
 /**

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -10,6 +10,7 @@ import {idTokenNonProfileClaims} from '../jwt/utils';
 const initialState = {
   user: null,
   error: null,
+  initialized: false,
 };
 
 /**

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -49,10 +49,13 @@ const Auth0Provider = ({domain, clientId, children}) => {
       let user = null;
 
       if (await client.credentialsManager.hasValidCredentials()) {
-        const credentials = await client.credentialsManager.getCredentials();
-
-        if (credentials) {
-          user = getIdTokenProfileClaims(credentials.idToken);
+        try {
+          const credentials = await client.credentialsManager.getCredentials();
+          if (credentials) {
+            user = getIdTokenProfileClaims(credentials.idToken);
+          }
+        } catch (error) {
+          dispatch({type: 'ERROR', error});
         }
       }
 

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -10,7 +10,7 @@ import {idTokenNonProfileClaims} from '../jwt/utils';
 const initialState = {
   user: null,
   error: null,
-  isInitializing: true,
+  isLoading: true,
 };
 
 /**

--- a/src/hooks/reducer.js
+++ b/src/hooks/reducer.js
@@ -10,10 +10,10 @@ const reducer = (state, action) => {
       return {...state, error: null, user: null};
 
     case 'ERROR':
-      return {...state, isInitializing: false, error: action.error};
+      return {...state, isLoading: false, error: action.error};
 
     case 'INITIALIZED':
-      return {...state, isInitializing: false, user: action.user};
+      return {...state, isLoading: false, user: action.user};
   }
 };
 

--- a/src/hooks/reducer.js
+++ b/src/hooks/reducer.js
@@ -13,7 +13,7 @@ const reducer = (state, action) => {
       return {...state, error: action.error};
 
     case 'INITIALIZED':
-      return {...state, initialized: true, user: action.user};
+      return {...state, isInitialized: true, user: action.user};
   }
 };
 

--- a/src/hooks/reducer.js
+++ b/src/hooks/reducer.js
@@ -13,7 +13,7 @@ const reducer = (state, action) => {
       return {...state, error: action.error};
 
     case 'INITIALIZED':
-      return {...state, user: action.user};
+      return {...state, initialized: true, user: action.user};
   }
 };
 

--- a/src/hooks/reducer.js
+++ b/src/hooks/reducer.js
@@ -10,10 +10,10 @@ const reducer = (state, action) => {
       return {...state, error: null, user: null};
 
     case 'ERROR':
-      return {...state, isInitialized: true, error: action.error};
+      return {...state, isInitializing: false, error: action.error};
 
     case 'INITIALIZED':
-      return {...state, isInitialized: true, user: action.user};
+      return {...state, isInitializing: false, user: action.user};
   }
 };
 

--- a/src/hooks/reducer.js
+++ b/src/hooks/reducer.js
@@ -10,7 +10,7 @@ const reducer = (state, action) => {
       return {...state, error: null, user: null};
 
     case 'ERROR':
-      return {...state, error: action.error};
+      return {...state, isInitialized: true, error: action.error};
 
     case 'INITIALIZED':
       return {...state, isInitialized: true, user: action.user};

--- a/src/hooks/use-auth0.js
+++ b/src/hooks/use-auth0.js
@@ -5,7 +5,7 @@ import Auth0Context from './auth0-context';
  * @typedef {Object} Auth0ContextInterface
  * @property {Object} user The user profile as decoded from the ID token after authentication
  * @property {Object} error An object representing the last exception
- * @property {boolean} isInitialized A flag that is false until the state knows that a user is either logged in or not
+ * @property {boolean} isInitializing A flag that is true until the state knows that a user is either logged in or not
  * @property {Function} authorize Authorize the user using Auth0 Universal Login. See {@link WebAuth#authorize}
  * @property {Function} clearSession Clears the user's web session, credentials and logs them out. See {@link WebAuth#clearSession}.
  * @property {Function} getCredentials Gets the user's credentials from the native credential store. See {@link CredentialsManager#getCredentials}
@@ -21,7 +21,7 @@ import Auth0Context from './auth0-context';
  *   // State
  *   error,
  *   user,
- *   initialized,
+ *   isInitializing,
  *   // Methods
  *   authorize,
  *   clearSession,

--- a/src/hooks/use-auth0.js
+++ b/src/hooks/use-auth0.js
@@ -5,7 +5,7 @@ import Auth0Context from './auth0-context';
  * @typedef {Object} Auth0ContextInterface
  * @property {Object} user The user profile as decoded from the ID token after authentication
  * @property {Object} error An object representing the last exception
- * @property {boolean} isInitializing A flag that is true until the state knows that a user is either logged in or not
+ * @property {boolean} isLoading A flag that is true until the state knows that a user is either logged in or not
  * @property {Function} authorize Authorize the user using Auth0 Universal Login. See {@link WebAuth#authorize}
  * @property {Function} clearSession Clears the user's web session, credentials and logs them out. See {@link WebAuth#clearSession}.
  * @property {Function} getCredentials Gets the user's credentials from the native credential store. See {@link CredentialsManager#getCredentials}
@@ -21,7 +21,7 @@ import Auth0Context from './auth0-context';
  *   // State
  *   error,
  *   user,
- *   isInitializing,
+ *   isLoading,
  *   // Methods
  *   authorize,
  *   clearSession,

--- a/src/hooks/use-auth0.js
+++ b/src/hooks/use-auth0.js
@@ -5,6 +5,7 @@ import Auth0Context from './auth0-context';
  * @typedef {Object} Auth0ContextInterface
  * @property {Object} user The user profile as decoded from the ID token after authentication
  * @property {Object} error An object representing the last exception
+ * @property {boolean} initialized A flag that is false until the state knows that a user is either logged in or not
  * @property {Function} authorize Authorize the user using Auth0 Universal Login. See {@link WebAuth#authorize}
  * @property {Function} clearSession Clears the user's web session, credentials and logs them out. See {@link WebAuth#clearSession}.
  * @property {Function} getCredentials Gets the user's credentials from the native credential store. See {@link CredentialsManager#getCredentials}
@@ -20,6 +21,7 @@ import Auth0Context from './auth0-context';
  *   // State
  *   error,
  *   user,
+ *   initialized,
  *   // Methods
  *   authorize,
  *   clearSession,

--- a/src/hooks/use-auth0.js
+++ b/src/hooks/use-auth0.js
@@ -5,7 +5,7 @@ import Auth0Context from './auth0-context';
  * @typedef {Object} Auth0ContextInterface
  * @property {Object} user The user profile as decoded from the ID token after authentication
  * @property {Object} error An object representing the last exception
- * @property {boolean} initialized A flag that is false until the state knows that a user is either logged in or not
+ * @property {boolean} isInitialized A flag that is false until the state knows that a user is either logged in or not
  * @property {Function} authorize Authorize the user using Auth0 Universal Login. See {@link WebAuth#authorize}
  * @property {Function} clearSession Clears the user's web session, credentials and logs them out. See {@link WebAuth#clearSession}.
  * @property {Function} getCredentials Gets the user's credentials from the native credential store. See {@link CredentialsManager#getCredentials}


### PR DESCRIPTION
### Changes

Add `isInitializing` flag to `useAuth0`. This is true until we know that a user is either logged in or logged out. This allows us to prevent showing the logged in or logged out state of an app incorrectly while the `user` is returned from the `CredentialsManager`. 

### Testing

```js
const MyComponent = () => {
  const { isInitializing, user } = useAuth0();

  if (isInitializing) {
    return <Text>Auth0 is initializing</Text>;
  }

  return <Text>User is logged { user ? 'in' : 'out' }</Text>;
}
```

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
