### PR TITLE
[SDK-4299] Support forceRefresh in Android (without Android config changes)

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ repositories {
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactnativeVersion', '+')}"
     implementation "androidx.browser:browser:1.2.0"
-    implementation 'com.auth0.android:auth0:2.8.0'
+    implementation 'com.auth0.android:auth0:2.9.2'
 }
 
 def configureReactNativePom(def pom) {

--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -68,7 +68,7 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
     }
 
     @ReactMethod
-    public void getCredentials(String scope, double minTtl, ReadableMap parameters, Promise promise) {
+    public void getCredentials(String scope, double minTtl, ReadableMap parameters, boolean forceRefresh, Promise promise) {
         Map<String,String> cleanedParameters = new HashMap<>();
         for (Map.Entry<String, Object> entry : parameters.toHashMap().entrySet()) {
             if (entry.getValue() != null) {
@@ -76,7 +76,7 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
             }
         }
 
-        this.secureCredentialsManager.getCredentials(scope, (int) minTtl, cleanedParameters, new com.auth0.android.callback.Callback<Credentials, CredentialsManagerException>() {
+        this.secureCredentialsManager.getCredentials(scope, (int) minTtl, cleanedParameters, forceRefresh, new com.auth0.android.callback.Callback<Credentials, CredentialsManagerException>() {
             @Override
             public void onSuccess(Credentials credentials) {
                 ReadableMap map = CredentialsParser.toMap(credentials);

--- a/src/credentials-manager/__tests__/credentials-manager.spec.js
+++ b/src/credentials-manager/__tests__/credentials-manager.spec.js
@@ -119,7 +119,7 @@ describe('credentials manager tests', () => {
 
       expect(
         credentialsManager.Auth0Module.getCredentials
-      ).toHaveBeenCalledWith(null, 0, true, {});
+      ).toHaveBeenCalledWith(null, 0, {}, true);
 
       newNativeModule.mockRestore();
     });

--- a/src/credentials-manager/__tests__/credentials-manager.spec.js
+++ b/src/credentials-manager/__tests__/credentials-manager.spec.js
@@ -1,10 +1,10 @@
 import CredentialsManager from '../index';
-import {Platform} from 'react-native';
+import { Platform } from 'react-native';
 
 describe('credentials manager tests', () => {
   const credentialsManager = new CredentialsManager(
     'https://auth0.com',
-    'abc123',
+    'abc123'
   );
 
   credentialsManager.Auth0Module.hasValidCredentialManagerInstance = () =>
@@ -27,7 +27,7 @@ describe('credentials manager tests', () => {
       const testToken = Object.assign({}, validToken);
       testToken.idToken = undefined;
       await expect(
-        credentialsManager.saveCredentials(testToken),
+        credentialsManager.saveCredentials(testToken)
       ).rejects.toThrow();
     });
 
@@ -35,7 +35,7 @@ describe('credentials manager tests', () => {
       const testToken = Object.assign({}, validToken);
       testToken.tokenType = undefined;
       await expect(
-        credentialsManager.saveCredentials(testToken),
+        credentialsManager.saveCredentials(testToken)
       ).rejects.toThrow();
     });
 
@@ -43,7 +43,7 @@ describe('credentials manager tests', () => {
       const testToken = Object.assign({}, validToken);
       testToken.accessToken = undefined;
       await expect(
-        credentialsManager.saveCredentials(testToken),
+        credentialsManager.saveCredentials(testToken)
       ).rejects.toThrow();
     });
 
@@ -51,7 +51,7 @@ describe('credentials manager tests', () => {
       const testToken = Object.assign({}, validToken);
       testToken.expiresIn = undefined;
       await expect(
-        credentialsManager.saveCredentials(testToken),
+        credentialsManager.saveCredentials(testToken)
       ).rejects.toThrow();
     });
 
@@ -59,7 +59,7 @@ describe('credentials manager tests', () => {
       const testToken = Object.assign({}, validToken);
       testToken.expiresIn = 0;
       await expect(
-        credentialsManager.saveCredentials(testToken),
+        credentialsManager.saveCredentials(testToken)
       ).rejects.toThrow();
     });
 
@@ -67,13 +67,13 @@ describe('credentials manager tests', () => {
       const newNativeModule = jest
         .spyOn(
           credentialsManager.Auth0Module,
-          'hasValidCredentialManagerInstance',
+          'hasValidCredentialManagerInstance'
         )
         .mockImplementation(() => {
           throw Error('123123');
         });
       await expect(
-        credentialsManager.saveCredentials(validToken),
+        credentialsManager.saveCredentials(validToken)
       ).rejects.toThrow();
       newNativeModule.mockRestore();
     });
@@ -83,7 +83,7 @@ describe('credentials manager tests', () => {
         .spyOn(credentialsManager.Auth0Module, 'saveCredentials')
         .mockImplementation(() => Promise.resolve(true));
       await expect(
-        credentialsManager.saveCredentials(validToken),
+        credentialsManager.saveCredentials(validToken)
       ).resolves.toEqual(true);
       newNativeModule.mockRestore();
     });
@@ -105,8 +105,22 @@ describe('credentials manager tests', () => {
         .spyOn(credentialsManager.Auth0Module, 'getCredentials')
         .mockImplementation(() => Promise.resolve(validToken));
       await expect(credentialsManager.getCredentials()).resolves.toEqual(
-        validToken,
+        validToken
       );
+      newNativeModule.mockRestore();
+    });
+
+    it('passes along the forceRefresh parameter', async () => {
+      const newNativeModule = jest
+        .spyOn(credentialsManager.Auth0Module, 'getCredentials')
+        .mockImplementation(() => Promise.resolve(validToken));
+
+      await credentialsManager.getCredentials(null, 0, {}, true);
+
+      expect(
+        credentialsManager.Auth0Module.getCredentials
+      ).toHaveBeenCalledWith(null, 0, true, {});
+
       newNativeModule.mockRestore();
     });
   });
@@ -117,7 +131,7 @@ describe('credentials manager tests', () => {
         .spyOn(credentialsManager.Auth0Module, 'hasValidCredentials')
         .mockImplementation(() => Promise.resolve(true));
       await expect(credentialsManager.hasValidCredentials()).resolves.toEqual(
-        true,
+        true
       );
       newNativeModule.mockRestore();
     });
@@ -127,7 +141,7 @@ describe('credentials manager tests', () => {
         .spyOn(credentialsManager.Auth0Module, 'hasValidCredentials')
         .mockImplementation(() => Promise.resolve(true));
       await expect(credentialsManager.hasValidCredentials()).resolves.toEqual(
-        true,
+        true
       );
       newNativeModule.mockRestore();
     });
@@ -139,7 +153,7 @@ describe('credentials manager tests', () => {
         .spyOn(credentialsManager.Auth0Module, 'clearCredentials')
         .mockImplementation(() => Promise.resolve(true));
       await expect(credentialsManager.clearCredentials()).resolves.toEqual(
-        true,
+        true
       );
       newNativeModule.mockRestore();
     });
@@ -149,7 +163,7 @@ describe('credentials manager tests', () => {
         .spyOn(credentialsManager.Auth0Module, 'clearCredentials')
         .mockImplementation(() => Promise.resolve(true));
       await expect(credentialsManager.clearCredentials()).resolves.toEqual(
-        true,
+        true
       );
       newNativeModule.mockRestore();
     });

--- a/src/credentials-manager/index.ts
+++ b/src/credentials-manager/index.ts
@@ -1,7 +1,7 @@
-import {NativeModules, Platform} from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 import CredentialsManagerError from './credentialsManagerError';
 import LocalAuthenticationStrategy from './localAuthenticationStrategy';
-import {Credentials} from '../types';
+import { Credentials } from '../types';
 
 /**
  * Type representing the Native Auth0 API's on iOS and Android
@@ -12,13 +12,14 @@ type Auth0Module = {
     scope?: string,
     minTtl?: number,
     parameters?: object,
+    forceRefresh?: boolean
   ) => Promise<Credentials>;
   enableLocalAuthentication:
     | ((
         title?: string,
         cancelTitle?: string,
         fallbackTitle?: string,
-        strategy?: LocalAuthenticationStrategy,
+        strategy?: LocalAuthenticationStrategy
       ) => Promise<void>)
     | ((title?: string, description?: string) => Promise<void>);
   hasValidCredentials: (minTtl?: number) => Promise<boolean>;
@@ -26,7 +27,7 @@ type Auth0Module = {
   hasValidCredentialManagerInstance: () => Promise<boolean>;
   initializeCredentialManager: (
     clientId: string,
-    domain: string,
+    domain: string
   ) => Promise<void>;
 };
 
@@ -68,7 +69,7 @@ class CredentialsManager {
           error_description: `${key} cannot be empty`,
           invalid_parameter: key,
         };
-        throw new CredentialsManagerError({json, status: 0});
+        throw new CredentialsManagerError({ json, status: 0 });
       }
     });
     try {
@@ -79,7 +80,7 @@ class CredentialsManager {
         error: 'a0.credential_manager.invalid',
         error_description: e.message,
       };
-      throw new CredentialsManagerError({json, status: 0});
+      throw new CredentialsManagerError({ json, status: 0 });
     }
   }
 
@@ -95,16 +96,22 @@ class CredentialsManager {
     scope?: string,
     minTtl: number = 0,
     parameters: object = {},
+    forceRefresh: boolean = false
   ): Promise<Credentials> {
     try {
       await this._ensureCredentialManagerIsInitialized();
-      return this.Auth0Module.getCredentials(scope, minTtl, parameters);
+      return this.Auth0Module.getCredentials(
+        scope,
+        minTtl,
+        parameters,
+        forceRefresh
+      );
     } catch (e) {
       const json = {
         error: 'a0.credential_manager.invalid',
         error_description: e.message,
       };
-      throw new CredentialsManagerError({json, status: 0});
+      throw new CredentialsManagerError({ json, status: 0 });
     }
   }
 
@@ -123,7 +130,7 @@ class CredentialsManager {
     description?: string,
     cancelTitle?: string,
     fallbackTitle?: string,
-    strategy = LocalAuthenticationStrategy.deviceOwnerWithBiometrics,
+    strategy = LocalAuthenticationStrategy.deviceOwnerWithBiometrics
   ): Promise<void> {
     try {
       await this._ensureCredentialManagerIsInitialized();
@@ -132,7 +139,7 @@ class CredentialsManager {
           title,
           cancelTitle,
           fallbackTitle,
-          strategy,
+          strategy
         );
       } else {
         await this.Auth0Module.enableLocalAuthentication(title, description);
@@ -142,7 +149,7 @@ class CredentialsManager {
         error: 'a0.credential_manager.invalid',
         error_description: e.message,
       };
-      throw new CredentialsManagerError({json, status: 0});
+      throw new CredentialsManagerError({ json, status: 0 });
     }
   }
 
@@ -170,7 +177,7 @@ class CredentialsManager {
     if (!hasValid) {
       await this.Auth0Module.initializeCredentialManager(
         this.clientId,
-        this.domain,
+        this.domain
       );
     }
   }

--- a/src/hooks/__tests__/use-auth0.spec.jsx
+++ b/src/hooks/__tests__/use-auth0.spec.jsx
@@ -2,15 +2,15 @@
  * @jest-environment jsdom
  */
 import * as React from 'react';
-import {renderHook} from '@testing-library/react-hooks';
+import { renderHook } from '@testing-library/react-hooks';
 import Auth0Provider from '../auth0-provider';
 import useAuth0 from '../use-auth0';
 import LocalAuthenticationStrategy from '../../credentials-manager/localAuthenticationStrategy';
-import {act} from 'react-dom/test-utils';
+import { act } from 'react-dom/test-utils';
 import Auth0Error from '../../auth/auth0Error';
 
 function makeJwt(claims) {
-  const header = {alg: 'RS256', typ: 'JWT'};
+  const header = { alg: 'RS256', typ: 'JWT' };
 
   const payload = {
     sub: '1',
@@ -19,7 +19,7 @@ function makeJwt(claims) {
     name: 'Test User',
     family_name: 'User',
     picture: 'https://images/pic.png',
-    ...(claims !== undefined ? {...claims} : null),
+    ...(claims !== undefined ? { ...claims } : null),
   };
 
   // prettier-ignore
@@ -33,10 +33,10 @@ const mockCredentials = {
   accessToken: 'ACCESS TOKEN',
 };
 
-const mockAuthError = new Auth0Error({json: {error: 'mock error'}});
+const mockAuthError = new Auth0Error({ json: { error: 'mock error' } });
 
 const updatedMockCredentialsWithIdToken = {
-  idToken: makeJwt({name: 'Different User'}),
+  idToken: makeJwt({ name: 'Different User' }),
   accessToken: 'ACCESS TOKEN',
 };
 
@@ -44,7 +44,7 @@ const updatedMockCredentialsWithoutIdToken = {
   accessToken: 'ACCESS TOKEN',
 };
 
-const wrapper = ({children}) => (
+const wrapper = ({ children }) => (
   <Auth0Provider domain="DOMAIN" clientId="CLIENT ID">
     {children}
   </Auth0Provider>
@@ -86,27 +86,29 @@ describe('The useAuth0 hook', () => {
   });
 
   it('defines error', () => {
-    const {result} = renderHook(() => useAuth0());
+    const { result } = renderHook(() => useAuth0());
     expect(result.current.error).toBeNull();
   });
 
   it('defines user', () => {
-    const {result} = renderHook(() => useAuth0());
+    const { result } = renderHook(() => useAuth0());
     expect(result.current.user).toBeNull();
   });
 
   it('defines authorize', () => {
-    const {result} = renderHook(() => useAuth0());
+    const { result } = renderHook(() => useAuth0());
     expect(result.current.authorize).toBeDefined();
   });
 
   it('defines clearSession', () => {
-    const {result} = renderHook(() => useAuth0());
+    const { result } = renderHook(() => useAuth0());
     expect(result.current.clearSession).toBeDefined();
   });
 
   it('isLoading is true until initialization finishes', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     expect(result.current.isLoading).toBe(true);
 
     await waitForNextUpdate();
@@ -119,7 +121,9 @@ describe('The useAuth0 hook', () => {
   it('isLoading flag set on start up with valid credentials', async () => {
     mockAuth0.credentialsManager.hasValidCredentials.mockResolvedValue(true);
 
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     expect(result.current.isLoading).toBe(true);
 
     await waitForNextUpdate();
@@ -132,7 +136,9 @@ describe('The useAuth0 hook', () => {
     mockAuth0.credentialsManager.hasValidCredentials.mockResolvedValue(true);
     mockAuth0.credentialsManager.getCredentials.mockRejectedValue(errorToThrow);
 
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     expect(result.current.isLoading).toBe(true);
 
     await waitForNextUpdate();
@@ -141,7 +147,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('does not initialize the user on start up without valid credentials', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     await waitForNextUpdate();
     expect(mockAuth0.credentialsManager.getCredentials).not.toBeCalled();
@@ -152,33 +160,37 @@ describe('The useAuth0 hook', () => {
   it('initializes the user on start up with valid credentials', async () => {
     mockAuth0.credentialsManager.hasValidCredentials.mockResolvedValue(true);
     mockAuth0.credentialsManager.getCredentials.mockResolvedValue(
-      mockCredentials,
+      mockCredentials
     );
 
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     await waitForNextUpdate();
     expect(result.current.user).not.toBeNull();
   });
 
   it('throws an error when login is called without a wrapper', () => {
-    const {result} = renderHook(() => useAuth0());
+    const { result } = renderHook(() => useAuth0());
 
     expect(() => result.current.authorize()).toThrowError(
-      /no provider was set/i,
+      /no provider was set/i
     );
   });
 
   it('throws an error when logout is called without a wrapper', () => {
-    const {result} = renderHook(() => useAuth0());
+    const { result } = renderHook(() => useAuth0());
 
     expect(() => result.current.clearSession()).toThrowError(
-      /no provider was set/i,
+      /no provider was set/i
     );
   });
 
   it('can authorize', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     result.current.authorize();
 
     await waitForNextUpdate();
@@ -188,7 +200,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can authorize, passing through all parameters', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorize(
       {
@@ -198,7 +212,7 @@ describe('The useAuth0 hook', () => {
       },
       {
         ephemeralSession: true,
-      },
+      }
     );
 
     await waitForNextUpdate();
@@ -211,12 +225,14 @@ describe('The useAuth0 hook', () => {
       },
       {
         ephemeralSession: true,
-      },
+      }
     );
   });
 
   it('can authorize, passing through all options', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorize(
       {},
@@ -225,24 +241,26 @@ describe('The useAuth0 hook', () => {
         customScheme: 'demo',
         leeway: 100,
         skipLegacyListener: false,
-      },
+      }
     );
 
     await waitForNextUpdate();
 
     expect(mockAuth0.webAuth.authorize).toHaveBeenCalledWith(
-      {scope: 'openid profile email'},
+      { scope: 'openid profile email' },
       {
         ephemeralSession: true,
         customScheme: 'demo',
         leeway: 100,
         skipLegacyListener: false,
-      },
+      }
     );
   });
 
   it('adds the default scopes when none are specified', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorize();
 
@@ -252,14 +270,16 @@ describe('The useAuth0 hook', () => {
       {
         scope: 'openid profile email',
       },
-      {},
+      {}
     );
   });
 
   it('adds the default scopes when some are specified with custom scope', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
-    result.current.authorize({scope: 'custom-scope openid'});
+    result.current.authorize({ scope: 'custom-scope openid' });
 
     await waitForNextUpdate();
 
@@ -267,12 +287,14 @@ describe('The useAuth0 hook', () => {
       {
         scope: 'custom-scope openid profile email',
       },
-      {},
+      {}
     );
   });
 
   it('does not duplicate default scopes', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorize({
       scope: 'openid profile',
@@ -288,12 +310,14 @@ describe('The useAuth0 hook', () => {
         audience: 'http://my-api',
         customParam: '1234',
       },
-      {},
+      {}
     );
   });
 
   it('sets the user prop after authorizing', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorize();
     await waitForNextUpdate();
@@ -307,7 +331,9 @@ describe('The useAuth0 hook', () => {
 
   it('does not set user prop when authorization fails', async () => {
     mockAuth0.webAuth.authorize.mockRejectedValue(mockAuthError);
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorize();
     await waitForNextUpdate();
@@ -317,7 +343,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('sends SMS code', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.sendSMSCode();
     await waitForNextUpdate();
@@ -326,7 +354,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can authorize with SMS, passing through all parameters', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithSMS({
       phoneNumber: '+11234567890',
@@ -346,7 +376,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('adds the default scopes when none are specified for SMS login', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithSMS();
 
@@ -358,9 +390,11 @@ describe('The useAuth0 hook', () => {
   });
 
   it('adds the default scopes when some are specified with custom scope for SMS login', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
-    result.current.authorizeWithSMS({scope: 'custom-scope openid'});
+    result.current.authorizeWithSMS({ scope: 'custom-scope openid' });
 
     await waitForNextUpdate();
 
@@ -370,7 +404,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('does not duplicate default scopes for SMS login', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithSMS({
       scope: 'openid profile',
@@ -386,7 +422,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('sets the user prop after authorizing with SMS', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithSMS();
     await waitForNextUpdate();
@@ -400,7 +438,9 @@ describe('The useAuth0 hook', () => {
 
   it('does not set user prop when SMS authorization fails', async () => {
     mockAuth0.auth.loginWithSMS.mockRejectedValue(mockAuthError);
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithSMS();
     await waitForNextUpdate();
@@ -410,7 +450,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('sends email code', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.sendEmailCode();
     await waitForNextUpdate();
@@ -419,7 +461,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can authorize with email, passing through all parameters', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithEmail({
       email: 'foo@gmail.com',
@@ -439,7 +483,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('adds the default scopes when none are specified for email login', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithEmail();
 
@@ -451,9 +497,11 @@ describe('The useAuth0 hook', () => {
   });
 
   it('adds the default scopes when some are specified with custom scope for email login', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
-    result.current.authorizeWithEmail({scope: 'custom-scope openid'});
+    result.current.authorizeWithEmail({ scope: 'custom-scope openid' });
 
     await waitForNextUpdate();
 
@@ -463,7 +511,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('does not duplicate default scopes for email login', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithEmail({
       scope: 'openid profile',
@@ -479,7 +529,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('sets the user prop after authorizing with email', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithEmail();
     await waitForNextUpdate();
@@ -493,7 +545,9 @@ describe('The useAuth0 hook', () => {
 
   it('does not set user prop when email authorization fails', async () => {
     mockAuth0.auth.loginWithEmail.mockRejectedValue(mockAuthError);
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithEmail();
     await waitForNextUpdate();
@@ -503,7 +557,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('sends multifactor challenge code', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.sendMultifactorChallenge();
     await waitForNextUpdate();
@@ -512,7 +568,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can authorize with OOB, passing through all parameters', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithOOB({
       mfaToken: 'mfa_token',
@@ -530,7 +588,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('sets the user prop after authorizing with OOB', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithOOB();
     await waitForNextUpdate();
@@ -544,7 +604,9 @@ describe('The useAuth0 hook', () => {
 
   it('does not set user prop when OOB authorization fails', async () => {
     mockAuth0.auth.loginWithOOB.mockRejectedValue(mockAuthError);
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithOOB();
     await waitForNextUpdate();
@@ -554,7 +616,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can authorize with OTP, passing through all parameters', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithOTP({
       mfaToken: 'mfa_token',
@@ -570,7 +634,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('sets the user prop after authorizing with OTP', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithOTP();
     await waitForNextUpdate();
@@ -584,7 +650,9 @@ describe('The useAuth0 hook', () => {
 
   it('does not set user prop when OTP authorization fails', async () => {
     mockAuth0.auth.loginWithOTP.mockRejectedValue(mockAuthError);
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithOTP();
     await waitForNextUpdate();
@@ -594,7 +662,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can authorize with recover code, passing through all parameters', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithRecoveryCode({
       mfaToken: 'mfa_token',
@@ -610,7 +680,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('sets the user prop after authorizing with recovery code', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithRecoveryCode();
     await waitForNextUpdate();
@@ -624,7 +696,9 @@ describe('The useAuth0 hook', () => {
 
   it('does not set user prop when recovery code authorization fails', async () => {
     mockAuth0.auth.loginWithRecoveryCode.mockRejectedValue(mockAuthError);
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.authorizeWithRecoveryCode();
     await waitForNextUpdate();
@@ -634,7 +708,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can clear the session', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     result.current.clearSession();
     await waitForNextUpdate();
@@ -644,19 +720,23 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can clear the session and pass parameters', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
-    result.current.clearSession({parameter: 1}, {option: 1});
+    result.current.clearSession({ parameter: 1 }, { option: 1 });
     await waitForNextUpdate();
 
     expect(mockAuth0.webAuth.clearSession).toHaveBeenCalledWith(
-      {parameter: 1},
-      {option: 1},
+      { parameter: 1 },
+      { option: 1 }
     );
   });
 
   it('can clear the credentials', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     act(() => {
       result.current.clearCredentials();
@@ -667,11 +747,13 @@ describe('The useAuth0 hook', () => {
   });
 
   it('sets the error property when an error is raised in clearing credentials', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     const errorToThrow = new Error('Error clearing credentials');
 
     mockAuth0.credentialsManager.clearCredentials.mockRejectedValue(
-      errorToThrow,
+      errorToThrow
     );
 
     result.current.clearCredentials();
@@ -680,11 +762,13 @@ describe('The useAuth0 hook', () => {
   });
 
   it('clears the error on successful logout when clearing credentials', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     const errorToThrow = new Error('Error clearing credentials');
 
     mockAuth0.credentialsManager.clearCredentials.mockRejectedValueOnce(
-      errorToThrow,
+      errorToThrow
     );
     mockAuth0.credentialsManager.clearCredentials.mockResolvedValue();
 
@@ -697,7 +781,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('sets the error property when an error is raised in authorize', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     const errorToThrow = new Error('Authorize error');
 
     mockAuth0.webAuth.authorize.mockRejectedValue(errorToThrow);
@@ -708,7 +794,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('clears the error on successful login', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     const errorToThrow = new Error('Authorize error');
 
     mockAuth0.webAuth.authorize.mockRejectedValueOnce(errorToThrow);
@@ -723,7 +811,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('sets the error property when an error is raised in clearSession', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     const errorToThrow = new Error('Authorize error');
 
     mockAuth0.webAuth.clearSession.mockRejectedValue(errorToThrow);
@@ -734,7 +824,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('clears the error on successful logout', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     const errorToThrow = new Error('Authorize error');
 
     mockAuth0.webAuth.clearSession.mockRejectedValueOnce(errorToThrow);
@@ -750,7 +842,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can get credentials', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     await waitForNextUpdate();
     let credentials;
@@ -761,7 +855,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can get credentials with options', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     await waitForNextUpdate();
 
@@ -779,11 +875,14 @@ describe('The useAuth0 hook', () => {
       {
         hello: 'world',
       },
+      false
     );
   });
 
   it('can get credentials and update user when id token is present', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     act(() => {
       result.current.authorize();
     });
@@ -797,7 +896,7 @@ describe('The useAuth0 hook', () => {
     });
 
     mockAuth0.credentialsManager.getCredentials.mockResolvedValue(
-      updatedMockCredentialsWithIdToken,
+      updatedMockCredentialsWithIdToken
     );
     result.current.getCredentials();
     await waitForNextUpdate();
@@ -809,7 +908,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can get credentials and not update user when id token is not present', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     act(() => {
       result.current.authorize();
     });
@@ -823,7 +924,7 @@ describe('The useAuth0 hook', () => {
     });
 
     mockAuth0.credentialsManager.getCredentials.mockResolvedValue(
-      updatedMockCredentialsWithoutIdToken,
+      updatedMockCredentialsWithoutIdToken
     );
     result.current.getCredentials();
     expect(result.current.user).toMatchObject({
@@ -834,7 +935,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can get credentials and not update user when same as before', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     act(() => {
       result.current.authorize();
     });
@@ -848,7 +951,7 @@ describe('The useAuth0 hook', () => {
     });
 
     mockAuth0.credentialsManager.getCredentials.mockResolvedValue(
-      mockCredentials,
+      mockCredentials
     );
     await act(async () => {
       await result.current.getCredentials();
@@ -857,7 +960,9 @@ describe('The useAuth0 hook', () => {
   });
 
   it('dispatches an error when getCredentials fails', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     const thrownError = new Error('Get credentials failed');
 
     mockAuth0.credentialsManager.getCredentials.mockRejectedValue(thrownError);
@@ -870,19 +975,23 @@ describe('The useAuth0 hook', () => {
   });
 
   it('can require local authentication', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     await waitForNextUpdate();
 
     result.current.requireLocalAuthentication();
 
     expect(
-      mockAuth0.credentialsManager.requireLocalAuthentication,
+      mockAuth0.credentialsManager.requireLocalAuthentication
     ).toHaveBeenCalled();
   });
 
   it('can require local authentication with options', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     await waitForNextUpdate();
 
@@ -891,26 +1000,28 @@ describe('The useAuth0 hook', () => {
       'description',
       'cancel',
       'fallback',
-      LocalAuthenticationStrategy.deviceOwner,
+      LocalAuthenticationStrategy.deviceOwner
     );
 
     expect(
-      mockAuth0.credentialsManager.requireLocalAuthentication,
+      mockAuth0.credentialsManager.requireLocalAuthentication
     ).toHaveBeenCalledWith(
       'title',
       'description',
       'cancel',
       'fallback',
-      LocalAuthenticationStrategy.deviceOwner,
+      LocalAuthenticationStrategy.deviceOwner
     );
   });
 
   it('dispatches an error when requireLocalAuthentication fails', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
     const thrownError = new Error('requireLocalAuthentication failed');
 
     mockAuth0.credentialsManager.requireLocalAuthentication.mockRejectedValue(
-      thrownError,
+      thrownError
     );
 
     result.current.requireLocalAuthentication();
@@ -919,14 +1030,16 @@ describe('The useAuth0 hook', () => {
   });
 
   it('calls hasValidCredentials with correct parameters', async () => {
-    const {result, waitForNextUpdate} = renderHook(() => useAuth0(), {wrapper});
+    const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
+      wrapper,
+    });
 
     await waitForNextUpdate();
 
     result.current.hasValidCredentials(100);
 
     expect(
-      mockAuth0.credentialsManager.hasValidCredentials,
+      mockAuth0.credentialsManager.hasValidCredentials
     ).toHaveBeenCalledWith(100);
   });
 });

--- a/src/hooks/auth0-context.ts
+++ b/src/hooks/auth0-context.ts
@@ -1,4 +1,4 @@
-import {createContext} from 'react';
+import { createContext } from 'react';
 import {
   ClearSessionOptions,
   ClearSessionParameters,
@@ -21,29 +21,30 @@ export interface Auth0ContextInterface<TUser extends User = User>
   extends AuthState<TUser> {
   authorize: (
     parameters: WebAuthorizeParameters,
-    options: WebAuthorizeOptions,
+    options: WebAuthorizeOptions
   ) => Promise<void>;
   sendSMSCode: (parameters: PasswordlessWithSMSOptions) => Promise<void>;
   authorizeWithSMS: (parameters: LoginWithSMSOptions) => Promise<void>;
   sendEmailCode: (parameters: PasswordlessWithEmailOptions) => Promise<void>;
   authorizeWithEmail: (parameters: LoginWithEmailOptions) => Promise<void>;
   sendMultifactorChallenge: (
-    parameters: MultifactorChallengeOptions,
+    parameters: MultifactorChallengeOptions
   ) => Promise<void>;
   authorizeWithOOB: (parameters: LoginWithOOBOptions) => Promise<void>;
   authorizeWithOTP: (parameters: LoginWithOTPOptions) => Promise<void>;
   authorizeWithRecoveryCode: (
-    parameters: LoginWithRecoveryCodeOptions,
+    parameters: LoginWithRecoveryCodeOptions
   ) => Promise<void>;
   hasValidCredentials: (minTtl: number) => Promise<boolean>;
   clearSession: (
     parameters: ClearSessionParameters,
-    options: ClearSessionOptions,
+    options: ClearSessionOptions
   ) => Promise<void>;
   getCredentials: (
     scope?: string,
     minTtl?: number,
     parameters?: object,
+    forceRefresh?: boolean
   ) => Promise<Credentials | undefined>;
   clearCredentials: () => Promise<void>;
   requireLocalAuthentication: (
@@ -51,7 +52,7 @@ export interface Auth0ContextInterface<TUser extends User = User>
     description?: string,
     cancelTitle?: string,
     fallbackTitle?: string,
-    strategy?: LocalAuthenticationStrategy,
+    strategy?: LocalAuthenticationStrategy
   ) => Promise<void>;
 }
 

--- a/src/hooks/auth0-provider.tsx
+++ b/src/hooks/auth0-provider.tsx
@@ -1,6 +1,11 @@
-import React, {useEffect, useReducer, useState, PropsWithChildren} from 'react';
-import {useCallback, useMemo} from 'react';
-import jwtDecode, {JwtPayload} from 'jwt-decode';
+import React, {
+  useEffect,
+  useReducer,
+  useState,
+  PropsWithChildren,
+} from 'react';
+import { useCallback, useMemo } from 'react';
+import jwtDecode, { JwtPayload } from 'jwt-decode';
 import PropTypes from 'prop-types';
 import Auth0Context from './auth0-context';
 import Auth0 from '../auth0';
@@ -22,8 +27,8 @@ import {
   WebAuthorizeParameters,
 } from '../types';
 import LocalAuthenticationStrategy from '../credentials-manager/localAuthenticationStrategy';
-import {CustomJwtPayload} from '../internal-types';
-import {convertUser} from '../utils/userConversion';
+import { CustomJwtPayload } from '../internal-types';
+import { convertUser } from '../utils/userConversion';
 
 const initialState = {
   user: null,
@@ -35,7 +40,7 @@ const initialState = {
  * @ignore
  */
 const getIdTokenProfileClaims = (idToken: string): User => {
-const payload = jwtDecode<CustomJwtPayload>(idToken);
+  const payload = jwtDecode<CustomJwtPayload>(idToken);
   return convertUser(payload);
 };
 
@@ -65,8 +70,8 @@ const Auth0Provider = ({
   domain,
   clientId,
   children,
-}: PropsWithChildren<{domain: string; clientId: string}>) => {
-  const [client] = useState(() => new Auth0({domain, clientId}));
+}: PropsWithChildren<{ domain: string; clientId: string }>) => {
+  const [client] = useState(() => new Auth0({ domain, clientId }));
   const [state, dispatch] = useReducer(reducer, initialState);
 
   useEffect(() => {
@@ -80,52 +85,52 @@ const Auth0Provider = ({
             user = getIdTokenProfileClaims(credentials.idToken);
           }
         } catch (error) {
-          dispatch({type: 'ERROR', error});
+          dispatch({ type: 'ERROR', error });
         }
       }
 
-      dispatch({type: 'INITIALIZED', user});
+      dispatch({ type: 'INITIALIZED', user });
     })();
   }, [client]);
 
   const authorize = useCallback(
     async (
       parameters: WebAuthorizeParameters = {},
-      options: WebAuthorizeOptions = {},
+      options: WebAuthorizeOptions = {}
     ) => {
       try {
         parameters.scope = finalizeScopeParam(parameters.scope);
         const credentials: Credentials = await client.webAuth.authorize(
           parameters,
-          options,
+          options
         );
         const user = getIdTokenProfileClaims(credentials.idToken);
 
         await client.credentialsManager.saveCredentials(credentials);
-        dispatch({type: 'LOGIN_COMPLETE', user});
+        dispatch({ type: 'LOGIN_COMPLETE', user });
       } catch (error) {
-        dispatch({type: 'ERROR', error});
+        dispatch({ type: 'ERROR', error });
         return;
       }
     },
-    [client],
+    [client]
   );
 
   const clearSession = useCallback(
     async (
       parameters: ClearSessionParameters = {},
-      options: ClearSessionOptions = {},
+      options: ClearSessionOptions = {}
     ) => {
       try {
         await client.webAuth.clearSession(parameters, options);
         await client.credentialsManager.clearCredentials();
-        dispatch({type: 'LOGOUT_COMPLETE'});
+        dispatch({ type: 'LOGOUT_COMPLETE' });
       } catch (error) {
-        dispatch({type: 'ERROR', error});
+        dispatch({ type: 'ERROR', error });
         return;
       }
     },
-    [client],
+    [client]
   );
 
   const getCredentials = useCallback(
@@ -133,24 +138,26 @@ const Auth0Provider = ({
       scope?: string,
       minTtl: number = 0,
       parameters: object = {},
+      forceRefresh: boolean = false
     ): Promise<Credentials | undefined> => {
       try {
         const credentials = await client.credentialsManager.getCredentials(
           scope,
           minTtl,
           parameters,
+          forceRefresh
         );
         if (credentials.idToken) {
           const user = getIdTokenProfileClaims(credentials.idToken);
-          dispatch({type: 'SET_USER', user});
+          dispatch({ type: 'SET_USER', user });
         }
         return credentials;
       } catch (error) {
-        dispatch({type: 'ERROR', error});
+        dispatch({ type: 'ERROR', error });
         return;
       }
     },
-    [client],
+    [client]
   );
 
   const sendSMSCode = useCallback(
@@ -158,11 +165,11 @@ const Auth0Provider = ({
       try {
         await client.auth.passwordlessWithSMS(parameters);
       } catch (error) {
-        dispatch({type: 'ERROR', error});
+        dispatch({ type: 'ERROR', error });
         return;
       }
     },
-    [client],
+    [client]
   );
 
   const authorizeWithSMS = useCallback(
@@ -170,19 +177,19 @@ const Auth0Provider = ({
       try {
         let scope = finalizeScopeParam(parameters?.scope);
         if (scope) {
-          parameters = {...parameters, scope};
+          parameters = { ...parameters, scope };
         }
         const credentials = await client.auth.loginWithSMS(parameters);
         const user = getIdTokenProfileClaims(credentials.idToken);
 
         await client.credentialsManager.saveCredentials(credentials);
-        dispatch({type: 'LOGIN_COMPLETE', user});
+        dispatch({ type: 'LOGIN_COMPLETE', user });
       } catch (error) {
-        dispatch({type: 'ERROR', error});
+        dispatch({ type: 'ERROR', error });
         return;
       }
     },
-    [client],
+    [client]
   );
 
   const sendEmailCode = useCallback(
@@ -190,11 +197,11 @@ const Auth0Provider = ({
       try {
         await client.auth.passwordlessWithEmail(parameters);
       } catch (error) {
-        dispatch({type: 'ERROR', error});
+        dispatch({ type: 'ERROR', error });
         return;
       }
     },
-    [client],
+    [client]
   );
 
   const authorizeWithEmail = useCallback(
@@ -202,20 +209,20 @@ const Auth0Provider = ({
       try {
         let scope = finalizeScopeParam(parameters?.scope);
         if (scope) {
-          parameters = {...parameters, scope};
+          parameters = { ...parameters, scope };
         }
 
         const credentials = await client.auth.loginWithEmail(parameters);
         const user = getIdTokenProfileClaims(credentials.idToken);
 
         await client.credentialsManager.saveCredentials(credentials);
-        dispatch({type: 'LOGIN_COMPLETE', user});
+        dispatch({ type: 'LOGIN_COMPLETE', user });
       } catch (error) {
-        dispatch({type: 'ERROR', error});
+        dispatch({ type: 'ERROR', error });
         return;
       }
     },
-    [client],
+    [client]
   );
 
   const sendMultifactorChallenge = useCallback(
@@ -223,11 +230,11 @@ const Auth0Provider = ({
       try {
         await client.auth.multifactorChallenge(parameters);
       } catch (error) {
-        dispatch({type: 'ERROR', error});
+        dispatch({ type: 'ERROR', error });
         return;
       }
     },
-    [client],
+    [client]
   );
 
   const authorizeWithOOB = useCallback(
@@ -237,13 +244,13 @@ const Auth0Provider = ({
         const user = getIdTokenProfileClaims(credentials.idToken);
 
         await client.credentialsManager.saveCredentials(credentials);
-        dispatch({type: 'LOGIN_COMPLETE', user});
+        dispatch({ type: 'LOGIN_COMPLETE', user });
       } catch (error) {
-        dispatch({type: 'ERROR', error});
+        dispatch({ type: 'ERROR', error });
         return;
       }
     },
-    [client],
+    [client]
   );
 
   const authorizeWithOTP = useCallback(
@@ -253,13 +260,13 @@ const Auth0Provider = ({
         const user = getIdTokenProfileClaims(credentials.idToken);
 
         await client.credentialsManager.saveCredentials(credentials);
-        dispatch({type: 'LOGIN_COMPLETE', user});
+        dispatch({ type: 'LOGIN_COMPLETE', user });
       } catch (error) {
-        dispatch({type: 'ERROR', error});
+        dispatch({ type: 'ERROR', error });
         return;
       }
     },
-    [client],
+    [client]
   );
 
   const authorizeWithRecoveryCode = useCallback(
@@ -269,28 +276,28 @@ const Auth0Provider = ({
         const user = getIdTokenProfileClaims(credentials.idToken);
 
         await client.credentialsManager.saveCredentials(credentials);
-        dispatch({type: 'LOGIN_COMPLETE', user});
+        dispatch({ type: 'LOGIN_COMPLETE', user });
       } catch (error) {
-        dispatch({type: 'ERROR', error});
+        dispatch({ type: 'ERROR', error });
         return;
       }
     },
-    [client],
+    [client]
   );
 
   const hasValidCredentials = useCallback(
     async (minTtl: number = 0) => {
       return await client.credentialsManager.hasValidCredentials(minTtl);
     },
-    [client],
+    [client]
   );
 
   const clearCredentials = useCallback(async () => {
     try {
       await client.credentialsManager.clearCredentials();
-      dispatch({type: 'LOGOUT_COMPLETE'});
+      dispatch({ type: 'LOGOUT_COMPLETE' });
     } catch (error) {
-      dispatch({type: 'ERROR', error});
+      dispatch({ type: 'ERROR', error });
       return;
     }
   }, [client]);
@@ -301,7 +308,7 @@ const Auth0Provider = ({
       description?: string,
       cancelTitle?: string,
       fallbackTitle?: string,
-      strategy = LocalAuthenticationStrategy.deviceOwnerWithBiometrics,
+      strategy = LocalAuthenticationStrategy.deviceOwnerWithBiometrics
     ) => {
       try {
         await client.credentialsManager.requireLocalAuthentication(
@@ -309,14 +316,14 @@ const Auth0Provider = ({
           description,
           cancelTitle,
           fallbackTitle,
-          strategy,
+          strategy
         );
       } catch (error) {
-        dispatch({type: 'ERROR', error});
+        dispatch({ type: 'ERROR', error });
         return;
       }
     },
-    [],
+    []
   );
 
   const contextValue = useMemo(
@@ -353,7 +360,7 @@ const Auth0Provider = ({
       getCredentials,
       clearCredentials,
       requireLocalAuthentication,
-    ],
+    ]
   );
 
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2143,11 +2143,11 @@
   integrity sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==
 
 "@octokit/plugin-rest-endpoint-methods@^7.1.2":
-  version "7.2.1"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.1.tgz#0e086930c8b4470b0eabaa7d68b67fd1b245bb3a"
-  integrity sha512-UmlNrrcF+AXxcxhZslTt1a/8aDxUKH0trrt/mJCxEPrWbW1ZEc+6xxcd5/n0iw3b+Xo8UBJQUKDr71+vNCBpRQ==
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.2.tgz#d142bad316efa045693ae24737399498f6b4a97f"
+  integrity sha512-bNoDKPtCL3Au0aL1sKfYhJ8uuVJ/Z3B9I2tSs1Ib68Guojv+hk++FH8Sc9ul/YTZ6S5Xr39QwJzoRCJZFKYPLA==
   dependencies:
-    "@octokit/types" "^9.3.1"
+    "@octokit/types" "^10.0.0"
 
 "@octokit/request-error@^3.0.0":
   version "3.0.3"
@@ -2159,9 +2159,9 @@
     once "^1.4.0"
 
 "@octokit/request@^6.0.0":
-  version "6.2.5"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-6.2.5.tgz#7beef1065042998f7455973ef3f818e7b84d6ec2"
-  integrity sha512-z83E8UIlPNaJUsXpjD8E0V5o/5f+vJJNbNcBwVZsX3/vC650U41cOkTLjq4PKk9BYonQGOnx7N17gvLyNjgGcQ==
+  version "6.2.6"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-6.2.6.tgz#ff8f503c690f84e3ebd33d2d43e63c0a27ac50e0"
+  integrity sha512-T/waXf/xjie8Qn5IyFYAcI/HXvw9SPkcQWErGP9H471IWRDRCN+Gn/QOptPMAZRT4lJb2bLHxQfCXjU0mJRyng==
   dependencies:
     "@octokit/endpoint" "^7.0.0"
     "@octokit/request-error" "^3.0.0"
@@ -2185,10 +2185,17 @@
   resolved "https://registry.yarnpkg.com/@octokit/tsconfig/-/tsconfig-1.0.2.tgz#59b024d6f3c0ed82f00d08ead5b3750469125af7"
   integrity sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==
 
-"@octokit/types@^9.0.0", "@octokit/types@^9.2.3", "@octokit/types@^9.3.1":
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-9.3.1.tgz#9eb20390f8cfcc975635d813f9a2094efd4aa2dd"
-  integrity sha512-zfJzyXLHC42sWcn2kS+oZ/DRvFZBYCCbfInZtwp1Uopl1qh6pRg4NSP/wFX1xCOpXvEkctiG1sxlSlkZmzvxdw==
+"@octokit/types@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-10.0.0.tgz#7ee19c464ea4ada306c43f1a45d444000f419a4a"
+  integrity sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==
+  dependencies:
+    "@octokit/openapi-types" "^18.0.0"
+
+"@octokit/types@^9.0.0", "@octokit/types@^9.2.3":
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-9.3.2.tgz#3f5f89903b69f6a2d196d78ec35f888c0013cac5"
+  integrity sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
@@ -2205,9 +2212,9 @@
     graceful-fs "4.2.10"
 
 "@pnpm/npm-conf@^2.1.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@pnpm/npm-conf/-/npm-conf-2.2.0.tgz#221b4cfcde745d5f8928c25f391e5cc9d405b345"
-  integrity sha512-roLI1ul/GwzwcfcVpZYPdrgW2W/drLriObl1h+yLF5syc8/5ULWw2ALbCHUWF+4YltIqA3xFSbG4IwyJz37e9g==
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@pnpm/npm-conf/-/npm-conf-2.2.2.tgz#0058baf1c26cbb63a828f0193795401684ac86f0"
+  integrity sha512-UA91GwWPhFExt3IizW6bOeY/pQ0BkuNwKjk9iQW9KqxluGCrg4VenZ0/L+2Y0+ZOtme72EVvg6v0zo3AMQRCeA==
   dependencies:
     "@pnpm/config.env-replace" "^1.1.0"
     "@pnpm/network.ca-file" "^1.0.1"
@@ -4076,9 +4083,9 @@ camelcase@^7.0.1:
   integrity sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==
 
 caniuse-lite@^1.0.30001502:
-  version "1.0.30001502"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001502.tgz#f7e4a76eb1d2d585340f773767be1fefc118dca8"
-  integrity sha512-AZ+9tFXw1sS0o0jcpJQIXvFTOB/xGiQ4OQ2t98QX3NDn2EZTSRBC801gxrsGgViuq2ak/NLkNgSNEPtCr5lfKg==
+  version "1.0.30001503"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001503.tgz#88b6ff1b2cf735f1f3361dc1a15b59f0561aa398"
+  integrity sha512-Sf9NiF+wZxPfzv8Z3iS0rXM1Do+iOy2Lxvib38glFX+08TCYYYGR5fRJXk4d77C4AYwhUjgYgMsMudbh2TqCKw==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -5306,9 +5313,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.428:
-  version "1.4.429"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.429.tgz#055a2543ba8b1a847bebf521791715ec30f8d97b"
-  integrity sha512-COua8RvN548KwPFzKMrTjFbmDsQRgdi0zSAhmo70TwC1tfLOSqq8p09n+GkdF5buvzE/NEYn1dP3itbfhun9gg==
+  version "1.4.430"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.430.tgz#52693c812a81800fafb5b312c1a850142e2fc9eb"
+  integrity sha512-FytjTbGwz///F+ToZ5XSeXbbSaXalsVRXsz2mHityI5gfxft7ieW3HqFLkU5V1aIrY42aflICqbmFoDxW10etg==
 
 emittery@^0.10.2:
   version "0.10.2"


### PR DESCRIPTION
### Changes

This PR adds support for `forceRefresh` on Android (iOS pending in a separate PR).

Also, Android version was upgraded to 31 and `useAndroidX` specific in Gradle settings.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [X] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [X] All active GitHub checks have passed
