### PR TITLE
Run requireAuth on UI thread

### DIFF
--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -105,12 +105,14 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
             promise.reject(ERROR_CODE, "No current activity present");
             return;
         }
-        try {
-            this.secureCredentialsManager.requireAuthentication(activity, LOCAL_AUTH_REQUEST_CODE, title, description);
-            promise.resolve(true);
-        } catch (CredentialsManagerException e){
-            promise.reject(ERROR_CODE, e.getMessage());
-        }
+        activity.runOnUiThread(() -> {
+            try {
+                A0Auth0Module.this.secureCredentialsManager.requireAuthentication(activity, LOCAL_AUTH_REQUEST_CODE, title, description);
+                promise.resolve(true);
+            } catch (CredentialsManagerException e){
+                promise.reject(ERROR_CODE, e.getMessage());
+            }
+        });
     }
 
     @ReactMethod


### PR DESCRIPTION
### Changes
`requireAuthentication` method in Android if executed before `onStart` uses activity results API which needs to be run on main thread. If not run on main thread it throws an exception. To avoid this edge case we will execute the method on main thread

### References
https://github.com/auth0/react-native-auth0/issues/589

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not
