### PR TITLE
Add Web Callback/Logout URL Configuration to React Native Web Setup Guide

### DIFF
--- a/REACT_NATIVE_WEB_SETUP.md
+++ b/REACT_NATIVE_WEB_SETUP.md
@@ -33,6 +33,26 @@ yarn add @auth0/auth0-spa-js
 
 Once React Native Web and Auth0 SPA JS are installed, you can use React Native Auth0 exactly as you would in a native React Native app. The library will automatically detect the web platform and use the appropriate implementation.
 
+---
+
+## 🔁 Web Callback and Logout URL Setup
+
+When running on Web—especially with **Expo** or custom Webpack servers—you must configure **callback** and **logout URLs** in your [Auth0 Application settings](https://manage.auth0.com/#/applications):
+
+### ✅ For local development (Expo or Metro)
+
+Add the following URLs:
+
+* **Allowed Callback URLs**:
+  `http://localhost:8081`
+
+* **Allowed Logout URLs**:
+  `http://localhost:8081`
+
+> ⚠️ If you've customized your Webpack Dev Server port (e.g., `3000`), replace `8081` accordingly.
+
+---
+
 ## Example Usage
 
 ```jsx


### PR DESCRIPTION
This PR enhances the React Native Web setup documentation by adding necessary instructions for configuring **callback** and **logout URLs** in the Auth0 dashboard, especially for **Expo** and **custom Webpack setups**.

#### This update includes:
- A new section: "Web Callback and Logout URL Setup".
- Guidance on configuring `http://localhost:8081` (default for Expo/Metro) for local development.
- Notes for replacing the port if using a custom Webpack dev server.
- Reinforced the need to set up these URLs correctly in the Auth0 Application settings to ensure proper login/logout behavior on web.

These additions aim to reduce setup friction and clarify the steps required to enable web auth flow during development.