### PR TITLE
[SDK-3881] Fix expo scheme clash issue

### DIFF
--- a/BREAKING-CHANGE.md
+++ b/BREAKING-CHANGE.md
@@ -7,3 +7,19 @@
 - Minimum supported version for iOS is bumped to 13
 - skipLegacyListener has been removed in `authorize` and `clearSession`
 - `customScheme` is now part of `ClearSessionOptions` instead of `ClearSessionParameters` in `clearSession`
+- Callback URL migration:
+  We are migrating the callback URL we use for the SDK to below:   
+  ```
+  iOS: {PRODUCT_BUNDLE_IDENTIFIER}.auth0://{DOMAIN}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
+  Android: {YOUR_APP_PACKAGE_NAME}.auth0://{DOMAIN}/android/{YOUR_APP_PACKAGE_NAME}/callback
+  ```
+  You can choose to migrate or not by following the below steps
+  - **If your project is built with Expo:**
+    - To keep things as it is, you don't have to do anything
+    - To migrate to new non-custom scheme flow.
+      - Remove custom scheme in app.json and `authorize()`.
+      - Run npx expo prebuild --clean (Any manual changes to Android or iOS folders will be lost)
+      - Add the new callback URL to Auth0 dashboard
+  - **If your project is built with Non Expo:**
+    - To keep things as it is, set `useLegacyCallbackUrl` to true in `authorize` and `clearSession`
+    - To migrate to new non-custom scheme flow, Add the new callback URL to Auth0 dashboard

