### PR TITLE
Temporarily Remove preinstall Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "prepare": "husky && bob build && rm -rf lib/*/package.json",
     "example:android": "cd example && npm run android",
     "example:ios": "cd example && npm run ios",
-    "precommit": "pretty-quick --staged",
-    "preinstall": "node scripts/ensure-yarn.js"
+    "precommit": "pretty-quick --staged"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
### 🚨 Problem

The `preinstall` script was running every time a developer executed `npm install` in their own repository. This is not the intended behavior and can cause unnecessary side effects during local development.

### 🔧 Solution

- **Temporarily removed** the `preinstall` command from package.json.
- This prevents the script from running on every install in downstream projects.

### 📝 Notes

- This is a **temporary workaround** until a better solution is found to enforce Yarn usage or manage install hooks without impacting consumers.
- Will revisit and reintroduce the script once a more robust approach is identified.

### 📌 Next Steps

- Investigate alternative approaches for install hooks that do not affect downstream developers.