### PR TITLE
Remove CircleCI tests config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   codecov: codecov/codecov@3
 
 jobs:
-  build:
+  pre-publish:
     executor:
       name: ship/node
       tag: 18.16.0
@@ -13,20 +13,22 @@ jobs:
       - checkout
       - ship/node-install-packages:
           pkg-manager: yarn
-      - run: yarn run test:ci
-      - codecov/upload:
-          file: coverage/coverage-final.json
 
 workflows:
-  build-and-test:
+  publish:
     jobs:
-      - build
+      - pre-publish:
+          filters:
+            branches:
+              only:
+                - master
+
       - ship/node-publish:
           node-version: 18.16.0
           pkg-manager: yarn
           publish-command: npm publish
           requires:
-            - build
+            - pre-publish
           context:
             - publish-npm
             - publish-gh


### PR DESCRIPTION
### Changes

This PR updates the CircleCI config to remove the test and Codecov steps, now that the build & test workflows have been migrated to GitHub Actions.

The remaining CircleCI config pertaining to package publishing was left in place, as it uses our CircleCI orb, which hasn't been updated to use GitHub Actions yet.

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
