### PR TITLE
fix: concurrent credential storage errors by preventing unnecessary state updates

### DIFF
--- a/src/core/utils/deepEqual.ts
+++ b/src/core/utils/deepEqual.ts
@@ -1,0 +1,21 @@
+export function deepEqual<T>(x: T, y: T): boolean {
+  if (x === y) {
+    return true;
+  } else if (
+    typeof x == 'object' &&
+    x != null &&
+    typeof y == 'object' &&
+    y != null
+  ) {
+    if (Object.keys(x).length != Object.keys(y).length) return false;
+
+    for (const prop in x) {
+      if (Object.prototype.hasOwnProperty.call(y, prop)) {
+        if (!deepEqual(x[prop], y[prop])) return false;
+      } else return false;
+    }
+    return true;
+  } else {
+    return false;
+  }
+}

--- a/src/hooks/Auth0Provider.tsx
+++ b/src/hooks/Auth0Provider.tsx
@@ -146,21 +146,31 @@ export const Auth0Provider = ({
   );
 
   const getCredentials = useCallback(
-    (
+    async (
       scope?: string,
       minTtl?: number,
       parameters?: Record<string, unknown>,
       forceRefresh?: boolean
-    ) =>
-      loginFlow(
-        client.credentialsManager.getCredentials(
+    ) => {
+      try {
+        const credentials = await client.credentialsManager.getCredentials(
           scope,
           minTtl,
           parameters,
           forceRefresh
-        )
-      ),
-    [client, loginFlow]
+        );
+        if (credentials.idToken) {
+          const user = Auth0User.fromIdToken(credentials.idToken);
+          dispatch({ type: 'SET_USER', user });
+        }
+        return credentials;
+      } catch (e) {
+        const error = e as AuthError;
+        dispatch({ type: 'ERROR', error });
+        throw error;
+      }
+    },
+    [client]
   );
 
   const hasValidCredentials = useCallback(

--- a/src/hooks/reducer.ts
+++ b/src/hooks/reducer.ts
@@ -1,5 +1,6 @@
 import type { User } from '../types';
 import type { AuthError } from '../core/models';
+import { deepEqual } from '../core/utils/deepEqual';
 
 /**
  * The shape of the authentication state managed by the Auth0Provider.
@@ -18,7 +19,8 @@ export type AuthAction =
   | { type: 'LOGIN_COMPLETE'; user: User }
   | { type: 'LOGOUT_COMPLETE' }
   | { type: 'ERROR'; error: AuthError }
-  | { type: 'INITIALIZED'; user: User | null };
+  | { type: 'INITIALIZED'; user: User | null }
+  | { type: 'SET_USER'; user: User | null };
 
 /**
  * A pure function that calculates the new state based on the previous state and a dispatched action.
@@ -34,5 +36,10 @@ export const reducer = (state: AuthState, action: AuthAction): AuthState => {
       return { ...state, isLoading: false, error: action.error };
     case 'INITIALIZED':
       return { ...state, isLoading: false, user: action.user };
+    case 'SET_USER':
+      if (deepEqual(state.user, action.user)) {
+        return state;
+      }
+      return { ...state, user: action.user };
   }
 };


### PR DESCRIPTION
This PR fixes issue #1278 where frequent `CRYPTO_EXCEPTION` errors were occurring on Android devices due to concurrent credential storage operations.

## Why

The issue was caused by multiple concurrent calls to `getCredentials()` triggering unnecessary state updates and credential saves. When the same token was being stored multiple times concurrently, it led to crypto exceptions on Android devices.

The root cause was in the `getCredentials` method using the `loginFlow` wrapper, which would always save the credentials again.

## How

1. **Added deep equality utility**: Implemented a `deepEqual` function to compare user objects and detect actual changes
2. **Updated reducer**: Added a new `SET_USER` action type that only updates state when the user object has actually changed (using deep equality comparison)  
3. **Modified getCredentials behavior**: Changed from using `loginFlow` wrapper to a direct implementation that:
   - Only dispatches `SET_USER` instead of `LOGIN_COMPLETE` 
   - Avoids unnecessary credential saves when the user data hasn't changed
   - Prevents concurrent storage operations that were causing the crypto exceptions

## Testing

- [x] Verified that the changes prevent unnecessary state updates when user data is unchanged
- [x] Confirmed that legitimate user updates still trigger state changes correctly
- [x] Tested that concurrent `getCredentials` calls no longer cause crypto exceptions

Closes #1278