### PR TITLE
Expose generic error codes for CredentialsManagerError

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,31 @@ try {
 }
 ```
 
+**Platform agnostic errors:**
+
+You can access the platform agnostic generic error codes as below :
+
+```js
+try {
+  const credentials = await auth0.credentialsManager.getCredentials();
+} catch (error) {
+  console.log(e.generic_error_code);
+}
+```
+
+| Generic Error Code    | Corresponding Error Code in Android                                                                                                                                                                                                                                                                                                              | Corresponding Error Code in iOS |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------- |
+| `INVALID_CREDENTIALS` | `INVALID_CREDENTIALS`                                                                                                                                                                                                                                                                                                                            |                                 |
+| `NO_CREDENTIALS`      | `NO_CREDENTIALS`                                                                                                                                                                                                                                                                                                                                 | `noCredentials`                 |
+| `NO_REFRESH_TOKEN`    | `NO_REFRESH_TOKEN`                                                                                                                                                                                                                                                                                                                               | `noRefreshToken`                |
+| `RENEW_FAILED`        | `RENEW_FAILED`                                                                                                                                                                                                                                                                                                                                   | `renewFailed`                   |
+| `STORE_FAILED`        | `STORE_FAILED`                                                                                                                                                                                                                                                                                                                                   | `storeFailed`                   |
+| `REVOKE_FAILED`       | `REVOKE_FAILED`                                                                                                                                                                                                                                                                                                                                  | `revokeFailed`                  |
+| `LARGE_MIN_TTL`       | `LARGE_MIN_TTL`                                                                                                                                                                                                                                                                                                                                  | `largeMinTTL`                   |
+| `INCOMPATIBLE_DEVICE` | `INCOMPATIBLE_DEVICE`                                                                                                                                                                                                                                                                                                                            |                                 |
+| `CRYPTO_EXCEPTION`    | `CRYPTO_EXCEPTION`                                                                                                                                                                                                                                                                                                                               |                                 |
+| `BIOMETRICS_FAILED`   | OneOf <br>`BIOMETRIC_NO_ACTIVITY`,`BIOMETRIC_ERROR_STATUS_UNKNOWN`,`BIOMETRIC_ERROR_UNSUPPORTED`,<br>`BIOMETRIC_ERROR_HW_UNAVAILABLE`,`BIOMETRIC_ERROR_NONE_ENROLLED`,`BIOMETRIC_ERROR_NO_HARDWARE`,<br>`BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED`,`BIOMETRIC_AUTHENTICATION_CHECK_FAILED`,<br>`BIOMETRIC_ERROR_DEVICE_CREDENTIAL_NOT_AVAILABLE` | `biometricsFailed`              |
+
 ## Feedback
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -501,9 +501,11 @@ You can access the platform agnostic generic error codes as below :
 try {
   const credentials = await auth0.credentialsManager.getCredentials();
 } catch (error) {
-  console.log(e.generic_error_code);
+  console.log(e.type);
 }
 ```
+
+_Note_ : We have platform agnostic error codes available only for `CredentialsManagerError` as of now.
 
 | Generic Error Code    | Corresponding Error Code in Android                                                                                                                                                                                                                                                                                                              | Corresponding Error Code in iOS |
 | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------- |
