### PR TITLE
[ESD-27178] Fix browser not found issue not being surfaced

### DIFF
--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -38,6 +38,8 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
     private static final String SHA_256 = "SHA-256";
     private static final String ERROR_CODE = "a0.invalid_state.credential_manager_exception";
     private static final int LOCAL_AUTH_REQUEST_CODE = 150;
+    public static final int NO_BROWSER_FOUND_RESULT_CODE = 1404;
+    public static final int UNKNOWN_ERROR_RESULT_CODE = 1405;
 
     private final ReactApplicationContext reactContext;
     private Callback callback;
@@ -223,6 +225,22 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
 
         if(requestCode == LOCAL_AUTH_REQUEST_CODE) {
             secureCredentialsManager.checkAuthenticationResult(requestCode, resultCode);
+            return;
+        }
+
+        if (resultCode == NO_BROWSER_FOUND_RESULT_CODE) {
+            final WritableMap error = Arguments.createMap();
+            error.putString("name", "a0.browser_not_available");
+            error.putString("message", "No Browser application is installed.");
+            callback.invoke(error);
+            return;
+        }
+
+        if (resultCode == UNKNOWN_ERROR_RESULT_CODE) {
+            final WritableMap error = Arguments.createMap();
+            error.putString("name", "a0.response.invalid");
+            error.putString("message", "unknown error");
+            callback.invoke(error);
             return;
         }
 

--- a/android/src/main/java/com/auth0/react/AuthenticationActivity.java
+++ b/android/src/main/java/com/auth0/react/AuthenticationActivity.java
@@ -1,6 +1,10 @@
 package com.auth0.react;
 
+import static com.auth0.react.A0Auth0Module.NO_BROWSER_FOUND_RESULT_CODE;
+import static com.auth0.react.A0Auth0Module.UNKNOWN_ERROR_RESULT_CODE;
+
 import android.app.Activity;
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -65,11 +69,20 @@ public class AuthenticationActivity extends Activity {
     }
 
     private void launchAuthenticationIntent() {
-        Bundle extras = getIntent().getExtras();
-        Uri authorizeUri = extras.getParcelable(EXTRA_AUTHORIZE_URI);
-        CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
-        CustomTabsIntent customTabsIntent = builder.build();
-        customTabsIntent.launchUrl(this, authorizeUri);
+        try {
+            Bundle extras = getIntent().getExtras();
+            Uri authorizeUri = extras.getParcelable(EXTRA_AUTHORIZE_URI);
+            CustomTabsIntent.Builder builder = new CustomTabsIntent.Builder();
+            CustomTabsIntent customTabsIntent = builder.build();
+            customTabsIntent.launchUrl(this, authorizeUri);
+        } catch (Exception e) {
+            if(e instanceof ActivityNotFoundException) {
+                setResult(NO_BROWSER_FOUND_RESULT_CODE);
+            } else {
+                setResult(UNKNOWN_ERROR_RESULT_CODE);
+            }
+            finish();
+        }
     }
 
 }


### PR DESCRIPTION
### Changes
Currently when a browser is not available in Android, the issue is not surfaced and instead it gets engulfed. To fix this issue we have added a check to result code to check whether browser is not found.

The error written [here](https://github.com/auth0/react-native-auth0/blob/master/android/src/main/java/com/auth0/react/A0Auth0Module.java#L160) doesn't seem to be raised

### References
https://github.com/auth0/react-native-auth0/issues/340

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not