### PR TITLE
Support additional parameters for forceRefresh in iOS

### DIFF
--- a/ios/NativeBridge.swift
+++ b/ios/NativeBridge.swift
@@ -134,7 +134,7 @@ public class NativeBridge: NSObject {
     
     @objc public func getCredentials(scope: String?, minTTL: Int, parameters: [String: Any], forceRefresh: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         if(forceRefresh) {
-            credentialsManager.renew { result in
+            credentialsManager.renew(parameters: parameters) { result in
                 switch result {
                 case .success(let credentials):
                     resolve(credentials.asDictionary())

--- a/src/credentials-manager/index.ts
+++ b/src/credentials-manager/index.ts
@@ -56,7 +56,7 @@ class CredentialsManager {
    * @param scope The scope to request for the access token. If null is passed, the previous scope will be kept.
    * @param minTtl The minimum time in seconds that the access token should last before expiration.
    * @param parameters Additional parameters to send in the request to refresh expired credentials.
-   * @param forceRefresh Whether to force refresh the credentials. It will work only if the refresh token already exists. For iOS, doing forceRefresh will not send the scope and addtional parameters. Since scope change already does force refresh, it is better to avoid force refresh if the scope is being changed.
+   * @param forceRefresh Whether to force refresh the credentials. It will work only if the refresh token already exists. For iOS, doing forceRefresh will not send the scope. Since scope change already does force refresh, it is better to avoid force refresh if the scope is being changed.
    * @returns A populated instance of {@link Credentials}.
    */
   async getCredentials(


### PR DESCRIPTION
### Changes
Previously we were not passing `parameters` when `forceRefresh` was true **only in iOS**. We are fixing this issue by passing this value along to the native layer.

### References
There has been internal requests to fix this issue

### Testing
We have done manual tests. We couldn't write unit tests as the native layer is currently not covered by our unit tests.

- [ ] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not