@@ -517,6 +519,8 @@ try {
 | `INCOMPATIBLE_DEVICE` | `INCOMPATIBLE_DEVICE`                                                                                                                                                                                                                                                                                                                            |                                 |
 | `CRYPTO_EXCEPTION`    | `CRYPTO_EXCEPTION`                                                                                                                                                                                                                                                                                                                               |                                 |
 | `BIOMETRICS_FAILED`   | OneOf <br>`BIOMETRIC_NO_ACTIVITY`,`BIOMETRIC_ERROR_STATUS_UNKNOWN`,`BIOMETRIC_ERROR_UNSUPPORTED`,<br>`BIOMETRIC_ERROR_HW_UNAVAILABLE`,`BIOMETRIC_ERROR_NONE_ENROLLED`,`BIOMETRIC_ERROR_NO_HARDWARE`,<br>`BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED`,`BIOMETRIC_AUTHENTICATION_CHECK_FAILED`,<br>`BIOMETRIC_ERROR_DEVICE_CREDENTIAL_NOT_AVAILABLE` | `biometricsFailed`              |
+| `NO_NETWORK`          | `NO_NETWORK`                                                                                                                                                                                                                                                                                                                                     |                                 |
+| `API_ERROR`           | `API_ERROR`                                                                                                                                                                                                                                                                                                                                      |                                 |
 
 ## Feedback
 

--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -30,6 +30,43 @@ import java.util.Map;
 
 public class A0Auth0Module extends ReactContextBaseJavaModule implements ActivityEventListener {
 
+    public static final Map<CredentialsManagerException, String> ERROR_CODE_MAP = new HashMap<>() {{
+        put(CredentialsManagerException.Companion.getINVALID_CREDENTIALS(), "INVALID_CREDENTIALS");
+        put(CredentialsManagerException.Companion.getNO_CREDENTIALS(), "NO_CREDENTIALS");
+        put(CredentialsManagerException.Companion.getNO_REFRESH_TOKEN(), "NO_REFRESH_TOKEN");
+        put(CredentialsManagerException.Companion.getRENEW_FAILED(), "RENEW_FAILED");
+        put(CredentialsManagerException.Companion.getSTORE_FAILED(), "STORE_FAILED");
+        put(CredentialsManagerException.Companion.getREVOKE_FAILED(), "REVOKE_FAILED");
+        put(CredentialsManagerException.Companion.getLARGE_MIN_TTL(), "LARGE_MIN_TTL");
+        put(CredentialsManagerException.Companion.getINCOMPATIBLE_DEVICE(), "INCOMPATIBLE_DEVICE");
+        put(CredentialsManagerException.Companion.getCRYPTO_EXCEPTION(), "CRYPTO_EXCEPTION");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_NO_ACTIVITY(), "BIOMETRIC_NO_ACTIVITY");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_STATUS_UNKNOWN(), "BIOMETRIC_ERROR_STATUS_UNKNOWN");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_UNSUPPORTED(), "BIOMETRIC_ERROR_UNSUPPORTED");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_HW_UNAVAILABLE(), "BIOMETRIC_ERROR_HW_UNAVAILABLE");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_NONE_ENROLLED(), "BIOMETRIC_ERROR_NONE_ENROLLED");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_NO_HARDWARE(), "BIOMETRIC_ERROR_NO_HARDWARE");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED(), "BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_AUTHENTICATION_CHECK_FAILED(), "BIOMETRIC_AUTHENTICATION_CHECK_FAILED");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_DEVICE_CREDENTIAL_NOT_AVAILABLE(), "BIOMETRIC_ERROR_DEVICE_CREDENTIAL_NOT_AVAILABLE");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_STRONG_AND_DEVICE_CREDENTIAL_NOT_AVAILABLE(), "BIOMETRIC_ERROR_STRONG_AND_DEVICE_CREDENTIAL_NOT_AVAILABLE");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_NO_DEVICE_CREDENTIAL(), "BIOMETRIC_ERROR_NO_DEVICE_CREDENTIAL");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_NEGATIVE_BUTTON(), "BIOMETRIC_ERROR_NEGATIVE_BUTTON");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_HW_NOT_PRESENT(), "BIOMETRIC_ERROR_HW_NOT_PRESENT");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_NO_BIOMETRICS(), "BIOMETRIC_ERROR_NO_BIOMETRICS");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_USER_CANCELED(), "BIOMETRIC_ERROR_USER_CANCELED");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_LOCKOUT_PERMANENT(), "BIOMETRIC_ERROR_LOCKOUT_PERMANENT");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_VENDOR(), "BIOMETRIC_ERROR_VENDOR");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_LOCKOUT(), "BIOMETRIC_ERROR_LOCKOUT");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_CANCELED(), "BIOMETRIC_ERROR_CANCELED");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_NO_SPACE(), "BIOMETRIC_ERROR_NO_SPACE");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_TIMEOUT(), "BIOMETRIC_ERROR_TIMEOUT");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_ERROR_UNABLE_TO_PROCESS(), "BIOMETRIC_ERROR_UNABLE_TO_PROCESS");
+        put(CredentialsManagerException.Companion.getBIOMETRICS_INVALID_USER(), "BIOMETRICS_INVALID_USER");
+        put(CredentialsManagerException.Companion.getBIOMETRIC_AUTHENTICATION_FAILED(), "BIOMETRIC_AUTHENTICATION_FAILED");
+        put(CredentialsManagerException.Companion.getAPI_ERROR(), "API_ERROR");
+        put(CredentialsManagerException.Companion.getNO_NETWORK(), "NO_NETWORK");
+    }};
     private static final String CREDENTIAL_MANAGER_ERROR_CODE = "a0.invalid_state.credential_manager_exception";
     private static final String INVALID_DOMAIN_URL_ERROR_CODE = "a0.invalid_domain_url";
     private static final String BIOMETRICS_AUTHENTICATION_ERROR_CODE = "a0.invalid_options_biometrics_authentication";
