### PR TITLE
Feat: return `isLoading` from useAuth0 hook

### DIFF
--- a/src/hooks/__tests__/use-auth0.spec.js
+++ b/src/hooks/__tests__/use-auth0.spec.js
@@ -81,6 +81,28 @@ describe('The useAuth0 hook', () => {
     expect(result.current.clearSession).toBeDefined();
   });
 
+  it('initialized is false until initialization finishes', async () => {
+    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    expect(result.current.initialized).toBe(false);
+
+    await waitForNextUpdate();
+    expect(mockAuth0.credentialsManager.getCredentials).not.toBeCalled();
+    expect(mockAuth0.credentialsManager.hasValidCredentials).toBeCalledTimes(1);
+    expect(result.current.user).toBeNull();
+    expect(result.current.initialized).toBe(true);
+  });
+
+  it('initialize flag set on start up with valid credentials', async () => {
+    mockAuth0.credentialsManager.hasValidCredentials.mockResolvedValue(true);
+
+    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    expect(result.current.initialized).toBe(false);
+
+    await waitForNextUpdate();
+    expect(result.current.user).not.toBeNull();
+    expect(result.current.initialized).toBe(true);
+  });
+
   it('does not initialize the user on start up without valid credentials', async () => {
     const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
 

--- a/src/hooks/__tests__/use-auth0.spec.js
+++ b/src/hooks/__tests__/use-auth0.spec.js
@@ -81,26 +81,26 @@ describe('The useAuth0 hook', () => {
     expect(result.current.clearSession).toBeDefined();
   });
 
-  it('initialized is false until initialization finishes', async () => {
+  it('isLoading is true until initialization finishes', async () => {
     const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
-    expect(result.current.initialized).toBe(false);
+    expect(result.current.isLoading).toBe(true);
 
     await waitForNextUpdate();
     expect(mockAuth0.credentialsManager.getCredentials).not.toBeCalled();
     expect(mockAuth0.credentialsManager.hasValidCredentials).toBeCalledTimes(1);
     expect(result.current.user).toBeNull();
-    expect(result.current.initialized).toBe(true);
+    expect(result.current.isLoading).toBe(false);
   });
 
-  it('initialize flag set on start up with valid credentials', async () => {
+  it('isLoading flag set on start up with valid credentials', async () => {
     mockAuth0.credentialsManager.hasValidCredentials.mockResolvedValue(true);
 
     const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
-    expect(result.current.initialized).toBe(false);
+    expect(result.current.isLoading).toBe(true);
 
     await waitForNextUpdate();
     expect(result.current.user).not.toBeNull();
-    expect(result.current.initialized).toBe(true);
+    expect(result.current.isLoading).toBe(false);
   });
 
   it('does not initialize the user on start up without valid credentials', async () => {

--- a/src/hooks/auth0-context.js
+++ b/src/hooks/auth0-context.js
@@ -6,8 +6,8 @@ const stub = () => {
 
 const initialContext = {
   error: null,
+  isLoading: true,
   user: null,
-  initialized: false,
   authorize: stub,
   clearSession: stub,
   getCredentials: stub,

--- a/src/hooks/auth0-context.js
+++ b/src/hooks/auth0-context.js
@@ -7,6 +7,7 @@ const stub = () => {
 const initialContext = {
   error: null,
   user: null,
+  initialized: false,
   authorize: stub,
   clearSession: stub,
   getCredentials: stub,

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -1,4 +1,4 @@
-import React, {useEffect, useReducer, useState, useRef} from 'react';
+import React, {useEffect, useReducer, useState} from 'react';
 import {useCallback, useMemo} from 'react';
 import jwt_decode from 'jwt-decode';
 import PropTypes from 'prop-types';
@@ -10,7 +10,7 @@ import {idTokenNonProfileClaims} from '../jwt/utils';
 const initialState = {
   user: null,
   error: null,
-  initialized: false,
+  isLoading: true,
 };
 
 /**
@@ -62,6 +62,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
 
   const authorize = useCallback(
     async (...options) => {
+      dispatch({type: 'LOGIN_STARTED'});
       try {
         const params = options.length ? options[0] : {};
         const opts = options.length > 1 ? options[1] : {};

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -10,6 +10,7 @@ import {idTokenNonProfileClaims} from '../jwt/utils';
 const initialState = {
   user: null,
   error: null,
+  initialized: false,
 };
 
 /**

--- a/src/hooks/reducer.js
+++ b/src/hooks/reducer.js
@@ -3,17 +3,20 @@
  */
 const reducer = (state, action) => {
   switch (action.type) {
+    case 'LOGIN_STARTED':
+      return {...state, isLoading: true};
+
     case 'LOGIN_COMPLETE':
-      return {...state, error: null, user: action.user};
+      return {...state, error: null, isLoading: false, user: action.user};
 
     case 'LOGOUT_COMPLETE':
       return {...state, error: null, user: null};
 
     case 'ERROR':
-      return {...state, error: action.error};
+      return {...state, error: action.error, isLoading: false};
 
     case 'INITIALIZED':
-      return {...state, initialized: true, user: action.user};
+      return {...state, isLoading: false, user: action.user};
   }
 };
 

--- a/src/hooks/reducer.js
+++ b/src/hooks/reducer.js
@@ -13,7 +13,7 @@ const reducer = (state, action) => {
       return {...state, error: action.error};
 
     case 'INITIALIZED':
-      return {...state, user: action.user};
+      return {...state, initialized: true, user: action.user};
   }
 };
 

--- a/src/hooks/use-auth0.js
+++ b/src/hooks/use-auth0.js
@@ -5,6 +5,7 @@ import Auth0Context from './auth0-context';
  * @typedef {Object} Auth0ContextInterface
  * @property {Object} user The user profile as decoded from the ID token after authentication
  * @property {Object} error An object representing the last exception
+ * @property {boolean} initialized A flag that is false until the state knows that a user is either logged in or not
  * @property {Function} authorize Authorize the user using Auth0 Universal Login. See {@link WebAuth#authorize}
  * @property {Function} clearSession Clears the user's web session, credentials and logs them out. See {@link WebAuth#clearSession}.
  * @property {Function} getCredentials Gets the user's credentials from the native credential store. See {@link CredentialsManager#getCredentials}
@@ -20,6 +21,7 @@ import Auth0Context from './auth0-context';
  *   // State
  *   error,
  *   user,
+ *   initialized,
  *   // Methods
  *   authorize,
  *   clearSession,

--- a/src/hooks/use-auth0.js
+++ b/src/hooks/use-auth0.js
@@ -5,7 +5,7 @@ import Auth0Context from './auth0-context';
  * @typedef {Object} Auth0ContextInterface
  * @property {Object} user The user profile as decoded from the ID token after authentication
  * @property {Object} error An object representing the last exception
- * @property {boolean} initialized A flag that is false until the state knows that a user is either logged in or not
+ * @property {boolean} isLoading A flag that represents whether the login is in process or initializing.
  * @property {Function} authorize Authorize the user using Auth0 Universal Login. See {@link WebAuth#authorize}
  * @property {Function} clearSession Clears the user's web session, credentials and logs them out. See {@link WebAuth#clearSession}.
  * @property {Function} getCredentials Gets the user's credentials from the native credential store. See {@link CredentialsManager#getCredentials}
@@ -21,7 +21,7 @@ import Auth0Context from './auth0-context';
  *   // State
  *   error,
  *   user,
- *   initialized,
+ *   isLoading,
  *   // Methods
  *   authorize,
  *   clearSession,


### PR DESCRIPTION
### Changes

I added `isLoading` flag to useAuth0 hook. I just continued the work of @cranberyxl and their PR, then I made these requested changes: https://github.com/auth0/react-native-auth0/pull/561#pullrequestreview-1206283905

### References

Previous PR: https://github.com/auth0/react-native-auth0/pull/561
I used this as inspiration: [auth0-react/reducer](https://github.com/auth0/auth0-react/blob/master/src/reducer.tsx)

### Testing

```
const MyComponent = () => {
  const { isLoading, user } = useAuth0();

  if (isLoading) {
    return <Text>Auth0 is initializing</Text>;
  }

  return <Text>User is logged { user ? 'in' : 'out' }</Text>;
}
```

- [X] This change adds unit test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
