### PR TITLE
Change type of authParams to object in PasswordlessWithSMSOptions and…

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -349,7 +349,7 @@ export interface PasswordlessWithEmailOptions {
   /**
    * Optional parameters, used when strategy is 'linḱ'
    */
-  authParams?: string;
+  authParams?: object;
   [key: string]: any;
 }
 
@@ -368,7 +368,7 @@ export interface PasswordlessWithSMSOptions {
   /**
    * Optional passwordless parameters
    */
-  authParams?: string;
+  authParams?: object;
   [key: string]: any;
 }
 


### PR DESCRIPTION
### Changes
- Changed the type of authParams to object in `PasswordlessWithSMSOptions` and in `PasswordlessWithEmailOptions`

### References
- This PR is a contribution from [ben-qiu](https://github.com/ben-qiu)  (Refer #849 )

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
