### PR TITLE
Fix Auth0.Swift transitive dependencies

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -18,4 +18,6 @@ Pod::Spec.new do |s|
 
   s.dependency 'React-Core'
   s.dependency 'Auth0', '2.3.2'
+  s.dependency 'JWTDecode', '3.0.1'
+  s.dependency 'SimpleKeychain', '1.0.1'
 end


### PR DESCRIPTION
### Changes
Using dynamic pod version to fetch the latest version of the JWTDecode and SimpleKeychain SDK seems to break RNA. We have used fixed version because of this

### References
https://github.com/auth0/react-native-auth0/issues/646

### Testing
- [ ] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not
