### PR TITLE
Use Dependabot to update GH actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
### Changes

This PR sets up Dependabot to check for updates of the GitHub actions in use, which are pinned to a specific SHA.

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
