### PR TITLE
chore: Expand `.semgrepignore` exclusions to tests

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,1 +1,12 @@
+.circleci/
+.github/
 docs/
+src/auth/__tests__
+src/credentials-manager/__tests__
+src/hooks/__tests__
+src/jwt/__tests__
+src/management/__tests__
+src/networking/__tests__
+src/utils/__tests__
+src/webauth/__mocks__
+src/webauth/__tests__

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,5 +1,3 @@
-.circleci/
-.github/
 docs/
 src/auth/__tests__
 src/credentials-manager/__tests__


### PR DESCRIPTION
This PR expands the `.semgrepignore` manifest file to exclude test-related directories to avoid triggering false positives.