### PR TITLE
fix: Interop Layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-auth0",
-  "version": "4.1.0-interop.0",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-auth0",
-      "version": "4.1.0-interop.0",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "base-64": "^0.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-auth0",
-  "version": "4.0.0",
+  "version": "4.1.0-interop.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-auth0",
-      "version": "4.0.0",
+      "version": "4.1.0-interop.0",
       "license": "MIT",
       "dependencies": {
         "base-64": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-auth0",
   "title": "React Native Auth0",
-  "version": "4.1.0-interop.0",
+  "version": "4.0.0",
   "description": "React Native toolkit for Auth0 API",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-auth0",
   "title": "React Native Auth0",
-  "version": "4.0.0",
+  "version": "4.1.0-interop.0",
   "description": "React Native toolkit for Auth0 API",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",
@@ -200,11 +200,6 @@
         }
       ]
     ]
-  },
-  "codegenConfig": {
-    "name": "RNAuth0Spec",
-    "type": "modules",
-    "jsSrcsDir": "src"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This PR removes the `codegenConfig` which was caused builds to fail when running under the new architecture. This is also inline with the reactwg recommendation:

> If you have already added a Codegen spec to your library, but the library is not fully converted to TurboModules/Fabric, we recommend that you delete it before proceeding. You can add this back when you are ready to convert your library to natively use TurboModules/Fabric without the Interop Layer.

The changes have been tested with a sample app using the following React Native versions:

* 0.77.0
* 0.76
* 0.70.15

A follow-up PR will contain a complete migration to Turbo Modules.

The release is versioned as `4.1.0-interop.0` and should be tagged as `@interop`.