### PR TITLE
Release v3.0.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-auth0",
   "title": "React Native Auth0",
-  "version": "3.0.0-beta.0",
+  "version": "3.0.0-beta.1",
   "description": "React Native toolkit for Auth0 API",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## [v3.0.0-beta.1](https://github.com/auth0/react-native-auth0/tree/v3.0.0-beta.0) (2023-07-07)

[Full Changelog](https://github.com/auth0/react-native-auth0/compare/v2.17.4...v3.0.0-beta.1)

💡 Check the [Migration Guide](MIGRATION_GUIDE.md) to understand the changes required to migrate your application to v3.

**Added**
- Credentials are returned as part of authorize methods in hooks
- Added sample app in the repository
- Expo plugin is updated to latest version
- Added 'openid profile email' as mandatory scopes
- Option to `forceRefresh` is added in `getCredentials`
- Added `hasValidCredentials` to hooks
- More options to authorize using Hooks
- `authorizeWithSMS`
- `authorizeWithEmail`
- `authorizeWithOOB`
- `authorizeWithOTP`
- `authorizeWithRecoveryCode`

**Changed**

- Custom Scheme is now optional in Expo
- Migrated the codebase to Typescript
- Use Native SDKs ([Auth0.Android](https://github.com/auth0/Auth0.Android/) and [Auth0.Swift](https://github.com/auth0/Auth0.Swift)) for Web Authentication
- `Credentials` object in Android will return `expiresIn` instead of `expiresAt`
- `max_age` parameter is changed to `maxAge` in `WebAuth.authorize()`
- `customScheme` is now part of `ClearSessionOptions` instead of `ClearSessionParameters` in `clearSession`
- Minimum supported version for iOS is bumped to 13
- Revoke Token and Change Password now return `void` instead of an empty object

**Removed**
- Removed the `type` property returned in the `Credentials` object in Android. Use `tokenType` instead.
- `skipLegacyListener` has been removed in `authorize` and `clearSession`