### PR TITLE
docs: Add Ask DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![License][license-image]][license-url]
 [![Downloads][downloads-image]][downloads-url]
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fauth0%2Freact-native-auth0.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fauth0%2Freact-native-auth0?ref=badge_shield)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/auth0/react-native-auth0)
 
 📚 [Documentation](#documentation) • 🚀 [Getting Started](#getting-started) • ⏭️ [Next Steps](#next-steps) • ❓ [FAQs](https://github.com/auth0/react-native-auth0/blob/master/FAQ.md) • ❓ [Feedback](#feedback)
 


### PR DESCRIPTION

This pull request adds the 'Ask DeepWiki' badge to the repository's README file.

### Purpose
The badge provides a direct and convenient link for users and contributors to ask questions and get information about this codebase via DeepWiki, improving the repository's overall supportability and accessibility.

### Automation Context
This change was applied via an automated script to ensure consistency across multiple repositories. No other files or functional code have been modified.
