### PR TITLE
fix: Interop Layer 

### DIFF
--- a/package.json
+++ b/package.json
@@ -201,11 +201,6 @@
       ]
     ]
   },
-  "codegenConfig": {
-    "name": "RNAuth0Spec",
-    "type": "modules",
-    "jsSrcsDir": "src"
-  },
   "husky": {
     "hooks": {
       "pre-commit": "pretty-quick --staged"


### PR DESCRIPTION
Creating seperate PR for #1037 due to issues in Github organizational setup. Credits goes to @guabu for contributing this for us.

### Changes
This PR removes the `codegenConfig` which was caused builds to fail when running under the new architecture. This is also inline with the reactwg recommendation:

> If you have already added a Codegen spec to your library, but the library is not fully converted to TurboModules/Fabric, we recommend that you delete it before proceeding. You can add this back when you are ready to convert your library to natively use TurboModules/Fabric without the Interop Layer.

The changes have been tested with a sample app using the following React Native versions:

* 0.77.0
* 0.76
* 0.70.15

A follow-up PR will contain a complete migration to Turbo Modules.

### References
https://github.com/auth0/react-native-auth0/pull/1037

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
