### PR TITLE
Update A0Auth0.podspec

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'React-Core'
-  s.dependency 'Auth0', '2.5.0'
+  s.dependency 'Auth0', '2.7.0'
   s.dependency 'JWTDecode', '3.1.0'
   s.dependency 'SimpleKeychain', '1.1.0'
 end


### PR DESCRIPTION
### Changes
This PR bumps the Auht0.Swift dependency which has the Privacy Manifest support. This will bring Privacy Manifest support for RNA as well.

### References
https://github.com/auth0/Auth0.swift/pull/841
https://github.com/auth0/Auth0.swift/pull/842

### Testing
We haven't tested this as it is a simple version bump.

- [ ] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
