### PR TITLE
Fixed iOS Build Issues with Static Frameworks

### DIFF
--- a/example/Gemfile.lock
+++ b/example/Gemfile.lock
@@ -113,4 +113,4 @@ RUBY VERSION
    ruby 2.6.10p210
 
 BUNDLED WITH
-   1.17.2
+   2.6.9

--- a/ios/A0Auth0.mm
+++ b/ios/A0Auth0.mm
@@ -2,7 +2,20 @@
 
 #import <React/RCTUtils.h>
 
-#import "A0Auth0-Swift.h"
+/**
+ * This preprocessor directive resolves the static linking issue by ensuring
+ * the correct import of the Swift header file generated for the A0Auth0 module.
+ * It checks for the presence of the header file in different locations:
+ * 1. If the header is available in the framework's module path (<A0Auth0/A0Auth0-Swift.h>),
+ *    it imports it from there.
+ * 2. As a fallback, it imports the header from the local path to ensure compatibility.
+ */
+#if __has_include(<A0Auth0/A0Auth0-Swift.h>)
+    #import <A0Auth0/A0Auth0-Swift.h>
+#else
+    #import "A0Auth0-Swift.h"
+#endif
+
 #define ERROR_CANCELLED @{@"error": @"a0.session.user_cancelled",@"error_description": @"User cancelled the Auth"}
 #define ERROR_FAILED_TO_LOAD @{@"error": @"a0.session.failed_load",@"error_description": @"Failed to load url"}
 


### PR DESCRIPTION
## Description

This PR addresses critical issues that were preventing successful builds for users on iOS:

1. Enhanced Swift header imports in A0Auth0.mm to work correctly with static frameworks. The implementation now uses preprocessor directives to check for the header file in different locations:
   - First tries importing from the module path `<A0Auth0/A0Auth0-Swift.h>`
   - Falls back to the local import `"A0Auth0-Swift.h"` if the module import is not available

## Issues Resolved

- Fixes #1180
- Fixes #986
## Testing Done

- Verified that pod installation works successfully with the updated bundler version
- Confirmed that builds complete successfully in projects using static frameworks