### PR TITLE
Corrects login example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ const Component = () => {
   const {authorize, user, isLoading, error} = useAuth0();
 
   const login = async () => {
-    await clearSession(); // clearSession({customScheme: 'CUSTOM_SCHEME') when using Expo or a custom scheme
+    await authorize({scope: 'openid profile email'}); // authorize({scope: 'openid profile email'}, {customScheme: 'CUSTOM_SCHEME'}) when using Expo or a custom scheme
   };
 
   if(isLoading) {
@@ -336,7 +336,7 @@ const Component = () => {
   const {clearSession, user} = useAuth0();
 
   const logout = async () => {
-    await clearSession(); // clearSession({customScheme: 'CUSTOM_SCHEME') when using Expo or a custom scheme
+    await clearSession(); // clearSession({customScheme: 'CUSTOM_SCHEME'}) when using Expo or a custom scheme
   };
 
   return <View>{user && <Button onPress={logout} title="Log out" />}</View>;


### PR DESCRIPTION
### Changes

Fixes the login example in the README: https://github.com/auth0/react-native-auth0#login

The README erroneously instructs using the `clearSession()` method for login instead of `authorize()`.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
