### PR TITLE
Fixing comments & docs regarding requireLocalAuthentication "strategy" param

### DIFF
--- a/docs/credentials-manager_index.js.html
+++ b/docs/credentials-manager_index.js.html
@@ -347,7 +347,7 @@ class CredentialsManager {
    * @param {String} description Android Only - optional - the text to use as description in the authentication screen. On some Android versions it might not be shown. Passing null will result in using the OS's default value.
    * @param {String} cancelTitle iOS Only - optional - the cancel message to display on the local authentication prompt.
    * @param {String} fallbackTitle iOS Only - optional - the fallback message to display on the local authentication prompt after a failed match.
-   * @param {String} strategy iOS Only - optional - the evaluation policy to use when accessing the credentials. Defaults to LocalAuthenticationStrategy.deviceOwnerWithBiometrics.
+   * @param {Number} strategy iOS Only - optional - the evaluation policy to use when accessing the credentials. Defaults to LocalAuthenticationStrategy.deviceOwnerWithBiometrics.
    * @returns {Promise}
    */
   async requireLocalAuthentication(

--- a/src/credentials-manager/index.js
+++ b/src/credentials-manager/index.js
@@ -1,4 +1,4 @@
-import {Platform, NativeModules} from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 import CredentialsManagerError from './credentialsManagerError';
 import LocalAuthenticationStrategy from './localAuthenticationStrategy';
 
@@ -84,7 +84,7 @@ class CredentialsManager {
    * @param {String} description Android Only - optional - the text to use as description in the authentication screen. On some Android versions it might not be shown. Passing null will result in using the OS's default value.
    * @param {String} cancelTitle iOS Only - optional - the cancel message to display on the local authentication prompt.
    * @param {String} fallbackTitle iOS Only - optional - the fallback message to display on the local authentication prompt after a failed match.
-   * @param {String} strategy iOS Only - optional - the evaluation policy to use when accessing the credentials. Defaults to LocalAuthenticationStrategy.deviceOwnerWithBiometrics.
+   * @param {Number} strategy iOS Only - optional - the evaluation policy to use when accessing the credentials. Defaults to LocalAuthenticationStrategy.deviceOwnerWithBiometrics.
    * @returns {Promise}
    */
   async requireLocalAuthentication(


### PR DESCRIPTION
Strategy is a param of requireLocalAuthentication function that is actually a Number, but, is described as a String in the docs

This is my first PR here, let me know if I missed anything please. 

### Changes

- Changed comments above requireLocalAuthentication
- Changed html of requireLocalAuthentication

### References

Please include relevant links supporting this change such as a:

- If you take a look at LocalAuthenticationStrategy enum, you will see that those values are indeed numbers instead of strings.

Please note any links that are not publicly accessible.

### Testing

There's no functional changes at all, just docs.

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [X] All active GitHub checks have passed
