### PR TITLE
feat: initial tvOS support

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.homepage     = package['repository']['baseUrl']
   s.license      = package['license']
   s.authors      = package['author']
-  s.platforms    = { :ios => '13.0' }
+  s.platforms    = { :ios => '13.0', :tvos => '14.0' }
   s.source       = { :git => 'https://github.com/auth0/react-native-auth0.git', :tag => "v#{s.version}" }
 
   s.source_files = 'ios/**/*.{h,m,mm,swift}'

--- a/README.md
+++ b/README.md
@@ -37,12 +37,23 @@ The following shows platform minimums for running projects with this SDK:
 | Platform | Minimum version |
 | -------- | :-------------: |
 | iOS      |      13.0       |
+| tvOS     |      14.0       |
 | Android  |       28        |
+
+**iOS**
 
 Our SDK requires a minimum iOS deployment target of 13.0. In your project's ios/Podfile, ensure your platform target is set to 13.0.
 
 ```
 platform :ios, '13.0'
+```
+
+**tvOS**
+
+Our SDK requires a minimum tvOS deployment target of 14.0. In your project's ios/Podfile, ensure your platform target is set to 14.0.
+
+```
+platform :tvos, '14.0'
 ```
 
 ### Installation

--- a/ios/NativeBridge.swift
+++ b/ios/NativeBridge.swift
@@ -37,6 +37,8 @@ public class NativeBridge: NSObject {
         self.domain = domain
         self.credentialsManager = CredentialsManager(authentication: auth0)
         super.init()
+        
+        #if os(iOS)
         if let localAuthenticationOptions = localAuthenticationOptions {
             if let title = localAuthenticationOptions["title"] as? String {
                 var evaluationPolicy = LAPolicy.deviceOwnerAuthenticationWithBiometrics
@@ -51,6 +53,8 @@ public class NativeBridge: NSObject {
                 return
             }
         }
+        #endif
+        
         resolve(true)
    }
     
@@ -106,7 +110,7 @@ public class NativeBridge: NSObject {
                     reject(error.reactNativeErrorCode(), error.errorDescription, error)
                 }
             }
-        #endif    
+        #endif
     }
 
     @objc public func webAuthLogout(federated: Bool, redirectUri: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
@@ -242,6 +246,7 @@ extension Credentials {
     }
 }
 
+#if os(iOS)
 extension WebAuthError {
     func reactNativeErrorCode() -> String {
         var code: String
@@ -262,6 +267,7 @@ extension WebAuthError {
         return code
     }
 }
+#endif
 
 extension CredentialsManagerError {
     func reactNativeErrorCode() -> String {
@@ -280,7 +286,7 @@ extension CredentialsManagerError {
                 code = cause.code
             } else {
                 code = "REVOKE_FAILED"
-            } 
+            }
             case .largeMinTTL: code = "LARGE_MIN_TTL"
             default: code = "UNKNOWN"
         }


### PR DESCRIPTION
### Changes

The [Auth0.swift](https://github.com/auth0/Auth0.swift?tab=readme-ov-file#requirements) library supports tvOS, but when trying to link `react-native-auth0` to a tvOS project, there are compilation issues in its native swift bridging code due to accessing APIs that aren't available on tvOS (e.g. `Auth0.webAuth`, `WebAuthentication` etc).

This PR add `tvos` as a supported platform in the `react-native-auth0` podspec and wraps applicable pieces of the native swift bridging code in `#if os(tvOS) .. #else .. ##endif` statements.

This allows the `react-native-auth0` lib to be compiled for tvOS whilst not changing the iOS side at all.

### References

### Testing

* Verified code changes build and run successfully on a tvOS RN project.
* Verified code changes build and run successfully on an iOS RN project.

- [ ] ~This change adds unit test coverage~
- [ ] This change has been tested on the latest version of the platform/language

### Checklist

- [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
