### PR TITLE
Update android sdk version to v3.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following shows platform minimums for running projects with this SDK:
 | Platform | Minimum version |
 | -------- | :-------------: |
 | iOS      |      13.0       |
-| Android  |       28        |
+| Android  |       34        |
 
 Our SDK requires a minimum iOS deployment target of 13.0. In your project's ios/Podfile, ensure your platform target is set to 13.0.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -19,10 +19,10 @@ apply plugin: 'maven-publish'
 
 // Matches values in recent template from React Native 0.62
 // https://github.com/facebook/react-native/blob/0.62-stable/template/android/build.gradle#L5-L8
-def DEFAULT_COMPILE_SDK_VERSION = 28
+def DEFAULT_COMPILE_SDK_VERSION = 34
 def DEFAULT_BUILD_TOOLS_VERSION = "28.0.3"
 def DEFAULT_MIN_SDK_VERSION = 16
-def DEFAULT_TARGET_SDK_VERSION = 28
+def DEFAULT_TARGET_SDK_VERSION = 34
 
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
@@ -57,7 +57,7 @@ repositories {
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactnativeVersion', '+')}"
     implementation "androidx.browser:browser:1.2.0"
-    implementation 'com.auth0.android:auth0:3.0.0-beta.0'
+    implementation 'com.auth0.android:auth0:3.2.1'
 }
 
 def configureReactNativePom(def pom) {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -153,7 +153,7 @@ dependencies {
     implementation("com.facebook.react:react-android")
 
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.0.0")
-
+    implementation("org.jetbrains:annotations:16.0.2")
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}")
     debugImplementation("com.facebook.flipper:flipper-network-plugin:${FLIPPER_VERSION}") {
         exclude group:'com.squareup.okhttp3', module:'okhttp'

--- a/example/android/app/src/main/java/com/auth0example/MainApplication.java
+++ b/example/android/app/src/main/java/com/auth0example/MainApplication.java
@@ -10,6 +10,13 @@ import com.facebook.react.defaults.DefaultReactNativeHost;
 import com.facebook.soloader.SoLoader;
 import java.util.List;
 
+import android.content.Context;
+import android.content.BroadcastReceiver;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+import org.jetbrains.annotations.Nullable;
+
 public class MainApplication extends Application implements ReactApplication {
 
   private final ReactNativeHost mReactNativeHost =
@@ -47,6 +54,15 @@ public class MainApplication extends Application implements ReactApplication {
   @Override
   public ReactNativeHost getReactNativeHost() {
     return mReactNativeHost;
+  }
+
+  @Override
+  public Intent registerReceiver(@Nullable BroadcastReceiver receiver, IntentFilter filter) {
+      if (Build.VERSION.SDK_INT >= 34 && getApplicationInfo().targetSdkVersion >= 34) {
+          return super.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED);
+      } else {
+          return super.registerReceiver(receiver, filter);
+      }
   }
 
   @Override

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,8 +4,8 @@ buildscript {
     ext {
         buildToolsVersion = "33.0.0"
         minSdkVersion = 21
-        compileSdkVersion = 33
-        targetSdkVersion = 33
+        compileSdkVersion = 34
+        targetSdkVersion = 34
 
         // We use NDK 23 which has both M1 support and is the side-by-side NDK version from AGP.
         ndkVersion = "23.1.7779620"


### PR DESCRIPTION
### Changes
- Upgraded the version of the underlying [android:auth0](https://github.com/auth0/Auth0.Android/releases/tag/3.2.1) sdk version to `v3.2.1`

### References
- Refer [github-issue](https://github.com/facebook/react-native/issues/41288) for more details on the changes done to fix the errors observed on upgrade to Android 34.
- Fixes #1038  


### Testing

- [ ] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
