### PR TITLE
Remove build package as publish does it automatically

### DIFF
--- a/.github/actions/publish-package/action.yml
+++ b/.github/actions/publish-package/action.yml
@@ -20,11 +20,6 @@ runs:
         cache: 'npm'
         registry-url: 'https://registry.npmjs.org'
 
-    - name: Build package
-      uses: ./.github/actions/build
-      with:
-        ${{ inputs.node-version }}
-
     - name: Publish release to NPM
       run: npm publish
       shell: bash


### PR DESCRIPTION
### Changes
Remove build action as publish does it automatically and the action is missing

### Reference
https://github.com/auth0/react-native-auth0/actions/runs/7129536408/job/19413827588
