### PR TITLE
feat(auth): add `saveCredentials` method to `useAuth0` hook

### DIFF
--- a/src/hooks/Auth0Context.ts
+++ b/src/hooks/Auth0Context.ts
@@ -49,6 +49,14 @@ export interface Auth0ContextInterface extends AuthState {
   clearSession(parameters?: ClearSessionParameters): Promise<void>;
 
   /**
+   * Saves the user's credentials.
+   * @param credentials The credentials to save.
+   * @returns A promise that resolves when the credentials have been saved.
+   * @throws {AuthError} If the save fails.
+   */
+  saveCredentials(credentials: Credentials): Promise<void>;
+
+  /**
    * Retrieves the stored credentials, refreshing them if necessary.
    * @param scope The scopes to request for the new access token (used during refresh).
    * @param minTtl The minimum time-to-live (in seconds) required for the access token.
@@ -208,6 +216,7 @@ const initialContext: Auth0ContextInterface = {
   isLoading: true,
   authorize: stub,
   clearSession: stub,
+  saveCredentials: stub,
   getCredentials: stub,
   clearCredentials: stub,
   hasValidCredentials: stub,

--- a/src/hooks/Auth0Provider.tsx
+++ b/src/hooks/Auth0Provider.tsx
@@ -170,6 +170,19 @@ export const Auth0Provider = ({
     [client]
   );
 
+  const saveCredentials = useCallback(
+    async (credentials: Credentials) => {
+      try {
+        await client.credentialsManager.saveCredentials(credentials);
+      } catch (e) {
+        const error = e as AuthError;
+        dispatch({ type: 'ERROR', error });
+        throw error;
+      }
+    },
+    [client]
+  );
+
   const clearCredentials = useCallback(async (): Promise<void> => {
     try {
       await client.credentialsManager.clearCredentials();
@@ -290,6 +303,7 @@ export const Auth0Provider = ({
       ...state,
       authorize,
       clearSession,
+      saveCredentials,
       getCredentials,
       hasValidCredentials,
       clearCredentials,
@@ -313,6 +327,7 @@ export const Auth0Provider = ({
       state,
       authorize,
       clearSession,
+      saveCredentials,
       getCredentials,
       hasValidCredentials,
       clearCredentials,


### PR DESCRIPTION
### Changes

This PR introduces a new public method, `saveCredentials`, to the `useAuth0` hook.

This change is important because it enables developers to integrate the `react-native-auth0` SDK with custom authentication flows. Previously, the SDK could only manage credentials obtained through its own `authorize` method. With `saveCredentials`, developers can now obtain credentials from an external source (e.g., a custom backend API that performs authentication) and inject them into the SDK's secure storage. Once saved, the SDK can manage the user's session, including refreshing tokens, as if the login had occurred through the standard flow.
-   **Added:** `saveCredentials(credentials: Credentials): Promise<void>` to the `Auth0ContextInterface`.
-   **Added:** The `saveCredentials` function is now implemented in the `Auth0Provider` and exposed through the `useAuth0` hook.

### References

Fixes https://github.com/auth0/react-native-auth0/issues/950 ✨

### Testing

This change is tested with a new suite of unit tests in `Auth0Provider.spec.tsx`. The tests cover the following scenarios:
-   A successful call to `saveCredentials` correctly invokes the underlying `credentialsManager.saveCredentials` method with the provided credentials.
-   An error thrown by the `credentialsManager` is caught, dispatched to the Auth0 state, and re-thrown for the caller to handle.
-   The method correctly handles both complete and minimal `Credentials` objects (e.g., without a `refreshToken`).

-   [x] This change adds unit test coverage
-   [x] This change has been tested on the latest version of the platform/language or why not
