### PR TITLE
Add redirect URL to iOS login - new scheme changes

### DIFF
--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -140,7 +140,7 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
     }
 
     @ReactMethod
-    public void webAuth(String scheme, String state, String nonce, String audience, String scope, String connection, int maxAge, String organization, String invitationUrl, int leeway, boolean ephemeralSession, ReadableMap additionalParameters, Promise promise) {
+    public void webAuth(String scheme, String redirectUri, String state, String nonce, String audience, String scope, String connection, int maxAge, String organization, String invitationUrl, int leeway, boolean ephemeralSession, ReadableMap additionalParameters, Promise promise) {
         Map<String,String> cleanedParameters = new HashMap<>();
         for (Map.Entry<String, Object> entry : additionalParameters.toHashMap().entrySet()) {
             if (entry.getValue() != null) {
@@ -192,7 +192,7 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
     }
 
     @ReactMethod
-    public void webAuthLogout(String scheme, boolean federated, Promise promise) {
+    public void webAuthLogout(String scheme, boolean federated, String redirectUri, Promise promise) {
         WebAuthProvider.LogoutBuilder builder = WebAuthProvider.logout(this.auth0)
                 .withScheme(scheme);
         if(federated) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -96,7 +96,7 @@ android {
     namespace "com.auth0example"
     defaultConfig {
         applicationId "com.auth0example"
-        manifestPlaceholders = [auth0Domain: "brucke.auth0.com", auth0Scheme: "${applicationId}"]
+        manifestPlaceholders = [auth0Domain: "brucke.auth0.com", auth0Scheme: "${applicationId}.auth0"]
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1

--- a/example/ios/Auth0Example/Info.plist
+++ b/example/ios/Auth0Example/Info.plist
@@ -10,6 +10,19 @@
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>None</string>
+			<key>CFBundleURLName</key>
+			<string>auth0</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>$(PRODUCT_BUNDLE_IDENTIFIER).auth0</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/ios/A0Auth0.m
+++ b/ios/A0Auth0.m
@@ -50,12 +50,12 @@ RCT_EXPORT_METHOD(enableLocalAuthentication:(NSString *)title cancelTitle:(NSStr
     [self.nativeBridge enableLocalAuthenticationWithTitle:title cancelTitle:cancelTitle fallbackTitle:fallbackTitle evaluationPolicy: evaluationPolicy];
 }
 
-RCT_EXPORT_METHOD(webAuth:(NSString *)scheme state:(NSString *)state nonce:(NSString *)nonce audience:(NSString *)audience scope:(NSString *)scope connection:(NSString *)connection maxAge:(NSInteger)maxAge organization:(NSString *)organization invitationUrl:(NSString *)invitationUrl  leeway:(NSInteger)leeway ephemeralSession:(BOOL)ephemeralSession additionalParameters:(NSDictionary *)additionalParameters resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-    [self.nativeBridge webAuthWithState:state nonce:nonce audience:audience scope:scope connection:connection maxAge:maxAge organization:organization invitationUrl:invitationUrl leeway:leeway ephemeralSession:ephemeralSession additionalParameters:additionalParameters resolve:resolve reject:reject];
+RCT_EXPORT_METHOD(webAuth:(NSString *)scheme redirectUri:(NSString *)redirectUri state:(NSString *)state nonce:(NSString *)nonce audience:(NSString *)audience scope:(NSString *)scope connection:(NSString *)connection maxAge:(NSInteger)maxAge organization:(NSString *)organization invitationUrl:(NSString *)invitationUrl  leeway:(NSInteger)leeway ephemeralSession:(BOOL)ephemeralSession additionalParameters:(NSDictionary *)additionalParameters resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.nativeBridge webAuthWithState:state redirectUri:redirectUri nonce:nonce audience:audience scope:scope connection:connection maxAge:maxAge organization:organization invitationUrl:invitationUrl leeway:leeway ephemeralSession:ephemeralSession additionalParameters:additionalParameters resolve:resolve reject:reject];
 }
 
-RCT_EXPORT_METHOD(webAuthLogout:(NSString *)scheme federated:(BOOL)federated resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
-    [self.nativeBridge webAuthLogoutWithFederated:federated resolve:resolve reject:reject];
+RCT_EXPORT_METHOD(webAuthLogout:(NSString *)scheme federated:(BOOL)federated redirectUri:(NSString *)redirectUri resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    [self.nativeBridge webAuthLogoutWithFederated:federated redirectUri:redirectUri resolve:resolve reject:reject];
 }
 
 - (NSDictionary *)constantsToExport {

--- a/ios/NativeBridge.swift
+++ b/ios/NativeBridge.swift
@@ -39,8 +39,11 @@ public class NativeBridge: NSObject {
         super.init()
    }
     
-    @objc public func webAuth(state: String?, nonce: String?, audience: String?, scope: String?, connection: String?, maxAge: Int, organization: String?, invitationUrl: String?, leeway: Int, ephemeralSession: Bool, additionalParameters: [String: String], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    @objc public func webAuth(state: String?, redirectUri: String, nonce: String?, audience: String?, scope: String?, connection: String?, maxAge: Int, organization: String?, invitationUrl: String?, leeway: Int, ephemeralSession: Bool, additionalParameters: [String: String], resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         let builder = Auth0.webAuth(clientId: self.clientId, domain: self.domain)
+        if let value = URL(string: redirectUri) {
+            let _ = builder.redirectURL(value)
+        }
         if let value = state {
             let _ = builder.state(value)
         }
@@ -83,8 +86,11 @@ public class NativeBridge: NSObject {
             
     }
     
-    @objc public func webAuthLogout(federated: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    @objc public func webAuthLogout(federated: Bool, redirectUri: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         let builder = Auth0.webAuth(clientId: self.clientId, domain: self.domain)
+        if let value = URL(string: redirectUri) {
+            let _ = builder.redirectURL(value)
+        }
         builder.clearSession(federated: federated) { result in
                 switch result {
                 case .success:

--- a/src/internal-types.ts
+++ b/src/internal-types.ts
@@ -61,6 +61,7 @@ export type Auth0Module = {
   bundleIdentifier: string;
   webAuth: (
     scheme: string,
+    redirectUri: string,
     state?: string,
     nonce?: string,
     audience?: string,
@@ -73,7 +74,11 @@ export type Auth0Module = {
     ephemeralSession?: boolean,
     additionalParameters?: { [key: string]: string }
   ) => Promise<Credentials>;
-  webAuthLogout: (scheme: string, federated: boolean) => Promise<void>;
+  webAuthLogout: (
+    scheme: string,
+    federated: boolean,
+    redirectUri: string
+  ) => Promise<void>;
   saveCredentials: (credentials: Credentials) => Promise<void>;
   getCredentials: (
     scope?: string,

--- a/src/webauth/__tests__/agent.spec.js
+++ b/src/webauth/__tests__/agent.spec.js
@@ -161,4 +161,11 @@ describe('Agent', () => {
       await expect(agent.getScheme(true)).toEqual('com.test');
     });
   });
+
+
+  describe('callbackUri', () => {
+    it('should return callback uri with given domain and scheme', async () => {
+      await expect(agent.callbackUri('domain', 'scheme')).toEqual("scheme://domain/test-os/com.my.app/callback");
+    });
+  });
 });

--- a/src/webauth/__tests__/agent.spec.js
+++ b/src/webauth/__tests__/agent.spec.js
@@ -165,7 +165,7 @@ describe('Agent', () => {
 
   describe('callbackUri', () => {
     it('should return callback uri with given domain and scheme', async () => {
-      await expect(agent.callbackUri('domain', 'scheme')).toEqual("scheme://domain/test-os/com.my.app/callback");
+      await expect(agent.callbackUri('domain', 'scheme')).toEqual("scheme://domain/test-os/com.test/callback");
     });
   });
 });

--- a/src/webauth/__tests__/agent.spec.js
+++ b/src/webauth/__tests__/agent.spec.js
@@ -69,6 +69,7 @@ describe('Agent', () => {
       expect(mock).toBeCalledWith(NativeModules.A0Auth0, clientId, domain);
       expect(mockLogin).toBeCalledWith(
         'test',
+        'test://test.com/test-os/com.my.app/callback',
         'state',
         'nonce',
         'audience',
@@ -132,7 +133,7 @@ describe('Agent', () => {
         }
       );
       expect(mock).toBeCalledWith(NativeModules.A0Auth0, clientId, domain);
-      expect(mockLogin).toBeCalledWith('test', true);
+      expect(mockLogin).toBeCalledWith('test', true, 'test://test.com/test-os/com.my.app/callback');
     });
   });
 


### PR DESCRIPTION
### Changes
- iOS doesn't automatically pick up the scheme change similar to Android and it has to be set as a parameter in `redirectURL`. This has been achieved in this change. 
- Example app has new schemes implemented