### PR TITLE
[SDK-4365] Return credentials for authorize methods

### DIFF
--- a/src/hooks/__tests__/use-auth0.spec.jsx
+++ b/src/hooks/__tests__/use-auth0.spec.jsx
@@ -191,12 +191,19 @@ describe('The useAuth0 hook', () => {
     const { result, waitForNextUpdate } = renderHook(() => useAuth0(), {
       wrapper,
     });
-    result.current.authorize();
+    const promise = result.current.authorize();
 
     await waitForNextUpdate();
     expect(result.current.user).not.toBeNull();
     expect(mockAuth0.webAuth.authorize).toBeCalled();
     expect(mockAuth0.credentialsManager.saveCredentials).toBeCalled();
+
+    let credentials;
+    await act(async () => {credentials = await promise})
+    expect(credentials).toEqual({
+      idToken: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwiaXNzIjoiaHR0cHM6Ly9hdXRoMC5jb20iLCJhdWQiOiJjbGllbnQxMjMiLCJuYW1lIjoiVGVzdCBVc2VyIiwiZmFtaWx5X25hbWUiOiJVc2VyIiwicGljdHVyZSI6Imh0dHBzOi8vaW1hZ2VzL3BpYy5wbmcifQ==.c2lnbmF0dXJl',
+      accessToken: 'ACCESS TOKEN'
+    })
   });
 
   it('can authorize, passing through all parameters', async () => {
@@ -204,7 +211,7 @@ describe('The useAuth0 hook', () => {
       wrapper,
     });
 
-    result.current.authorize(
+    const promise = result.current.authorize(
       {
         scope: 'custom-scope',
         audience: 'http://my-api',
@@ -227,6 +234,12 @@ describe('The useAuth0 hook', () => {
         ephemeralSession: true,
       }
     );
+    let credentials;
+    await act(async () => {credentials = await promise})
+    expect(credentials).toEqual({
+      idToken: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwiaXNzIjoiaHR0cHM6Ly9hdXRoMC5jb20iLCJhdWQiOiJjbGllbnQxMjMiLCJuYW1lIjoiVGVzdCBVc2VyIiwiZmFtaWx5X25hbWUiOiJVc2VyIiwicGljdHVyZSI6Imh0dHBzOi8vaW1hZ2VzL3BpYy5wbmcifQ==.c2lnbmF0dXJl',
+      accessToken: 'ACCESS TOKEN'
+    })
   });
 
   it('can authorize, passing through all options', async () => {
@@ -358,7 +371,7 @@ describe('The useAuth0 hook', () => {
       wrapper,
     });
 
-    result.current.authorizeWithSMS({
+    let promise = result.current.authorizeWithSMS({
       phoneNumber: '+11234567890',
       code: '123456',
       scope: 'custom-scope',
@@ -373,6 +386,13 @@ describe('The useAuth0 hook', () => {
       scope: 'custom-scope openid profile email',
       audience: 'http://my-api',
     });
+
+    let credentials;
+    await act(async () => {credentials = await promise})
+    expect(credentials).toEqual({
+      idToken: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwiaXNzIjoiaHR0cHM6Ly9hdXRoMC5jb20iLCJhdWQiOiJjbGllbnQxMjMiLCJuYW1lIjoiVGVzdCBVc2VyIiwiZmFtaWx5X25hbWUiOiJVc2VyIiwicGljdHVyZSI6Imh0dHBzOi8vaW1hZ2VzL3BpYy5wbmcifQ==.c2lnbmF0dXJl',
+      accessToken: 'ACCESS TOKEN'
+    })
   });
 
   it('adds the default scopes when none are specified for SMS login', async () => {
@@ -465,7 +485,7 @@ describe('The useAuth0 hook', () => {
       wrapper,
     });
 
-    result.current.authorizeWithEmail({
+    let promise = result.current.authorizeWithEmail({
       email: 'foo@gmail.com',
       code: '123456',
       scope: 'custom-scope',
@@ -480,6 +500,13 @@ describe('The useAuth0 hook', () => {
       scope: 'custom-scope openid profile email',
       audience: 'http://my-api',
     });
+
+    let credentials;
+    await act(async () => {credentials = await promise})
+    expect(credentials).toEqual({
+      idToken: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwiaXNzIjoiaHR0cHM6Ly9hdXRoMC5jb20iLCJhdWQiOiJjbGllbnQxMjMiLCJuYW1lIjoiVGVzdCBVc2VyIiwiZmFtaWx5X25hbWUiOiJVc2VyIiwicGljdHVyZSI6Imh0dHBzOi8vaW1hZ2VzL3BpYy5wbmcifQ==.c2lnbmF0dXJl',
+      accessToken: 'ACCESS TOKEN'
+    })
   });
 
   it('adds the default scopes when none are specified for email login', async () => {
@@ -572,7 +599,7 @@ describe('The useAuth0 hook', () => {
       wrapper,
     });
 
-    result.current.authorizeWithOOB({
+    let promise = result.current.authorizeWithOOB({
       mfaToken: 'mfa_token',
       oobCode: 'oob_code',
       bindingCode: 'binding_code',
@@ -585,6 +612,13 @@ describe('The useAuth0 hook', () => {
       oobCode: 'oob_code',
       bindingCode: 'binding_code',
     });
+
+    let credentials;
+    await act(async () => {credentials = await promise})
+    expect(credentials).toEqual({
+      idToken: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwiaXNzIjoiaHR0cHM6Ly9hdXRoMC5jb20iLCJhdWQiOiJjbGllbnQxMjMiLCJuYW1lIjoiVGVzdCBVc2VyIiwiZmFtaWx5X25hbWUiOiJVc2VyIiwicGljdHVyZSI6Imh0dHBzOi8vaW1hZ2VzL3BpYy5wbmcifQ==.c2lnbmF0dXJl',
+      accessToken: 'ACCESS TOKEN'
+    })
   });
 
   it('sets the user prop after authorizing with OOB', async () => {
@@ -620,7 +654,7 @@ describe('The useAuth0 hook', () => {
       wrapper,
     });
 
-    result.current.authorizeWithOTP({
+    let promise = result.current.authorizeWithOTP({
       mfaToken: 'mfa_token',
       otp: 'otp',
     });
@@ -631,6 +665,13 @@ describe('The useAuth0 hook', () => {
       mfaToken: 'mfa_token',
       otp: 'otp',
     });
+
+    let credentials;
+    await act(async () => {credentials = await promise})
+    expect(credentials).toEqual({
+      idToken: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwiaXNzIjoiaHR0cHM6Ly9hdXRoMC5jb20iLCJhdWQiOiJjbGllbnQxMjMiLCJuYW1lIjoiVGVzdCBVc2VyIiwiZmFtaWx5X25hbWUiOiJVc2VyIiwicGljdHVyZSI6Imh0dHBzOi8vaW1hZ2VzL3BpYy5wbmcifQ==.c2lnbmF0dXJl',
+      accessToken: 'ACCESS TOKEN'
+    })
   });
 
   it('sets the user prop after authorizing with OTP', async () => {
@@ -666,7 +707,7 @@ describe('The useAuth0 hook', () => {
       wrapper,
     });
 
-    result.current.authorizeWithRecoveryCode({
+    let promise = result.current.authorizeWithRecoveryCode({
       mfaToken: 'mfa_token',
       recoveryCode: 'recovery_code',
     });
@@ -677,6 +718,13 @@ describe('The useAuth0 hook', () => {
       mfaToken: 'mfa_token',
       recoveryCode: 'recovery_code',
     });
+
+    let credentials;
+    await act(async () => {credentials = await promise})
+    expect(credentials).toEqual({
+      idToken: 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwiaXNzIjoiaHR0cHM6Ly9hdXRoMC5jb20iLCJhdWQiOiJjbGllbnQxMjMiLCJuYW1lIjoiVGVzdCBVc2VyIiwiZmFtaWx5X25hbWUiOiJVc2VyIiwicGljdHVyZSI6Imh0dHBzOi8vaW1hZ2VzL3BpYy5wbmcifQ==.c2lnbmF0dXJl',
+      accessToken: 'ACCESS TOKEN'
+    })
   });
 
   it('sets the user prop after authorizing with recovery code', async () => {

--- a/src/hooks/auth0-context.ts
+++ b/src/hooks/auth0-context.ts
@@ -27,7 +27,7 @@ export interface Auth0ContextInterface<TUser extends User = User>
   authorize: (
     parameters: WebAuthorizeParameters,
     options: WebAuthorizeOptions
-  ) => Promise<void>;
+  ) => Promise<Credentials | undefined>;
   /**
    * Start the passwordless SMS login flow. See {@link Auth#passwordlessWithSMS}
    */
@@ -35,7 +35,7 @@ export interface Auth0ContextInterface<TUser extends User = User>
   /**
    * Authorize the user using a SMS code. See {@link Auth#loginWithSMS}
    */
-  authorizeWithSMS: (parameters: LoginWithSMSOptions) => Promise<void>;
+  authorizeWithSMS: (parameters: LoginWithSMSOptions) => Promise<Credentials | undefined>;
   /**
    * Start the passwordless email login flow. See {@link Auth#passwordlessWithEmail}
    */
@@ -43,7 +43,7 @@ export interface Auth0ContextInterface<TUser extends User = User>
   /**
    * Authorize the user using an email code. See {@link Auth#loginWithEmail}
    */
-  authorizeWithEmail: (parameters: LoginWithEmailOptions) => Promise<void>;
+  authorizeWithEmail: (parameters: LoginWithEmailOptions) => Promise<Credentials | undefined>;
   /**
    * Send a challenge for multi-factor authentication. See {@link Auth#multifactorChallenge}
    */
@@ -53,17 +53,17 @@ export interface Auth0ContextInterface<TUser extends User = User>
   /**
    * Authorize the user using an Out Of Band authentication code. See {@link Auth#loginWithOOB}
    */
-  authorizeWithOOB: (parameters: LoginWithOOBOptions) => Promise<void>;
+  authorizeWithOOB: (parameters: LoginWithOOBOptions) => Promise<Credentials | undefined>;
   /**
    * Autohrize the user using a One Time Password code. See {@link Auth#loginWithOTP}.
    */
-  authorizeWithOTP: (parameters: LoginWithOTPOptions) => Promise<void>;
+  authorizeWithOTP: (parameters: LoginWithOTPOptions) => Promise<Credentials | undefined>;
   /**
    * Authorize the user using a multi-factor authentication Recovery Code. See {@link Auth#loginWithRecoveryCode}
    */
   authorizeWithRecoveryCode: (
     parameters: LoginWithRecoveryCodeOptions
-  ) => Promise<void>;
+  ) => Promise<Credentials | undefined>;
   /**
    * Whether the SDK currently holds valid, unexpired credentials.
    * @param minTtl The minimum time in seconds that the access token should last before expiration

--- a/src/hooks/auth0-provider.tsx
+++ b/src/hooks/auth0-provider.tsx
@@ -110,6 +110,7 @@ const Auth0Provider = ({
 
         await client.credentialsManager.saveCredentials(credentials);
         dispatch({ type: 'LOGIN_COMPLETE', user });
+        return credentials;
       } catch (error) {
         dispatch({ type: 'ERROR', error });
         return;
@@ -186,6 +187,7 @@ const Auth0Provider = ({
 
         await client.credentialsManager.saveCredentials(credentials);
         dispatch({ type: 'LOGIN_COMPLETE', user });
+        return credentials;
       } catch (error) {
         dispatch({ type: 'ERROR', error });
         return;
@@ -219,6 +221,7 @@ const Auth0Provider = ({
 
         await client.credentialsManager.saveCredentials(credentials);
         dispatch({ type: 'LOGIN_COMPLETE', user });
+        return credentials;
       } catch (error) {
         dispatch({ type: 'ERROR', error });
         return;
@@ -247,6 +250,7 @@ const Auth0Provider = ({
 
         await client.credentialsManager.saveCredentials(credentials);
         dispatch({ type: 'LOGIN_COMPLETE', user });
+        return credentials;
       } catch (error) {
         dispatch({ type: 'ERROR', error });
         return;
@@ -263,6 +267,7 @@ const Auth0Provider = ({
 
         await client.credentialsManager.saveCredentials(credentials);
         dispatch({ type: 'LOGIN_COMPLETE', user });
+        return credentials;
       } catch (error) {
         dispatch({ type: 'ERROR', error });
         return;
@@ -279,6 +284,7 @@ const Auth0Provider = ({
 
         await client.credentialsManager.saveCredentials(credentials);
         dispatch({ type: 'LOGIN_COMPLETE', user });
+        return credentials;
       } catch (error) {
         dispatch({ type: 'ERROR', error });
         return;


### PR DESCRIPTION
### Changes
The authorize methods currently doesn't return the credentials and instead we have to call `getCredentials`. This is unwanted call and inefficient to access file system when the credentials are already present. To handle this we return `Credentials` in all the authorize methods

### References
https://github.com/auth0/react-native-auth0/pull/640

Please note any links that are not publicly accessible.

### Testing
- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not