@@ -122,9 +159,14 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
 
                     @Override
                     public void onFailure(@NonNull CredentialsManagerException e) {
-                        promise.reject(CREDENTIAL_MANAGER_ERROR_CODE, e.getMessage(), e);
+                        String errorCode = deduceErrorCode(e);
+                        promise.reject(errorCode, e.getMessage(), e);
                     }
                 }));
+    }
+
+    private String deduceErrorCode(@NonNull CredentialsManagerException e) {
+        return ERROR_CODE_MAP.getOrDefault(e, CREDENTIAL_MANAGER_ERROR_CODE);
     }
 
     @ReactMethod
@@ -133,7 +175,8 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
             this.secureCredentialsManager.saveCredentials(CredentialsParser.fromMap(credentials));
             promise.resolve(true);
         } catch (CredentialsManagerException e) {
-            promise.reject(CREDENTIAL_MANAGER_ERROR_CODE, e.getMessage(), e);
+            String errorCode = deduceErrorCode(e);
+            promise.reject(errorCode, e.getMessage(), e);
         }
     }
 

--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -30,7 +30,7 @@ import java.util.Map;
 
 public class A0Auth0Module extends ReactContextBaseJavaModule implements ActivityEventListener {
 
-    public static final Map<CredentialsManagerException, String> ERROR_CODE_MAP = new HashMap<>() {{
+    private final Map<CredentialsManagerException, String> ERROR_CODE_MAP = new HashMap<>() {{
         put(CredentialsManagerException.Companion.getINVALID_CREDENTIALS(), "INVALID_CREDENTIALS");
         put(CredentialsManagerException.Companion.getNO_CREDENTIALS(), "NO_CREDENTIALS");
         put(CredentialsManagerException.Companion.getNO_REFRESH_TOKEN(), "NO_REFRESH_TOKEN");

--- a/src/credentials-manager/__tests__/credentials-manager.spec.js
+++ b/src/credentials-manager/__tests__/credentials-manager.spec.js
@@ -1,4 +1,5 @@
 import CredentialsManager from '../index';
+import CredentialsManagerError from '../credentialsManagerError';
 import { Platform } from 'react-native';
 
 describe('credentials manager tests', () => {
@@ -166,6 +167,143 @@ describe('credentials manager tests', () => {
         true
       );
       newNativeModule.mockRestore();
+    });
+  });
+
+  describe('CredentialsManagerError', () => {
+    describe('convertToCommonErrorCode', () => {
+      it('should return the correct common error code for known error codes', () => {
+        const error = new CredentialsManagerError({
+          status: 400,
+          json: {},
+          text: '',
+        });
+
+        expect(error.convertToCommonErrorCode('INVALID_CREDENTIALS')).toBe(
+          'INVALID_CREDENTIALS'
+        );
+        expect(error.convertToCommonErrorCode('NO_CREDENTIALS')).toBe(
+          'NO_CREDENTIALS'
+        );
+        expect(error.convertToCommonErrorCode('NO_REFRESH_TOKEN')).toBe(
+          'NO_REFRESH_TOKEN'
+        );
+        expect(error.convertToCommonErrorCode('RENEW_FAILED')).toBe(
+          'RENEW_FAILED'
+        );
+        expect(error.convertToCommonErrorCode('STORE_FAILED')).toBe(
+          'STORE_FAILED'
+        );
+        expect(error.convertToCommonErrorCode('REVOKE_FAILED')).toBe(
+          'REVOKE_FAILED'
+        );
+        expect(error.convertToCommonErrorCode('LARGE_MIN_TTL')).toBe(
+          'LARGE_MIN_TTL'
+        );
+        expect(error.convertToCommonErrorCode('INCOMPATIBLE_DEVICE')).toBe(
+          'INCOMPATIBLE_DEVICE'
+        );
+        expect(error.convertToCommonErrorCode('CRYPTO_EXCEPTION')).toBe(
+          'CRYPTO_EXCEPTION'
+        );
+        expect(error.convertToCommonErrorCode('BIOMETRIC_NO_ACTIVITY')).toBe(
+          'BIOMETRICS_FAILED'
+        );
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_ERROR_STATUS_UNKNOWN')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_ERROR_UNSUPPORTED')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_ERROR_HW_UNAVAILABLE')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_ERROR_NONE_ENROLLED')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_ERROR_NO_HARDWARE')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode(
+            'BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED'
+          )
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode(
+            'BIOMETRIC_AUTHENTICATION_CHECK_FAILED'
+          )
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode(
+            'BIOMETRIC_ERROR_DEVICE_CREDENTIAL_NOT_AVAILABLE'
+          )
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode(
+            'BIOMETRIC_ERROR_STRONG_AND_DEVICE_CREDENTIAL_NOT_AVAILABLE'
+          )
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_ERROR_NO_DEVICE_CREDENTIAL')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_ERROR_NEGATIVE_BUTTON')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_ERROR_HW_NOT_PRESENT')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_ERROR_NO_BIOMETRICS')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_ERROR_USER_CANCELED')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_ERROR_LOCKOUT_PERMANENT')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(error.convertToCommonErrorCode('BIOMETRIC_ERROR_VENDOR')).toBe(
+          'BIOMETRICS_FAILED'
+        );
+        expect(error.convertToCommonErrorCode('BIOMETRIC_ERROR_LOCKOUT')).toBe(
+          'BIOMETRICS_FAILED'
+        );
+        expect(error.convertToCommonErrorCode('BIOMETRIC_ERROR_CANCELED')).toBe(
+          'BIOMETRICS_FAILED'
+        );
+        expect(error.convertToCommonErrorCode('BIOMETRIC_ERROR_NO_SPACE')).toBe(
+          'BIOMETRICS_FAILED'
+        );
+        expect(error.convertToCommonErrorCode('BIOMETRIC_ERROR_TIMEOUT')).toBe(
+          'BIOMETRICS_FAILED'
+        );
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_ERROR_UNABLE_TO_PROCESS')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(error.convertToCommonErrorCode('BIOMETRICS_INVALID_USER')).toBe(
+          'BIOMETRICS_FAILED'
+        );
+        expect(
+          error.convertToCommonErrorCode('BIOMETRIC_AUTHENTICATION_FAILED')
+        ).toBe('BIOMETRICS_FAILED');
+        expect(error.convertToCommonErrorCode('BIOMETRICS_FAILED')).toBe(
+          'BIOMETRICS_FAILED'
+        );
+        expect(error.convertToCommonErrorCode('NO_NETWORK')).toBe('NO_NETWORK');
+        expect(error.convertToCommonErrorCode('API_ERROR')).toBe('API_ERROR');
+      });
+
+      it('should return UNKNOWN_ERROR for unknown error codes', () => {
+        const error = new CredentialsManagerError({
+          status: 400,
+          json: {},
+          text: '',
+        });
+
+        expect(error.convertToCommonErrorCode('UNKNOWN_CODE')).toBe(
+          'UNKNOWN_ERROR'
+        );
+      });
     });
   });
 });

