### PR TITLE
Fix: getBundleIdentifier Implementation

### DIFF
--- a/android/src/main/java/com/auth0/react/A0Auth0Module.java
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.java
@@ -85,8 +85,9 @@ public class A0Auth0Module extends ReactContextBaseJavaModule implements Activit
     }
 
     @ReactMethod
-    public String getBundleIdentifier() {
-        return reactContext.getApplicationInfo().packageName;
+    public void getBundleIdentifier(Promise promise) {
+        String packageName = reactContext.getApplicationInfo().packageName;
+        promise.resolve(packageName);
     }
 
     @ReactMethod


### PR DESCRIPTION
## Issue
This PR fixes [issue #1186](https://github.com/auth0/react-native-auth0/issues/1186) where the `getBundleIdentifier()` function was inconsistently implemented across platforms.

## Changes
- Corrected Android implementation to properly use the Promise pattern
- Verified iOS implementation was already correctly implemented
- Ensured both platforms return bundle identifiers consistently via Promises

This change ensures JavaScript code can reliably access bundle identifiers through a consistent Promise-based API across both iOS and Android platforms.