### PR TITLE
feat: export AuthError class from main entry point

### DIFF
--- a/src/exports/classes.ts
+++ b/src/exports/classes.ts
@@ -1,2 +1,6 @@
+export {
+  AuthError,
+  CredentialsManagerError,
+  WebAuthError,
+} from '../core/models';
 export { default as Auth0, TimeoutError } from '../index';
-export { AuthError } from '../core/models/AuthError';

--- a/src/exports/hooks.ts
+++ b/src/exports/hooks.ts
@@ -1,1 +1,1 @@
-export { useAuth0, Auth0Provider } from '../hooks';
+export { Auth0Provider, useAuth0 } from '../hooks';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,21 @@
-import { Auth0ClientFactory } from './factory/Auth0ClientFactory';
 import type { IAuth0Client } from './core/interfaces/IAuth0Client';
+import { Auth0ClientFactory } from './factory/Auth0ClientFactory';
 import type { Auth0Options } from './types';
-export { AuthError } from './core/models/AuthError';
+
+export {
+  AuthError,
+  CredentialsManagerError,
+  WebAuthError,
+} from './core/models';
 export { TimeoutError } from './core/utils/fetchWithTimeout';
-export { useAuth0 } from './hooks/useAuth0';
 export { Auth0Provider } from './hooks/Auth0Provider';
+export { useAuth0 } from './hooks/useAuth0';
+export * from './types';
 export type {
-  LocalAuthenticationOptions,
   LocalAuthenticationLevel,
+  LocalAuthenticationOptions,
   LocalAuthenticationStrategy,
 } from './types/platform-specific';
-
-export * from './types';
 
 /**
  * The main Auth0 client class.


### PR DESCRIPTION
### Changes

As per https://github.com/auth0/react-native-auth0/blob/master/MIGRATION_GUIDE.md#change-2-standardized-autherror-object, we should be exporting AuthError class to allow consumers to perform instanceof checks and better error handling. This aligns with the library's documentation and enables proper error type detection in user code.