### PR TITLE
Moved the package name to namespace in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -67,6 +67,7 @@ def configureReactNativePom(def pom) {
         artifactId packageJson.name
         version = packageJson.version
         group = "com.auth0.react"
+        namespace = "com.auth0.react"
         description packageJson.description
         url packageJson.repository.baseUrl
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <!--Ignore rule required due to the 'queries' tag, fix only available for targetSdk=30 -->
 <!--suppress AndroidElementNotAllowed -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.auth0.react">
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
 </manifest>


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Endpoints added, deleted, deprecated, or changed
- Classes and methods added, deleted, deprecated, or changed
- Screenshots of new or changed UI, if applicable
- A summary of usage if this is a new feature or change to a public API (this should also be added to relevant documentation once released)

The namespace now has been moved from the AndroidManifest.xml to the build.gradle. This makes this library unusable for any react native version above 0.73. This is the correct fix.

### References

Please include relevant links supporting this change such as a:

- support ticket
- community post
- StackOverflow post
- support forum thread

Please note any links that are not publicly accessible.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [ x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x ] All existing and new tests complete without errors
- [x ] All active GitHub checks have passed
