### PR TITLE
Ensure Swift 5 compilation for SDK pods to improve Swift 6 compatibility

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -11,6 +11,7 @@ Pod::Spec.new do |s|
   s.license      = package['license']
   s.authors      = package['author']
   s.platforms    = { :ios => min_ios_version_supported }
+  s.swift_version = '5.0'
   s.source       = { :git => 'https://github.com/auth0/react-native-auth0.git', :tag => "v#{s.version}" }
 
   s.source_files = 'ios/**/*.{h,m,mm,swift}'

--- a/README.md
+++ b/README.md
@@ -664,6 +664,32 @@ _Note_ : We have platform agnostic error codes available only for `CredentialsMa
 | `NO_NETWORK`          | `NO_NETWORK`                                                                                                                                                                                                                                                                                                                                     |                                 |
 | `API_ERROR`           | `API_ERROR`                                                                                                                                                                                                                                                                                                                                      |                                 |
 
+## Troubleshooting
+
+### Swift 6 Compatibility Issues on iOS
+
+If your main application project is configured to use Swift 6, and you encounter build errors related to Swift version incompatibilities with `react-native-auth0` or its dependencies (like `Auth0.swift`, `JWTDecode`, `SimpleKeychain`), you can ensure these specific pods are compiled with Swift 5.
+
+While `react-native-auth0` (from v5.0.0-beta.1 onwards) and its direct Swift dependencies are configured to use Swift 5, your project's build settings might try to override this. To enforce Swift 5 for these pods:
+
+**Recommended: Podfile `post_install` Hook**
+
+Add the following `post_install` hook to your application's `ios/Podfile`. This is generally the most robust way to manage build settings for dependencies:
+
+```ruby
+# In your application's ios/Podfile
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    # Target the react-native-auth0 pod and its Swift dependencies
+    if ['Auth0', 'A0Auth0', 'JWTDecode', 'SimpleKeychain'].include?(target.name)
+      target.build_configurations.each do |config|
+        config.build_settings['SWIFT_VERSION'] = '5.0'
+      end
+    end
+  end
+end
+```
+
 ## Feedback
 
 ### Contributing


### PR DESCRIPTION
This PR addresses build failures on iOS when the consuming application project is configured to use Swift 6, as discussed in issue #1185. While `react-native-auth0` and its dependencies do not yet officially support Swift 6 features, this change ensures the SDK itself is explicitly compiled using Swift 5. It also updates documentation to guide users on how to enforce Swift 5 for all relevant SDK dependencies if they encounter issues.

## Changes Made

1.  **`A0Auth0.podspec`:**
    *   Added `s.swift_version = '5.0'` to explicitly declare that the `A0Auth0` pod (which is `react-native-auth0` itself) should be compiled with Swift 5.0. This instructs Cocoapods to use the Swift 5 compiler for this pod, even if the main application project defaults to Swift 6.


3.  **`README.md`:**
    *   Updated the "Troubleshooting" section with more comprehensive guidance for users whose main application projects use Swift 6.
    *   The `post_install` hook example in the `README.md` now includes `JWTDecode` and `SimpleKeychain` in addition to `Auth0` and `A0Auth0`. This ensures that users can enforce Swift 5.0 compilation for all key Swift-based dependencies of the `react-native-auth0` SDK, providing a more robust solution against potential build system overrides.
    *   Updated manual Xcode steps to include checking `JWTDecode` and `SimpleKeychain`.

## Context

*   The primary Swift dependencies of `react-native-auth0` are `Auth0.swift`, `JWTDecode`, and `SimpleKeychain`. These libraries generally specify Swift 5 in their own podspecs.
*   This PR makes the Swift 5 requirement explicit for the `react-native-auth0` pod itself.
*   The `README.md` update provides a stronger fallback for users by allowing them to explicitly set the Swift version for all these dependencies in their own project's `Podfile`.

## Expected Outcome

Users with application projects set to Swift 6 should be able to build their iOS apps without encountering Swift version compatibility errors originating from `react-native-auth0` or its direct Swift dependencies, as these will be compiled using Swift 5.

## Related Issue

Closes #1185