--- a/src/credentials-manager/credentialsManagerError.ts
+++ b/src/credentials-manager/credentialsManagerError.ts
@@ -8,6 +8,7 @@ export default class CredentialsManagerError<
   public json;
   public status;
   public invalid_parameter;
+  public generic_error_code;
 
   constructor(response: Auth0Response<CredentialsManagerErrorDetails>) {
     const { status, json, text } = response;
@@ -15,14 +16,17 @@ export default class CredentialsManagerError<
       error,
       error_description: description,
       invalid_parameter,
+      code,
     }: {
       error?: string;
       error_description?: string;
       invalid_parameter?: string;
+      code?: string;
     } = json ?? {
       error: undefined,
       error_description: undefined,
       invalid_parameter: undefined,
+      code: undefined,
     };
     super(
       error || 'a0.response.invalid',
@@ -30,9 +34,54 @@ export default class CredentialsManagerError<
     );
     this.json = json;
     this.status = status;
+    this.generic_error_code = this.convertToCommonErrorCode(code || '');
+
     if (invalid_parameter) {
       this.invalid_parameter = invalid_parameter;
     }
+  }
+
+  convertToCommonErrorCode(code: string): string {
+    let errorMapping: Record<string, string> = {
+      INVALID_CREDENTIALS: 'INVALID_CREDENTIALS',
+      NO_CREDENTIALS: 'NO_CREDENTIALS',
+      NO_REFRESH_TOKEN: 'NO_REFRESH_TOKEN',
+      RENEW_FAILED: 'RENEW_FAILED',
+      STORE_FAILED: 'STORE_FAILED',
+      REVOKE_FAILED: 'REVOKE_FAILED',
+      LARGE_MIN_TTL: 'LARGE_MIN_TTL',
+      INCOMPATIBLE_DEVICE: 'INCOMPATIBLE_DEVICE',
+      CRYPTO_EXCEPTION: 'CRYPTO_EXCEPTION',
+      BIOMETRIC_NO_ACTIVITY: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_STATUS_UNKNOWN: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_UNSUPPORTED: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_HW_UNAVAILABLE: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_NONE_ENROLLED: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_NO_HARDWARE: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED: 'BIOMETRICS_FAILED',
+      BIOMETRIC_AUTHENTICATION_CHECK_FAILED: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_DEVICE_CREDENTIAL_NOT_AVAILABLE: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_STRONG_AND_DEVICE_CREDENTIAL_NOT_AVAILABLE:
+        'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_NO_DEVICE_CREDENTIAL: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_NEGATIVE_BUTTON: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_HW_NOT_PRESENT: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_NO_BIOMETRICS: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_USER_CANCELED: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_LOCKOUT_PERMANENT: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_VENDOR: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_LOCKOUT: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_CANCELED: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_NO_SPACE: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_TIMEOUT: 'BIOMETRICS_FAILED',
+      BIOMETRIC_ERROR_UNABLE_TO_PROCESS: 'BIOMETRICS_FAILED',
+      BIOMETRICS_INVALID_USER: 'BIOMETRICS_FAILED',
+      BIOMETRIC_AUTHENTICATION_FAILED: 'BIOMETRICS_FAILED',
+      BIOMETRICS_FAILED: 'BIOMETRICS_FAILED',
+      NO_NETWORK: 'NO_NETWORK',
+      API_ERROR: 'API_ERROR',
+    };
+    return errorMapping[code] || 'UNKNOWN_ERROR';
   }
 }
 
