### PR TITLE
feat: add optional timeout prop to Auth0Provider for authentication requests

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -12,6 +12,11 @@ ignore:
         reason: This issue is temporarily ignored while we evaluate alternative dependencies or wait for an update from Expo/Metro.
         expires: 2025-04-12T09:15:05.191Z
         created: 2025-03-12T09:15:05.191Z
+  SNYK-JS-IMAGESIZE-9634164:
+    - '*':
+        reason: This issue is temporarily ignored untill there is a new release of react native fixed this issue.
+        expires: 2025-05-12T09:15:05.191Z
+        created: 2025-04-07T09:15:05.191Z
   snyk:lic:npm:lightningcss-win32-x64-msvc:MPL-2.0:
     - '*':
         reason: This issue is temporarily ignored while we evaluate alternative dependencies or wait for an update from Expo/Metro.

--- a/src/hooks/auth0-provider.tsx
+++ b/src/hooks/auth0-provider.tsx
@@ -61,6 +61,8 @@ const finalizeScopeParam = (inputScopes?: string) => {
  * @param {String} domain Your Auth0 domain
  * @param {String} clientId Your Auth0 client ID
  * @param {LocalAuthenticationOptions} localAuthenticationOptions The local auth options
+ * @param {number} timeout - Optional timeout in milliseconds for authentication requests.
+ * @param {React.ReactNode} children - The child components to render within the provider.
  *
  * @example
  * ```ts
@@ -73,14 +75,16 @@ const Auth0Provider = ({
   domain,
   clientId,
   localAuthenticationOptions,
+  timeout,
   children,
 }: PropsWithChildren<{
   domain: string;
   clientId: string;
   localAuthenticationOptions?: LocalAuthenticationOptions;
+  timeout?: number;
 }>) => {
   const client = useMemo(
-    () => new Auth0({ domain, clientId, localAuthenticationOptions }),
+    () => new Auth0({ domain, clientId, localAuthenticationOptions, timeout }),
     [domain, clientId, localAuthenticationOptions]
   );
   const [state, dispatch] = useReducer(reducer, initialState);


### PR DESCRIPTION


### Changes

- feat: add optional timeout prop to Auth0Provider for authentication requests

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
