### PR TITLE
feat: Add an isInitialised state

### DIFF
--- a/src/hooks/auth0-context.js
+++ b/src/hooks/auth0-context.js
@@ -7,6 +7,7 @@ const stub = () => {
 const initialContext = {
   error: null,
   user: null,
+  isInitialised: false,
   authorize: stub,
   clearSession: stub,
   getCredentials: stub,

--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -10,6 +10,7 @@ import {idTokenNonProfileClaims} from '../jwt/utils';
 const initialState = {
   user: null,
   error: null,
+  isInitialised: false,
 };
 
 /**

--- a/src/hooks/reducer.js
+++ b/src/hooks/reducer.js
@@ -13,7 +13,7 @@ const reducer = (state, action) => {
       return {...state, error: action.error};
 
     case 'INITIALIZED':
-      return {...state, user: action.user};
+      return {...state, user: action.user, isInitialised: true};
   }
 };
 

--- a/src/hooks/use-auth0.js
+++ b/src/hooks/use-auth0.js
@@ -5,6 +5,7 @@ import Auth0Context from './auth0-context';
  * @typedef {Object} Auth0ContextInterface
  * @property {Object} user The user profile as decoded from the ID token after authentication
  * @property {Object} error An object representing the last exception
+ * @property {Boolean} isInitialised Whether the initial auth state has been retrieved
  * @property {Function} authorize Authorize the user using Auth0 Universal Login. See {@link WebAuth#authorize}
  * @property {Function} clearSession Clears the user's web session, credentials and logs them out. See {@link WebAuth#clearSession}.
  * @property {Function} getCredentials Gets the user's credentials from the native credential store. See {@link CredentialsManager#getCredentials}
@@ -20,6 +21,7 @@ import Auth0Context from './auth0-context';
  *   // State
  *   error,
  *   user,
+ *   isInitialised,
  *   // Methods
  *   authorize,
  *   clearSession,


### PR DESCRIPTION
Add an isInitialised state, so that consumers can handle an interim state whilst the current auth state (logged in, or logged out) is retrieved.

### Changes

Please describe both what is changing and why this is important. Include:

- new context property `isInitialised` which can be used for showing an interim state before the application knows whether the user is truly logged out or logged in 