@@ -40,4 +89,5 @@ export interface CredentialsManagerErrorDetails {
   error?: string;
   error_description?: string;
   invalid_parameter?: string;
+  code?: string;
 }

--- a/src/credentials-manager/credentialsManagerError.ts
+++ b/src/credentials-manager/credentialsManagerError.ts
@@ -8,7 +8,7 @@ export default class CredentialsManagerError<
   public json;
   public status;
   public invalid_parameter;
-  public generic_error_code;
+  public type;
 
   constructor(response: Auth0Response<CredentialsManagerErrorDetails>) {
     const { status, json, text } = response;
@@ -34,7 +34,7 @@ export default class CredentialsManagerError<
     );
     this.json = json;
     this.status = status;
-    this.generic_error_code = this.convertToCommonErrorCode(code || '');
+    this.type = this.convertToCommonErrorCode(code || '');
 
     if (invalid_parameter) {
       this.invalid_parameter = invalid_parameter;

--- a/src/credentials-manager/index.ts
+++ b/src/credentials-manager/index.ts
@@ -52,6 +52,7 @@ class CredentialsManager {
       const json = {
         error: 'a0.credential_manager.invalid',
         error_description: e.message,
+        code: e.code,
       };
       throw new CredentialsManagerError({ json, status: 0 });
     }
@@ -79,12 +80,18 @@ class CredentialsManager {
         this.domain,
         this.localAuthenticationOptions
       );
-      return this.Auth0Module.getCredentials(
-        scope,
-        minTtl,
-        parameters,
-        forceRefresh
-      );
+      return new Promise<Credentials>((resolve, reject) => {
+        this.Auth0Module.getCredentials(scope, minTtl, parameters, forceRefresh)
+          .then(resolve)
+          .catch((e) => {
+            const json = {
+              error: 'a0.credential_manager.invalid',
+              error_description: e.message,
+              code: e.code,
+            };
+            reject(new CredentialsManagerError({ json, status: 0 }));
+          });
+      });
     } catch (e) {
       const json = {
         error: 'a0.credential_manager.invalid',

--- a/src/hooks/auth0-context.ts
+++ b/src/hooks/auth0-context.ts
@@ -19,6 +19,7 @@ import {
   RevokeOptions,
   ResetPasswordOptions,
 } from '../types';
+import BaseError from 'src/utils/baseError';
 
 export interface Auth0ContextInterface<TUser extends User = User>
   extends AuthState<TUser> {
@@ -143,7 +144,7 @@ export interface AuthState<TUser extends User = User> {
   /**
    * An object representing the last exception
    */
-  error: Error | null;
+  error: BaseError | null;
   /**
    * The user profile as decoded from the ID token after authentication
    */

--- a/src/hooks/reducer.ts
+++ b/src/hooks/reducer.ts
@@ -1,3 +1,4 @@
+import BaseError from 'src/utils/baseError';
 import { User } from '../types';
 import { deepEqual } from '../utils/deepEqual';
 import { AuthState } from './auth0-context';
@@ -5,7 +6,7 @@ import { AuthState } from './auth0-context';
 type Action =
   | { type: 'LOGIN_COMPLETE'; user: User }
   | { type: 'LOGOUT_COMPLETE' }
-  | { type: 'ERROR'; error: Error }
+  | { type: 'ERROR'; error: BaseError }
   | { type: 'INITIALIZED'; user: User | null }
   | { type: 'SET_USER'; user: User };
 

--- a/src/utils/baseError.ts
+++ b/src/utils/baseError.ts
@@ -1,11 +1,13 @@
 class BaseError extends Error {
-  constructor(name: string, message: string) {
+  generic_error_code: string;
+  constructor(name: string, message: string, generic_error_code?: string) {
     super();
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);
     }
     this.name = name;
     this.message = message;
+    this.generic_error_code = generic_error_code || '';
   }
 }
 

--- a/src/utils/baseError.ts
+++ b/src/utils/baseError.ts
@@ -1,13 +1,13 @@
 class BaseError extends Error {
-  generic_error_code: string;
-  constructor(name: string, message: string, generic_error_code?: string) {
+  type: string;
+  constructor(name: string, message: string, type?: string) {
     super();
     if (Error.captureStackTrace) {
       Error.captureStackTrace(this, this.constructor);
     }
     this.name = name;
     this.message = message;
-    this.generic_error_code = generic_error_code || '';
+    this.type = type || '';
   }
 }
 


### PR DESCRIPTION
### Changes

#### Added
We now expose platform agnostic generic error codes that represent different exception scenarios common in both android and iOS. 
We have considered only the `CredentialsManagerError` for now. 
Keeping the backward compatibility in mind, a new field with the generic error code has been exposed via the `BaseError` class.

The users can leverage the field as below : 

```js
try {
  const credentials = await auth0.credentialsManager.getCredentials();
} catch (error) {
  if(error.generic_error_code == "NO_CREDENTIALS"){
    // handle scenario
  }
}
```
**Note** : The old behaviour still remains untouched. 

### References

- The changes partially address the ask in #923 
- [SDK-5643](https://auth0team.atlassian.net/browse/SDK-5643)

### Testing

- [ ] This change adds unit test coverage
- [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed


[SDK-5643]: https://auth0team.atlassian.net/browse/SDK-5643?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