### PR TITLE
Use outputs for capturing release-notes

### DIFF
--- a/.github/actions/get-release-notes/action.yml
+++ b/.github/actions/get-release-notes/action.yml
@@ -1,12 +1,11 @@
 name: Return the release notes extracted from the PR body
-
 #
 # Returns the release notes from the content of a pull request linked to a release branch. It expects the branch name to be in the format release/vX.Y.Z, release/X.Y.Z, release/vX.Y.Z-beta.N. etc.
 #
 # TODO: Remove once the common repo is public.
 #
 inputs:
-  version :
+  version:
     required: true
   repo_name:
     required: false
@@ -15,28 +14,26 @@ inputs:
   token:
     required: true
 
+outputs:
+  release-notes:
+    value: ${{ steps.get_release_notes.outputs.RELEASE_NOTES }}
+
 runs:
   using: composite
 
   steps:
-    - id: get_release_notes
-      shell: bash
-      run: |
-        RELEASE_PR_BRANCH="release/$VERSION"
-        API_URL="https://api.github.com/repos/$REPO_OWNER/$REPO_NAME/pulls"
-        RELEASE_NOTES=$(curl -G \
-        -H "Accept: application/json" \
-        -H "Authorization: token $GITHUB_TOKEN" \
-        --data-urlencode "state=all" \
-        --data-urlencode "head=$REPO_OWNER:$RELEASE_PR_BRANCH" \
-        "$API_URL" | jq -r ".[0].body"
-        )
-        {
-          echo 'RELEASE_NOTES<<EOF'
-          echo $RELEASE_NOTES
-          echo 'EOF'
-        } >> $GITHUB_ENV
-
+    - uses: actions/github-script@v7
+      id: get_release_notes
+      with:
+        result-encoding: string
+        script: |
+          const { data: pulls } = await github.rest.pulls.list({
+            owner: process.env.REPO_OWNER,
+            repo: process.env.REPO_NAME,
+            state: 'all',
+            head: `${process.env.REPO_OWNER}:release/${process.env.VERSION}`,
+          });
+          core.setOutput('RELEASE_NOTES', pulls[0].body);
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
         REPO_OWNER: ${{ inputs.repo_owner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ steps.get_version.outputs.version }}
-          body: ${{ env.RELEASE_NOTES }}
+          body: ${{ steps.get_release_notes.outputs.release-notes }}
           tag: ${{ steps.get_version.outputs.version }}
           commit: ${{ github.sha }}
           prerelease: ${{ steps.get_prerelease.outputs.prerelease }}


### PR DESCRIPTION
### Changes

Aligns the release-notes actions with others by using the github-scripts as well as ensuring we use outputs for capturing the release notes rather than relying on an environment variable.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All code quality tools/guidelines have been run/followed