--- a/plugin/src/__tests__/__snapshots__/withAuth0-test.ts.snap
+++ b/plugin/src/__tests__/__snapshots__/withAuth0-test.ts.snap
@@ -85,8 +85,8 @@ android {
     }
 
     defaultConfig {
-// @generated begin react-native-auth0-manifest-placeholder - expo prebuild (DO NOT MODIFY) sync-5c2b93e2cd1c118d64d307ce22e7a639e8ac8e15
-manifestPlaceholders = [auth0Domain: "sample.auth0.com", auth0Scheme: "com.auth0.sample"]
+// @generated begin react-native-auth0-manifest-placeholder - expo prebuild (DO NOT MODIFY) sync-390402dddcbdc956c1498501708569e2654135a0
+manifestPlaceholders = [auth0Domain: "sample.auth0.com", auth0Scheme: "com.auth0.sample.auth0"]
 // @generated end react-native-auth0-manifest-placeholder
         applicationId 'com.example.app'
         minSdkVersion rootProject.ext.minSdkVersion
@@ -399,7 +399,7 @@ exports[`addIOSAuth0ConfigInInfoPList should have the bundle identifier if schem
       {
         "CFBundleURLName": "auth0",
         "CFBundleURLSchemes": [
-          "com.sample.auth0",
+          "com.sample.auth0.auth0",
         ],
       },
     ],

--- a/plugin/src/withAuth0.ts
+++ b/plugin/src/withAuth0.ts
@@ -52,9 +52,13 @@ export const addAndroidAuth0Gradle = (
       throw Error('No auth0 domain specified in expo config');
     }
     const auth0Domain = props.domain;
+    let applicationId;
+    if (config.android?.package) {
+      applicationId = config.android?.package + APPLICATION_ID_SUFFIX;
+    }
     let auth0Scheme =
       props.customScheme ??
-      config.android?.package + APPLICATION_ID_SUFFIX ??
+      applicationId ??
       (() => {
         throw new Error(
           'No auth0 scheme specified or package found in expo config'
@@ -132,9 +136,13 @@ export const addIOSAuth0ConfigInInfoPList = (
   if (!config.modResults.CFBundleURLTypes) {
     config.modResults.CFBundleURLTypes = [];
   }
+  let bundleIdentifier;
+  if (config.ios?.bundleIdentifier) {
+    bundleIdentifier = config.ios?.bundleIdentifier + APPLICATION_ID_SUFFIX;
+  }
   let auth0Scheme =
     props.customScheme ??
-    config.ios?.bundleIdentifier + APPLICATION_ID_SUFFIX ??
+    bundleIdentifier ??
     (() => {
       throw new Error(
         'No auth0 scheme specified or bundle identifier found in expo config'

--- a/plugin/src/withAuth0.ts
+++ b/plugin/src/withAuth0.ts
@@ -9,6 +9,7 @@ import {
 } from 'expo/config-plugins';
 import { mergeContents } from './generateCode';
 
+let APPLICATION_ID_SUFFIX = '.auth0';
 let pkg: { name: string; version?: string } = {
   name: 'react-native-auth0',
 };
@@ -53,7 +54,7 @@ export const addAndroidAuth0Gradle = (
     const auth0Domain = props.domain;
     let auth0Scheme =
       props.customScheme ??
-      config.android?.package ??
+      config.android?.package + APPLICATION_ID_SUFFIX ??
       (() => {
         throw new Error(
           'No auth0 scheme specified or package found in expo config'
@@ -133,7 +134,7 @@ export const addIOSAuth0ConfigInInfoPList = (
   }
   let auth0Scheme =
     props.customScheme ??
-    config.ios?.bundleIdentifier ??
+    config.ios?.bundleIdentifier + APPLICATION_ID_SUFFIX ??
     (() => {
       throw new Error(
         'No auth0 scheme specified or bundle identifier found in expo config'

--- a/src/credentials-manager/index.ts
+++ b/src/credentials-manager/index.ts
@@ -68,7 +68,7 @@ class CredentialsManager {
    * @param {String} scope optional - the scope to request for the access token. If null is passed, the previous scope will be kept.
    * @param {String} minTtl optional - the minimum time in seconds that the access token should last before expiration.
    * @param {Object} parameters optional - additional parameters to send in the request to refresh expired credentials.
-   * @param {Object} forceRefresh optional - to force refresh the credentials. It will work only if the refresh token already exists.
+   * @param {Object} forceRefresh optional - to force refresh the credentials. It will work only if the refresh token already exists. For iOS, doing forceRefresh will not send the scope and addtional parameters. Since scope change already does force refresh, it is better to avoid force refresh is scope is being changed.
    * @returns {Promise}
    */
   async getCredentials(

--- a/src/internal-types.ts
+++ b/src/internal-types.ts
@@ -103,6 +103,7 @@ export type AgentParameters = {
 export type AgentLogoutOptions = {
   customScheme?: string;
   federated?: boolean;
+  useLegacyCallbackUrl?: boolean;
 };
 
 export interface AgentLoginOptions {
@@ -118,4 +119,5 @@ export interface AgentLoginOptions {
   leeway?: number;
   ephemeralSession?: boolean;
   additionalParameters?: { [key: string]: string };
+  useLegacyCallbackUrl?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export interface WebAuthorizeOptions {
   leeway?: number;
   ephemeralSession?: boolean;
   customScheme?: string;
+  useLegacyCallbackUrl?: boolean;
 }
 
 export interface ClearSessionParameters {
@@ -64,6 +65,7 @@ export interface ClearSessionParameters {
 
 export interface ClearSessionOptions {
   customScheme?: string;
+  useLegacyCallbackUrl?: boolean;
 }
 
 export interface GetUserOptions {

--- a/src/webauth/__tests__/agent.spec.js
+++ b/src/webauth/__tests__/agent.spec.js
@@ -138,17 +138,26 @@ describe('Agent', () => {
 
   describe('getScheme', () => {
     it('should return custom scheme', async () => {
-      await expect(agent.getScheme('custom')).toEqual('custom');
+      await expect(agent.getScheme(false, 'custom')).toEqual('custom');
+    });
+
+    it('should return custom scheme even if legacy behaviour set to true', async () => {
+      await expect(agent.getScheme(true, 'custom')).toEqual('custom');
     });
 
     it('should return bundle identifier', async () => {
       NativeModules.A0Auth0.bundleIdentifier = 'com.test';
-      await expect(agent.getScheme()).toEqual('com.test');
+      await expect(agent.getScheme()).toEqual('com.test.auth0');
     });
 
     it('should return bundle identifier lower cased', async () => {
       NativeModules.A0Auth0.bundleIdentifier = 'com.Test';
-      await expect(agent.getScheme()).toEqual('com.test');
+      await expect(agent.getScheme()).toEqual('com.test.auth0');
+    });
+
+    it('should return legacy scheme', async () => {
+      NativeModules.A0Auth0.bundleIdentifier = 'com.Test';
+      await expect(agent.getScheme(true)).toEqual('com.test');
     });
   });
 });

--- a/src/webauth/agent.ts
+++ b/src/webauth/agent.ts
@@ -31,7 +31,10 @@ class Agent {
       parameters.clientId,
       parameters.domain
     );
-    let scheme = this.getScheme(options.customScheme);
+    let scheme = this.getScheme(
+      options.useLegacyCallbackUrl ?? false,
+      options.customScheme
+    );
     return A0Auth0.webAuth(
       scheme,
       options.state,
@@ -60,7 +63,10 @@ class Agent {
       );
     }
     let federated = options.federated ?? false;
-    let scheme = this.getScheme(options.customScheme);
+    let scheme = this.getScheme(
+      options.useLegacyCallbackUrl ?? false,
+      options.customScheme
+    );
     await _ensureNativeModuleIsInitialized(
       NativeModules.A0Auth0,
       parameters.clientId,
@@ -70,8 +76,12 @@ class Agent {
     return A0Auth0.webAuthLogout(scheme, federated);
   }
 
-  getScheme(customScheme?: string) {
-    return customScheme ?? NativeModules.A0Auth0.bundleIdentifier.toLowerCase();
+  getScheme(useLegacyCustomSchemeBehaviour: boolean, customScheme?: string) {
+    let scheme = NativeModules.A0Auth0.bundleIdentifier.toLowerCase();
+    if (!useLegacyCustomSchemeBehaviour) {
+      scheme = scheme + '.auth0';
+    }
+    return customScheme ?? scheme;
   }
 }
 

--- a/src/webauth/index.ts
+++ b/src/webauth/index.ts
@@ -91,8 +91,8 @@ class WebAuth {
     return agent.logout(
       { clientId, domain },
       {
-        customScheme: options.customScheme,
-        federated: parameters.federated,
+        ...parameters,
+        ...options,
       }
     );
   }


### PR DESCRIPTION
### Changes
- Add `.auth0` suffix to end of scheme in callback URL to be unique from the callback URL used in frameworks like Expo.
- Provide `useLegacyCallbackUrl` option for non Expo users who don't want to migrate

⚠️ Breaking Change
We are migrating the callback URL we use in the SDK. Please follow the steps in BREAKING-CHANGE.md. Following flow chart shows an idea on how to go ahead with the migration
![callback-url-migration](https://github.com/auth0/react-native-auth0/assets/15910425/0f0f7cda-2968-4f08-ae2d-9dbd859ab037)
The new callback URLs are 
```
iOS: {PRODUCT_BUNDLE_IDENTIFIER}.auth0://{DOMAIN}/ios/{PRODUCT_BUNDLE_IDENTIFIER}/callback
Android: {YOUR_APP_PACKAGE_NAME}.auth0://{DOMAIN}/android/{YOUR_APP_PACKAGE_NAME}/callback
```

### References
https://github.com/auth0/react-native-auth0/pull/610

### Testing
- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not