### PR TITLE
Fix the authParams type 

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -349,7 +349,7 @@ export interface PasswordlessWithEmailOptions {
   /**
    * Optional parameters, used when strategy is 'linḱ'
    */
-  authParams?: string;
+  authParams?: object;
   [key: string]: any;
 }
 
@@ -368,7 +368,7 @@ export interface PasswordlessWithSMSOptions {
   /**
    * Optional passwordless parameters
    */
-  authParams?: string;
+  authParams?: object;
   [key: string]: any;
 }
 


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

`authParams` in `PasswordlessWithEmailOptions` and `PasswordlessWithSMSOptions` should be an object, when passes as a `string`, it will throw an error `bad.authParams: error in authParams - invalid type: string (expected object)`

- Fix the authParams type in PasswordlessWithEmailOptions and PasswordlessWithSMSOptions. It should be an object



### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
