### PR TITLE
chore: fix docs build script

### DIFF
--- a/scripts/jsdocs.js
+++ b/scripts/jsdocs.js
@@ -3,15 +3,17 @@ if (process.platform === 'win32') {
   process.exit(1);
 }
 
-var library = require('../package.json');
 var execSync = require('child_process').execSync;
 var fs = require('fs');
 
-execSync('yarn run jsdocs', {stdio: 'inherit'});
+execSync('yarn docs', { stdio: 'inherit' });
+
 if (fs.existsSync('docs')) {
-  execSync('rm -r docs', {stdio: 'inherit'});
+  execSync('rm -r docs', { stdio: 'inherit' });
 }
-execSync(`mv out/react-native-auth0/${library.version}/ docs`, {
+
+execSync('mv out/ docs/', {
   stdio: 'inherit',
 });
+
 execSync('git add docs');


### PR DESCRIPTION
This PR fixes the docs build:

- publishes from the correct source folder `out/` as opposed to `out/react-native-auth0/{version}`
- uses the correct NPM script name `docs`

This was tested manually to verify correctness.