### PR TITLE
Update top level hook to facilitate `exchangeNativeSocial` sign-in flows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@speechmatics/react-native-auth0",
+  "name": "react-native-auth0",
   "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@speechmatics/react-native-auth0",
+      "name": "react-native-auth0",
       "version": "4.0.1",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "react-native-auth0",
-  "version": "4.0.0",
+  "name": "@speechmatics/react-native-auth0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "react-native-auth0",
-      "version": "4.0.0",
+      "name": "@speechmatics/react-native-auth0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "base-64": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@speechmatics/react-native-auth0",
+  "name": "react-native-auth0",
   "title": "React Native Auth0",
   "version": "4.0.1",
   "description": "React Native toolkit for Auth0 API",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "react-native-auth0",
+  "name": "@speechmatics/react-native-auth0",
   "title": "React Native Auth0",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "React Native toolkit for Auth0 API",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/hooks/auth0-context.ts
+++ b/src/hooks/auth0-context.ts
@@ -14,6 +14,8 @@ import {
   WebAuthorizeParameters,
   PasswordlessWithSMSOptions,
   ClearSessionOptions,
+  ExchangeNativeSocialOptions,
+  RevokeOptions,
 } from '../types';
 
 export interface Auth0ContextInterface<TUser extends User = User>
@@ -72,6 +74,13 @@ export interface Auth0ContextInterface<TUser extends User = User>
     parameters: LoginWithRecoveryCodeOptions
   ) => Promise<Credentials | undefined>;
   /**
+   * Exchange an external token obtained via a native social authentication solution for the user's tokens.
+   * See {@link Auth#exchangeNativeSocial}
+   */
+  exchangeNativeSocial: (
+    parameters: ExchangeNativeSocialOptions
+  ) => Promise<Credentials | undefined>;
+  /**
    * Whether the SDK currently holds valid, unexpired credentials.
    * @param minTtl The minimum time in seconds that the access token should last before expiration
    * @returns `true` if there are valid credentials. Otherwise, `false`.
@@ -105,6 +114,10 @@ export interface Auth0ContextInterface<TUser extends User = User>
    * Clears the user's credentials without clearing their web session and logs them out.
    */
   clearCredentials: () => Promise<void>;
+  /**
+   *Revokes an issued refresh token. See {@link Auth#revoke}
+   */
+  revoke: (parameters: RevokeOptions) => Promise<void>;
 }
 
 export interface AuthState<TUser extends User = User> {
@@ -139,10 +152,12 @@ const initialContext = {
   authorizeWithOOB: stub,
   authorizeWithOTP: stub,
   authorizeWithRecoveryCode: stub,
+  exchangeNativeSocial: stub,
   hasValidCredentials: stub,
   clearSession: stub,
   getCredentials: stub,
   clearCredentials: stub,
+  revoke: stub,
 };
 
 const Auth0Context = createContext<Auth0ContextInterface>(initialContext);

--- a/src/hooks/auth0-provider.tsx
+++ b/src/hooks/auth0-provider.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useEffect,
-  useReducer,
-  useState,
-  PropsWithChildren,
-} from 'react';
+import React, { useEffect, useReducer, PropsWithChildren } from 'react';
 import { useCallback, useMemo } from 'react';
 import jwtDecode from 'jwt-decode';
 import PropTypes from 'prop-types';
@@ -14,6 +9,7 @@ import {
   ClearSessionOptions,
   ClearSessionParameters,
   Credentials,
+  ExchangeNativeSocialOptions,
   LoginWithEmailOptions,
   LoginWithOOBOptions,
   LoginWithOTPOptions,
@@ -22,6 +18,7 @@ import {
   MultifactorChallengeOptions,
   PasswordlessWithEmailOptions,
   PasswordlessWithSMSOptions,
+  RevokeOptions,
   User,
   WebAuthorizeOptions,
   WebAuthorizeParameters,
@@ -301,6 +298,23 @@ const Auth0Provider = ({
     [client]
   );
 
+  const exchangeNativeSocial = useCallback(
+    async (parameters: ExchangeNativeSocialOptions) => {
+      try {
+        const credentials = await client.auth.exchangeNativeSocial(parameters);
+        const user = getIdTokenProfileClaims(credentials.idToken);
+
+        await client.credentialsManager.saveCredentials(credentials);
+        dispatch({ type: 'LOGIN_COMPLETE', user });
+        return credentials;
+      } catch (error) {
+        dispatch({ type: 'ERROR', error });
+        return;
+      }
+    },
+    [client]
+  );
+
   const hasValidCredentials = useCallback(
     async (minTtl: number = 0) => {
       return await client.credentialsManager.hasValidCredentials(minTtl);
@@ -318,6 +332,13 @@ const Auth0Provider = ({
     }
   }, [client]);
 
+  const revoke = useCallback(
+    (parameters: RevokeOptions) => {
+      return client.auth.revoke(parameters);
+    },
+    [client]
+  );
+
   const contextValue = useMemo(
     () => ({
       ...state,
@@ -330,10 +351,12 @@ const Auth0Provider = ({
       authorizeWithOOB,
       authorizeWithOTP,
       authorizeWithRecoveryCode,
+      exchangeNativeSocial,
       hasValidCredentials,
       clearSession,
       getCredentials,
       clearCredentials,
+      revoke,
     }),
     [
       state,
@@ -346,10 +369,12 @@ const Auth0Provider = ({
       authorizeWithOOB,
       authorizeWithOTP,
       authorizeWithRecoveryCode,
+      exchangeNativeSocial,
       hasValidCredentials,
       clearSession,
       getCredentials,
       clearCredentials,
+      revoke,
     ]
   );
 


### PR DESCRIPTION

### Changes

This PR exposes two more functions from the top level `useAuth0` hook:

- `revoke` Exposes the Auth0 SDK function for revoking refresh tokens
- `exchangeNativeSocial`: Exposes the option for a Native social exchange

### References

The reason we forked the SDK was to more easily implement native Apple ID sign-in on our React Native app, following the guidance in this documentation: https://auth0.com/docs/authenticate/identity-providers/social-identity-providers/apple-native

### Testing

- [x] Native social exchange works on our iOS app
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

Happy to make an issue/discussion before proceeding with this PR if that's the usual flow. We're already maintaining this fork though and using it in production, so it should be ready to go.

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [ ] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed
