### PR TITLE
Export types as part of root

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { TimeoutError } from './utils/fetchWithTimeout';
 export { default as useAuth0 } from './hooks/use-auth0';
 export { default as Auth0Provider } from './hooks/auth0-provider';
 export { default as LocalAuthenticationStrategy } from './credentials-manager/localAuthenticationStrategy';
+export * from './types';
 
 import Auth0 from './auth0';
 export default Auth0;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["example"]
+  "exclude": ["example", "lib", "docs", "scripts", "babel.config.js", "jest.environment.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "baseUrl": "./",
     "paths": {
-      "react-native-auth0": ["./index"]
+      "react-native-auth0": ["./src/index"]
     },
     "module": "esnext",
     "allowJs": true,
@@ -24,15 +24,5 @@
     "declaration": true,
     "declarationDir": "./lib/typescript/",
     "outDir": "./lib/typescript"
-  },
-  "exclude": [
-    "node_modules",
-    "babel.config.js",
-    "metro.config.js",
-    "jest.config.js",
-    "./dist",
-    "**/__mocks__/**",
-    "**/__tests__/**",
-    "./lib"
-  ]
+  }
 }


### PR DESCRIPTION
### Changes
- We are exporting all the external types through root now.
- Typescript currently packages some of the unwanted files in the package. Previous exclude didn't work as `tsconfig.build.json` overrides it
- The path refers to root package

### References
https://github.com/auth0/react-native-auth0/issues/675

### Testing
- [ ] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not
