### PR TITLE
Fix migration guide to add Android Callback URL in `build.gradle`

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -48,5 +48,31 @@ Choose one of the following migration paths depending on your application:
     - Run `npx expo prebuild --clean` (any manual changes to Android or iOS folders will be lost)
     - Add the new callback URL to Auth0 dashboard
 - **If your project is built with Non Expo:**
+
   - To keep things as it is, set `useLegacyCallbackUrl` to true in `authorize` and `clearSession`
   - To migrate to new non-custom scheme flow, add the new callback URL to Auth0 dashboard
+  - Replace the manifest placeholders in your app's build.gradle file (typically at android/app/build.gradle) from:
+
+  **Old**
+
+```
+  android {
+    defaultConfig {
+        manifestPlaceholders = [auth0Domain: "YOUR_AUTH0_DOMAIN", auth0Scheme: "${applicationId}"]
+    }
+    ...
+}
+```
+
+**New**
+
+Notice the new `.auth0` suffix in auth0Scheme:
+
+```
+android {
+    defaultConfig {
+        manifestPlaceholders = [auth0Domain: "YOUR_AUTH0_DOMAIN", auth0Scheme: "${applicationId}.auth0"]
+    }
+    ...
+}
+```

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -53,7 +53,7 @@ Choose one of the following migration paths depending on your application:
 
   - To keep things as it is, set `useLegacyCallbackUrl` to true in `authorize` and `clearSession`
   - To migrate to new non-custom scheme flow, add the new callback URL to Auth0 dashboard
-  - Replace the manifest placeholders in your app's build.gradle file (typically at android/app/build.gradle) from:
+  - Change the manifest placeholders in your app's build.gradle file (typically at android/app/build.gradle):
 
   **Old**
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 📚 [Documentation](#documentation) • 🚀 [Getting Started](#getting-started) • ⏭️ [Next Steps](#next-steps) • ❓ [FAQs](https://github.com/auth0/react-native-auth0/blob/master/FAQ.md) • ❓ [Feedback](#feedback)
 
-## ⚠️ Important Migration Notice: v3.0.0
+### ⚠️ Important Migration Notice: v3.0.0
 
 We're excited to announce the release of react-native-auth0 v3.0.0! Please note that this update includes breaking changes that require your attention. To ensure a smooth transition, please review our
 👉 [Migration Guide](https://github.com/auth0/react-native-auth0/blob/master/MIGRATION_GUIDE.md) 👈 for detailed instructions on updating your integration.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 
 📚 [Documentation](#documentation) • 🚀 [Getting Started](#getting-started) • ⏭️ [Next Steps](#next-steps) • ❓ [FAQs](https://github.com/auth0/react-native-auth0/blob/master/FAQ.md) • ❓ [Feedback](#feedback)
 
+## ⚠️ Important Migration Notice: v3.0.0
+
+We're excited to announce the release of react-native-auth0 v3.0.0! Please note that this update includes breaking changes that require your attention. To ensure a smooth transition, please review our
+👉 [Migration Guide](https://github.com/auth0/react-native-auth0/blob/master/MIGRATION_GUIDE.md) 👈 for detailed instructions on updating your integration.
+
 ## Documentation
 
 - [Quickstart](https://auth0.com/docs/quickstart/native/react-native/interactive)


### PR DESCRIPTION
### Changes
Fixed migration guide to add update to build.gradle
Added migration guide notice to README

### References
https://github.com/auth0/react-native-auth0/issues/704