### PR TITLE
chore: support React 19 (remove propTypes, update peerDependencies)

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "peerDependencies": {
     "expo": ">=48.0.0",
-    "react": "^16.11.0 || ^17 || ^18",
+    "react": "^16.11.0 || ^17 || ^18 || ^19",
     "react-native": ">=0.65.0 <1.0.x"
   },
   "peerDependenciesMeta": {

--- a/src/hooks/auth0-provider.tsx
+++ b/src/hooks/auth0-provider.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useReducer, useMemo, useCallback } from 'react';
 import type { PropsWithChildren } from 'react';
 import jwtDecode from 'jwt-decode';
-import PropTypes from 'prop-types';
 import Auth0Context from './auth0-context';
 import Auth0 from '../auth0';
 import reducer from './reducer';
@@ -80,7 +79,14 @@ const Auth0Provider = ({
   children,
 }: PropsWithChildren<Auth0Options>) => {
   const client = useMemo(
-    () => new Auth0({ domain, clientId, localAuthenticationOptions, timeout, headers }),
+    () =>
+      new Auth0({
+        domain,
+        clientId,
+        localAuthenticationOptions,
+        timeout,
+        headers,
+      }),
     [domain, clientId, localAuthenticationOptions, timeout]
   );
   const [state, dispatch] = useReducer(reducer, initialState);
@@ -436,13 +442,6 @@ const Auth0Provider = ({
       {children}
     </Auth0Context.Provider>
   );
-};
-
-Auth0Provider.propTypes = {
-  domain: PropTypes.string.isRequired,
-  clientId: PropTypes.string.isRequired,
-  children: PropTypes.element.isRequired,
-  headers: PropTypes.object,
 };
 
 export default Auth0Provider;


### PR DESCRIPTION
### Changes

#### Peer Dependency Update:
Updated react in peerDependencies in [package.json](https://psychic-journey-wrpqp9qr5gxc9xjq.github.dev/) to include React 19 (^16.11.0 || ^17 || ^18 || ^19).
This allows installation and use of this library with React 19, ensuring compatibility with the latest React ecosystem.
#### PropTypes Removal:
Removed propTypes usage from the [Auth0Provider](https://psychic-journey-wrpqp9qr5gxc9xjq.github.dev/) function component in [auth0-provider.tsx](https://psychic-journey-wrpqp9qr5gxc9xjq.github.dev/).
React 19 no longer supports propTypes on function components; type safety is now enforced via TypeScript interfaces.
#### API Usage:
Usage of [Auth0Provider](https://psychic-journey-wrpqp9qr5gxc9xjq.github.dev/) and other APIs remains unchanged for consumers, except that runtime prop validation is now handled by TypeScript.

### References

https://github.com/auth0/react-native-auth0/issues/1177
https://react.dev/blog/2024/04/25/react-19-upgrade-guide#new-deprecations

### Testing

#### Manual Testing:
The package installs and works as expected with React 19.
Existing functionality was verified in a React 19 environment.
#### Automated Testing:
All existing unit and integration tests pass without errors.
No new tests were required, as this is a compatibility and maintenance update.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed
