### PR TITLE
Fix `expiresIn` in iOS has an incorrect value

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
-  - A0Auth0 (3.0.0-beta.2):
-    - Auth0 (= 2.4.0)
+  - A0Auth0 (3.0.0-beta.3):
+    - Auth0 (= 2.5.0)
     - JWTDecode (= 3.1.0)
     - React-Core
     - SimpleKeychain (= 1.1.0)
-  - Auth0 (2.4.0):
+  - Auth0 (2.5.0):
     - JWTDecode (~> 3.1)
     - SimpleKeychain (~> 1.1)
   - boost (1.76.0)
@@ -584,8 +584,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  A0Auth0: 34a88d6ea01d78133e7d228384d07b840162c7ea
-  Auth0: 7c454e679f19d160f1f32bf1e9fa095db19f8769
+  A0Auth0: 9b09cdadf55316a7169a046ad4acaa73f0060cfa
+  Auth0: 72f19ad566fdf57f07bf37f828afd0c1570769a5
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
@@ -640,4 +640,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 78e8dab006d0d9a82e41a924fda07d925d4623c7
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.12.1

--- a/ios/NativeBridge.swift
+++ b/ios/NativeBridge.swift
@@ -109,9 +109,9 @@ public class NativeBridge: NSObject {
         let scope = credentialsDict[NativeBridge.scopeKey] as? String
         var expiresIn: Date?
          if let string = credentialsDict[NativeBridge.expiresInKey] as? String, let double = Double(string) {
-             expiresIn = Date(timeIntervalSinceNow: double)
+             expiresIn = Date(timeIntervalSince1970: double)
          } else if let double = credentialsDict[NativeBridge.expiresInKey] as? Double {
-             expiresIn = Date(timeIntervalSinceNow: double)
+             expiresIn = Date(timeIntervalSince1970: double)
          } else if let dateStr = credentialsDict[NativeBridge.expiresInKey] as? String {
              let dateFormatter = DateFormatter()
              dateFormatter.dateFormat = NativeBridge.dateFormat


### PR DESCRIPTION
### Changes
This issue is occuring since web authentication returns `timeIntervalSince1970` but save credentials used `timeIntervalSinceNow`. This is fixed in this change.

### References
https://github.com/auth0/react-native-auth0/issues/684

### Testing
Tested the changes manually