### PR TITLE
Release v3.0.0 beta.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,4 +34,4 @@ workflows:
             branches:
               only:
                 - master
-                # - vnext
+                - vnext

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 
-## [v3.0.0-beta.0](https://github.com/auth0/react-native-auth0/tree/v3.0.0-beta.0) (2023-07-07)
+## [v3.0.0-beta.2](https://github.com/auth0/react-native-auth0/tree/v3.0.0-beta.2) (2023-07-10)
 
-[Full Changelog](https://github.com/auth0/react-native-auth0/compare/v2.17.4...v3.0.0-beta.0)
+[Full Changelog](https://github.com/auth0/react-native-auth0/compare/v2.17.4...v3.0.0-beta.2)
 
 💡 Check the [Migration Guide](MIGRATION_GUIDE.md) to understand the changes required to migrate your application to v3.
 


### PR DESCRIPTION
## [v3.0.0-beta.2](https://github.com/auth0/react-native-auth0/tree/v3.0.0-beta.2) (2023-07-10)

[Full Changelog](https://github.com/auth0/react-native-auth0/compare/v2.17.4...v3.0.0-beta.2)

💡 Check the [Migration Guide](MIGRATION_GUIDE.md) to understand the changes required to migrate your application to v3.

**Added**
- Credentials are returned as part of authorize methods in hooks
- Added sample app in the repository
- Expo plugin is updated to latest version
- Added 'openid profile email' as mandatory scopes
- Option to `forceRefresh` is added in `getCredentials`
- Added `hasValidCredentials` to hooks
- More options to authorize using Hooks
- `authorizeWithSMS`
- `authorizeWithEmail`
- `authorizeWithOOB`
- `authorizeWithOTP`
- `authorizeWithRecoveryCode`

**Changed**

- Custom Scheme is now optional in Expo
- Migrated the codebase to Typescript
- Use Native SDKs ([Auth0.Android](https://github.com/auth0/Auth0.Android/) and [Auth0.Swift](https://github.com/auth0/Auth0.Swift)) for Web Authentication
- `Credentials` object in Android will return `expiresIn` instead of `expiresAt`
- `max_age` parameter is changed to `maxAge` in `WebAuth.authorize()`
- `customScheme` is now part of `ClearSessionOptions` instead of `ClearSessionParameters` in `clearSession`
- Minimum supported version for iOS is bumped to 13
- Revoke Token and Change Password now return `void` instead of an empty object

**Removed**
- Removed the `type` property returned in the `Credentials` object in Android. Use `tokenType` instead.
- `skipLegacyListener` has been removed in `authorize` and `clearSession`

**Supported Versions**
- Minimum supported version for iOS is bumped to 13
- Minimum supported version for Expo is bumped to 48