### PR TITLE
Make `hasValidCredentials` parameter optional

### DIFF
--- a/src/hooks/auth0-context.ts
+++ b/src/hooks/auth0-context.ts
@@ -77,7 +77,7 @@ export interface Auth0ContextInterface<TUser extends User = User>
    * @param minTtl The minimum time in seconds that the access token should last before expiration
    * @returns `true` if there are valid credentials. Otherwise, `false`.
    */
-  hasValidCredentials: (minTtl: number) => Promise<boolean>;
+  hasValidCredentials: (minTtl?: number) => Promise<boolean>;
   /**
    * Clears the user's web session, credentials and logs them out. See {@link WebAuth#clearSession}
    * @param parameters Additional parameters to send to the Auth0 logout endpoint.


### PR DESCRIPTION
### Changes
`hasValidCredentials` only requires an optional parameter. This is update in the type declaration to reflect the same.

### References
https://github.com/auth0/react-native-auth0/issues/711
