### PR TITLE
fix: add missing clearSession native options

### DIFF
--- a/src/hooks/Auth0Context.ts
+++ b/src/hooks/Auth0Context.ts
@@ -20,7 +20,10 @@ import type {
   ResetPasswordParameters,
   MfaChallengeResponse,
 } from '../types';
-import type { NativeAuthorizeOptions } from '../types/platform-specific';
+import type {
+  NativeAuthorizeOptions,
+  NativeClearSessionOptions,
+} from '../types/platform-specific';
 import type { AuthState } from './reducer';
 
 /**
@@ -43,10 +46,14 @@ export interface Auth0ContextInterface extends AuthState {
   /**
    * Clears the user's session and logs them out.
    * @param parameters The parameters to send to the `/v2/logout` endpoint.
+   * @param options Platform-specific options to customize the logout experience.
    * @returns A promise that resolves when the session has been cleared.
    * @throws {AuthError} If the logout fails.
    */
-  clearSession(parameters?: ClearSessionParameters): Promise<void>;
+  clearSession(
+    parameters?: ClearSessionParameters,
+    options?: NativeClearSessionOptions
+  ): Promise<void>;
 
   /**
    * Saves the user's credentials.


### PR DESCRIPTION
### Changes

I am using the `clearSession` native options and they are missing from here. It looks like they are still defined on the native bridge, so it will work without this change, but will throw type safety errors

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If this library has unit and/or integration testing, tests should be added for new functionality and existing tests should complete without errors.

- [ ] This change adds unit test coverage
- [X] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [X] All active GitHub checks have passed
