### PR TITLE
fix(iOS): Remove insecure ATS exception for localhost and enforce secure defaults

### DIFF
--- a/example/ios/Auth0Example/Info.plist
+++ b/example/ios/Auth0Example/Info.plist
@@ -41,14 +41,11 @@
 	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSExceptionDomains</key>
-		<dict>
-			<key>localhost</key>
-			<dict>
-				<key>NSExceptionAllowsInsecureHTTPLoads</key>
-				<true/>
-			</dict>
-		</dict>
+	  <!-- Do not change NSAllowsArbitraryLoads to true, or you will risk app rejection! -->
+		<key>NSAllowsArbitraryLoads</key>
+		<false/>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
 	</dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>


### PR DESCRIPTION
This PR addresses a security issue raised by the Semgrep scan regarding the use of `NSExceptionAllowsInsecureHTTPLoads` under the `NSExceptionDomains` configuration for `localhost` in `example/ios/Auth0Example/Info.plist`.

### Issue

Semgrep reported an **Insecure App Transport Security (ATS) exception**, allowing unencrypted HTTP traffic for `localhost`, which violates recommended security practices.

**Findings:**  
- `NSExceptionAllowsInsecureHTTPLoads` was set to `true`
- No `NSExceptionMinimumTLSVersion` or `NSExceptionRequiresForwardSecrecy` was enforced

### Mitigation

As per the recommendation:
- Removed `NSExceptionDomains` entry for `localhost`
- Ensured that `NSAllowsArbitraryLoads` is explicitly set to `false`
- Enabled `NSAllowsLocalNetworking` to preserve support for local development/test environments

### Impact

- No functional impact expected since local development will still work due to `NSAllowsLocalNetworking`.
- Enhances security posture and satisfies Semgrep SAST policy.
