### PR TITLE
fix(iOS): Fix ephemeralSession parameter type conversion in webAuth

### DIFF
--- a/ios/A0Auth0.mm
+++ b/ios/A0Auth0.mm
@@ -120,7 +120,9 @@ additionalParameters:(NSDictionary * _Nullable)additionalParameters
     NSInteger maxAgeValue = maxAge != nil ? [maxAge integerValue] : 0;
     NSInteger leewayValue = leeway != nil ? [leeway integerValue] : 0;
     NSInteger safariStyleValue = safariViewControllerPresentationStyle != nil ? [safariViewControllerPresentationStyle integerValue] : 0;
-    [self.nativeBridge webAuthWithScheme:scheme state:state redirectUri:redirectUri nonce:nonce audience:audience scope:scope connection:connection maxAge:maxAgeValue organization:organization invitationUrl:invitationUrl leeway:leewayValue ephemeralSession:ephemeralSession safariViewControllerPresentationStyle:safariStyleValue additionalParameters:additionalParameters resolve:resolve reject:reject];
+    BOOL ephemeralSessionBool = [ephemeralSession boolValue];
+    
+    [self.nativeBridge webAuthWithScheme:scheme state:state redirectUri:redirectUri nonce:nonce audience:audience scope:scope connection:connection maxAge:maxAgeValue organization:organization invitationUrl:invitationUrl leeway:leewayValue ephemeralSession:ephemeralSessionBool safariViewControllerPresentationStyle:safariStyleValue additionalParameters:additionalParameters resolve:resolve reject:reject];
 }
 
 


### PR DESCRIPTION
## What

Fixes the `ephemeralSession` parameter type conversion in the iOS native webAuth method implementation.

## Why

The `ephemeralSession` parameter was being passed directly as an `NSNumber` to the native bridge without proper boolean conversion. This could cause issues when the native Swift code expects a proper boolean value.

## How

- Added explicit boolean conversion using `[ephemeralSession boolValue]` before passing to the native bridge
- This ensures the parameter is properly converted from `NSNumber` to `BOOL` type as expected by the Swift implementation

## Testing

- [x] Verified that `ephemeralSession: true` works correctly on iOS
- [x] Verified that `ephemeralSession: false` works correctly on iOS
- [x] Confirmed no regression in existing webAuth functionality

Fixes #1232