### PR TITLE
Update Auth0.Android to resolve CVE-2023-3635

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -56,7 +56,7 @@ repositories {
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactnativeVersion', '+')}"
     implementation "androidx.browser:browser:1.2.0"
-    implementation 'com.auth0.android:auth0:2.10.0'
+    implementation 'com.auth0.android:auth0:2.10.2'
 }
 
 def configureReactNativePom(def pom) {


### PR DESCRIPTION
We are updating Auth0.Android which has transitive dependency to okio from OkHttp to fix https://github.com/advisories/GHSA-w33c-445m-f8w7.