### PR TITLE
Added saveCredentials function to useAuth0 hook

### DIFF
--- a/src/hooks/__tests__/use-auth0.spec.js
+++ b/src/hooks/__tests__/use-auth0.spec.js
@@ -432,4 +432,26 @@ describe('The useAuth0 hook', () => {
     await waitForNextUpdate();
     expect(result.current.error).toEqual(thrownError);
   });
+
+  it('can save new credentials', async () => {
+    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+
+    result.current.saveCredentials({parameter: 1});
+    await waitForNextUpdate();
+
+    expect(mockAuth0.credentialsManager.saveCredentials).toHaveBeenCalledWith({
+      parameter: 1,
+    });
+  });
+
+  it('dispatches an error when saveCredentials fails', async () => {
+    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const thrownError = new Error('Error saving credentials');
+
+    mockAuth0.credentialsManager.saveCredentials.mockRejectedValue(thrownError);
+
+    result.current.saveCredentials();
+    await waitForNextUpdate();
+    expect(result.current.error).toEqual(thrownError);
+  });
 });

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -112,6 +112,18 @@ const Auth0Provider = ({domain, clientId, children}) => {
     [client],
   );
 
+  const saveCredentials = useCallback(
+    async credentials => {
+      try {
+        await client.credentialsManager.saveCredentials(credentials);
+      } catch (error) {
+        dispatch({type: 'ERROR', error});
+        return;
+      }
+    },
+    [client],
+  );
+
   const clearCredentials = useCallback(async () => {
     try {
       await client.credentialsManager.clearCredentials();
@@ -137,6 +149,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
       authorize,
       clearSession,
       getCredentials,
+      saveCredentials,
       clearCredentials,
       requireLocalAuthentication,
     }),
@@ -145,6 +158,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
       authorize,
       clearSession,
       getCredentials,
+      saveCredentials,
       clearCredentials,
       requireLocalAuthentication,
     ],

--- a/src/hooks/use-auth0.js
+++ b/src/hooks/use-auth0.js
@@ -8,6 +8,7 @@ import Auth0Context from './auth0-context';
  * @property {Function} authorize Authorize the user using Auth0 Universal Login. See {@link WebAuth#authorize}
  * @property {Function} clearSession Clears the user's web session, credentials and logs them out. See {@link WebAuth#clearSession}.
  * @property {Function} getCredentials Gets the user's credentials from the native credential store. See {@link CredentialsManager#getCredentials}
+ * @property {Function} saveCredentials Saves the user's credentials in the native credential store. See {@link CredentialsManager#saveCredentials}
  * @property {Function} clearCredentials Clears the user's credentials without clearing their web session and logs them out.
  * @property {Function} requireLocalAuthentication Enables Local Authentication (PIN, Biometric, Swipe etc) to get the credentials. See {@link CredentialsManager#requireLocalAuthentication}
  */
@@ -24,6 +25,7 @@ import Auth0Context from './auth0-context';
  *   authorize,
  *   clearSession,
  *   getCredentials,
+ *   saveCredentials,
  *   clearCredentials,
  *   requireLocalAuthentication
  * } = useAuth0();


### PR DESCRIPTION
### Changes

This PR makes `saveCredentials` function from `CredentialManager` accessible via the `useAuth0` hook.

### Testing

This change was tested on iPhone 14 (iOS 16.1) simulator with React Native 0.70.5 and React 18.1.0.

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
