### PR TITLE
Returning credentials at authorize

### DIFF
--- a/src/hooks/auth0-provider.js
+++ b/src/hooks/auth0-provider.js
@@ -82,6 +82,7 @@ const Auth0Provider = ({domain, clientId, children}) => {
 
         await client.credentialsManager.saveCredentials(credentials);
         dispatch({type: 'LOGIN_COMPLETE', user});
+        return credentials
       } catch (error) {
         dispatch({type: 'ERROR', error});
         return;


### PR DESCRIPTION
### Changes
I changed the authorize method to return the credentials, because it is on documentation but the code is not.

### Testing

- [] This change adds unit test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [X] All active GitHub checks have passed
