### PR TITLE
Fix `cancel-in-progress` in GH Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+    cancel-in-progress: true
 
 jobs:
     test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: ${{ github.ref == 'refs/heads/master' }}
+    cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
     test:


### PR DESCRIPTION
### Changes

This PR fixes the `cancel-in-progress` concurrency config in the GH Actions workflow. Given that the workflow is only configured to run on pull requests, the previous configuration does not really apply.

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
