### PR TITLE
Added deviceCredentialFallback default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,16 +468,16 @@ The options for configuring the display of local authentication prompt, authenti
 
 **Properties:**
 
-| Property                   | Type                                     | Description                                                                                                             | Applicable Platforms |
-| -------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| `title`                    | `String`                                 | The title of the authentication prompt.                                                                                 | Android, iOS         |
-| `subtitle`                 | `String` (optional)                      | The subtitle of the authentication prompt.                                                                              | Android              |
-| `description`              | `String` (optional)                      | The description of the authentication prompt.                                                                           | Android              |
-| `cancelTitle`              | `String` (optional)                      | The cancel button title of the authentication prompt.                                                                   | Android, iOS         |
-| `evaluationPolicy`         | `LocalAuthenticationStrategy` (optional) | The evaluation policy to use when prompting the user for authentication. Defaults to `deviceOwnerWithBiometrics`.       | iOS                  |
-| `fallbackTitle`            | `String` (optional)                      | The fallback button title of the authentication prompt.                                                                 | iOS                  |
-| `authenticationLevel`      | `LocalAuthenticationLevel` (optional)    | The authentication level to use when prompting the user for authentication. Defaults to `strong`.                       | Android              |
-| `deviceCredentialFallback` | `Boolean` (optional)                     | Should the user be given the option to authenticate with their device PIN, pattern, or password instead of a biometric. | Android              |
+| Property                   | Type                                     | Description                                                                                                                                 | Applicable Platforms |
+| -------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `title`                    | `String`                                 | The title of the authentication prompt.                                                                                                     | Android, iOS         |
+| `subtitle`                 | `String` (optional)                      | The subtitle of the authentication prompt.                                                                                                  | Android              |
+| `description`              | `String` (optional)                      | The description of the authentication prompt.                                                                                               | Android              |
+| `cancelTitle`              | `String` (optional)                      | The cancel button title of the authentication prompt.                                                                                       | Android, iOS         |
+| `evaluationPolicy`         | `LocalAuthenticationStrategy` (optional) | The evaluation policy to use when prompting the user for authentication. Defaults to `deviceOwnerWithBiometrics`.                           | iOS                  |
+| `fallbackTitle`            | `String` (optional)                      | The fallback button title of the authentication prompt.                                                                                     | iOS                  |
+| `authenticationLevel`      | `LocalAuthenticationLevel` (optional)    | The authentication level to use when prompting the user for authentication. Defaults to `strong`.                                           | Android              |
+| `deviceCredentialFallback` | `Boolean` (optional)                     | Should the user be given the option to authenticate with their device PIN, pattern, or password instead of a biometric. Defaults to `false` | Android              |
 
 > :warning: You need a real device to test Local Authentication for iOS. Local Authentication is not available in simulators.
 

--- a/src/utils/__tests__/addDefaultLocalAuthOptions.spec.js
+++ b/src/utils/__tests__/addDefaultLocalAuthOptions.spec.js
@@ -10,6 +10,7 @@ describe('addDefaultLocalAuthenticationOptions', () => {
       title: 'Please authenticate',
       authenticationLevel: LocalAuthenticationLevel.strong,
       evaluationPolicy: LocalAuthenticationStrategy.deviceOwnerWithBiometrics,
+      deviceCredentialFallback: false,
     });
   });
 
@@ -18,6 +19,7 @@ describe('addDefaultLocalAuthenticationOptions', () => {
       title: 'Please authenticate',
       authenticationLevel: LocalAuthenticationLevel.deviceCredential,
       evaluationPolicy: LocalAuthenticationStrategy.deviceOwner,
+      deviceCredentialFallback: false,
     };
     const result = addDefaultLocalAuthOptions(localAuthOptions);
     expect(result).toEqual(localAuthOptions);
@@ -33,6 +35,7 @@ describe('addDefaultLocalAuthenticationOptions', () => {
       title: 'Please authenticate',
       authenticationLevel: LocalAuthenticationLevel.deviceCredential,
       evaluationPolicy: LocalAuthenticationStrategy.deviceOwnerWithBiometrics,
+      deviceCredentialFallback: false,
     });
   });
 });

--- a/src/utils/addDefaultLocalAuthOptions.ts
+++ b/src/utils/addDefaultLocalAuthOptions.ts
@@ -5,6 +5,7 @@ import LocalAuthenticationLevel from '../credentials-manager/localAuthentication
 const defaultLocalAuthOptions = {
   evaluationPolicy: LocalAuthenticationStrategy.deviceOwnerWithBiometrics,
   authenticationLevel: LocalAuthenticationLevel.strong,
+  deviceCredentialFallback: false,
 };
 
 function addDefaultLocalAuthOptions(


### PR DESCRIPTION
### Changes
- Updated the deviceCredentialFallback property within the LocalAuthenticationOptions interface to default to false.
- Revised the SDK documentation to reflect the new default value of the deviceCredentialFallback property.

### References
- GitHub Issue: [#980](https://github.com/auth0/react-native-auth0/issues/980)

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
