### PR TITLE
[SDK-4416] Support Organisation Name

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'React-Core'
-  s.dependency 'Auth0', '2.4.0'
+  s.dependency 'Auth0', '2.5.0'
   s.dependency 'JWTDecode', '3.1.0'
   s.dependency 'SimpleKeychain', '1.1.0'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ repositories {
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactnativeVersion', '+')}"
     implementation "androidx.browser:browser:1.2.0"
-    implementation 'com.auth0.android:auth0:2.9.2'
+    implementation 'com.auth0.android:auth0:2.10.0'
 }
 
 def configureReactNativePom(def pom) {


### PR DESCRIPTION
### Changes
This PR checks for (org_name) claim when organisation parameter is used with Organisation Name instead of Organisation ID.

### References
https://github.com/auth0/Auth0.Android/pull/669
https://github.com/auth0/Auth0.swift/pull/782