### PR TITLE
Feature: Added refreshToken and saveCredentials to auth0 hook

### DIFF
--- a/src/hooks/auth0-context.ts
+++ b/src/hooks/auth0-context.ts
@@ -14,6 +14,7 @@ import {
   WebAuthorizeParameters,
   PasswordlessWithSMSOptions,
   ClearSessionOptions,
+  RefreshTokenOptions,
 } from '../types';
 import LocalAuthenticationStrategy from '../credentials-manager/localAuthenticationStrategy';
 
@@ -101,6 +102,23 @@ export interface Auth0ContextInterface<TUser extends User = User>
     minTtl?: number,
     parameters?: Record<string, unknown>,
     forceRefresh?: boolean
+  ) => Promise<Credentials | undefined>;
+   /**
+   * Manually saves the user's credentials to the native credential store.
+   * by default. See {@link CredentialsManager#getCredentials}
+   * @returns
+   */
+  saveCredentials: (
+    credentials:Credentials
+  ) => Promise<Credentials | undefined>;
+   /**
+   * Obtain new tokens using the Refresh Token obtained during Auth (requesting `offline_access` scope)
+   *
+   * @returns A populated instance of {@link Credentials}.
+   * @see https://auth0.com/docs/tokens/refresh-token/current#use-a-refresh-token
+   */
+  refreshToken: (
+    refreshTokenOptions: RefreshTokenOptions
   ) => Promise<Credentials | undefined>;
   /**
    * Clears the user's credentials without clearing their web session and logs them out.

--- a/src/hooks/auth0-provider.tsx
+++ b/src/hooks/auth0-provider.tsx
@@ -173,10 +173,6 @@ const Auth0Provider = ({
           credentials
         );
         const newCredentials = await getCredentials()
-        if (newCredentials.idToken) {
-          const user = getIdTokenProfileClaims(newCredentials.idToken);
-          dispatch({ type: 'SET_USER', user });
-        }
         return newCredentials;
       } catch (error) {
         dispatch({ type: 'ERROR', error });

--- a/src/hooks/auth0-provider.tsx
+++ b/src/hooks/auth0-provider.tsx
@@ -22,6 +22,7 @@ import {
   MultifactorChallengeOptions,
   PasswordlessWithEmailOptions,
   PasswordlessWithSMSOptions,
+  RefreshTokenOptions,
   User,
   WebAuthorizeOptions,
   WebAuthorizeParameters,
@@ -150,6 +151,48 @@ const Auth0Provider = ({
           parameters,
           forceRefresh
         );
+        if (credentials.idToken) {
+          const user = getIdTokenProfileClaims(credentials.idToken);
+          dispatch({ type: 'SET_USER', user });
+        }
+        return credentials;
+      } catch (error) {
+        dispatch({ type: 'ERROR', error });
+        return;
+      }
+    },
+    [client]
+  );
+
+   const saveCredentials = useCallback(
+    async (
+     credentials: Credentials
+    ): Promise<Credentials | undefined> => {
+      try {
+        await client.credentialsManager.saveCredentials(
+          credentials
+        );
+        const newCredentials = await getCredentials()
+        if (newCredentials.idToken) {
+          const user = getIdTokenProfileClaims(newCredentials.idToken);
+          dispatch({ type: 'SET_USER', user });
+        }
+        return newCredentials;
+      } catch (error) {
+        dispatch({ type: 'ERROR', error });
+        return;
+      }
+    },
+    [client]
+  );
+
+   const refreshToken = useCallback(
+    async (
+      refreshTokenOptions: RefreshTokenOptions
+    ): Promise<Credentials | undefined> => {
+      try {
+        const credentials = await client.auth.refreshToken(refreshTokenOptions);
+
         if (credentials.idToken) {
           const user = getIdTokenProfileClaims(credentials.idToken);
           dispatch({ type: 'SET_USER', user });
@@ -351,6 +394,8 @@ const Auth0Provider = ({
       getCredentials,
       clearCredentials,
       requireLocalAuthentication,
+      refreshToken,
+      saveCredentials
     }),
     [
       state,
@@ -368,6 +413,8 @@ const Auth0Provider = ({
       getCredentials,
       clearCredentials,
       requireLocalAuthentication,
+      refreshToken,
+      saveCredentials
     ]
   );
 

--- a/src/hooks/auth0-provider.tsx
+++ b/src/hooks/auth0-provider.tsx
@@ -192,12 +192,8 @@ const Auth0Provider = ({
     ): Promise<Credentials | undefined> => {
       try {
         const credentials = await client.auth.refreshToken(refreshTokenOptions);
-
-        if (credentials.idToken) {
-          const user = getIdTokenProfileClaims(credentials.idToken);
-          dispatch({ type: 'SET_USER', user });
-        }
-        return credentials;
+        const newCredentials = saveCredentials(credentials)
+        return newCredentials;
       } catch (error) {
         dispatch({ type: 'ERROR', error });
         return;

--- a/src/hooks/use-auth0.ts
+++ b/src/hooks/use-auth0.ts
@@ -25,7 +25,9 @@ import Auth0Context, { Auth0ContextInterface } from './auth0-context';
  *   clearSession,
  *   getCredentials,
  *   clearCredentials,
- *   requireLocalAuthentication
+ *   requireLocalAuthentication,
+ *   refreshToken,
+ *   saveCredentials
  * } = useAuth0();
  * ```
  * 


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

I've added refreshToken and saveCredentials to the auth0 hook for implementations requiring custom handling. For my use case at my professional job, we need to handle the refreshToken a certain way according to biometrics permissions and other factors.

### References

Please include relevant links supporting this change such as a:

https://github.com/auth0/react-native-auth0/issues/625

Please note any links that are not publicly accessible.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
