### PR TITLE
Fix metadata type in `CreateUserOptions`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -522,7 +522,7 @@ export interface CreateUserOptions {
   /**
    * Additional information that will be stored in `user_metadata`
    */
-  metadata?: string;
+  metadata?: object;
   [key: string]: any;
 }
 


### PR DESCRIPTION
### Changes
Fixes the `user_metadata` type `CreateUserOptions` to accept an object instead of string

### References
https://github.com/auth0/react-native-auth0/issues/758

### Testing
I have tested the changes manually
