### PR TITLE
Fix Auth0 pod version to constant

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'React-Core'
-  s.dependency 'Auth0', '~> 2.3'
+  s.dependency 'Auth0', '2.3'
 end


### PR DESCRIPTION
### Changes
Using dynamic pod version to fetch the latest version of the Auth0.Swift SDK seems to break RNA. We have used fixed version because of this

### References
https://github.com/auth0/react-native-auth0/issues/646

### Testing
- [ ] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not
