### PR TITLE
fix: Update prepare script to clean up package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "release": "release-it",
     "bootstrap": "cd example && npm ci",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build && expo-module clean",
-    "prepare": "bob build",
+    "prepare": "bob build && rm -rf lib/*/package.json",
     "example:android": "cd example && npm run android",
     "example:ios": "cd example && npm run ios"
   },


### PR DESCRIPTION
### 🛠️ Changes

This PR fixes issue #1081 where Expo users were experiencing an error with our config plugin: "Unexpected token 'typeof'" when running `expo install react-native-auth0` or `expo prebuild`.

The root cause is related to how react-native-builder-bob now generates package.json files inside the lib/*/ directories. This breaks Expo's plugin system because the `findUpPlugin` function (responsible for locating the nearest package.json) stops at the lib/commonjs directory instead of finding our root package.json.

Changes made:
- Modified the `prepare` script in package.json to remove the automatically generated package.json files in lib directories:
```
"prepare": "bob build && rm -rf lib/*/package.json"
```
- Updated dependencies to ensure compatibility with the latest versions of react-native-builder-bob
- Ensured the build process properly formats our plugin output to be compatible with Expo

These changes ensure our library continues to work with Expo projects without requiring users to downgrade to earlier versions.

### 🔗 References

- Issue #1081: https://github.com/auth0/react-native-auth0/issues/1081
- Related react-native-builder-bob changes: https://github.com/callstack/react-native-builder-bob/pull/598
