### PR TITLE
fix: TypeScript ESLint unbound-method errors in Auth0 context interface

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,7 @@ import { fixupConfigRules } from '@eslint/compat';
 import { FlatCompat } from '@eslint/eslintrc';
 import js from '@eslint/js';
 import prettier from 'eslint-plugin-prettier';
+import tseslint from 'typescript-eslint';
 import { defineConfig } from 'eslint/config';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -30,6 +31,23 @@ export default defineConfig([
           useTabs: false,
         },
       ],
+    },
+  },
+  // TypeScript-specific configuration for type-checked rules
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    ignores: ['**/__tests__/**', '**/__mocks__/**', '**/*.spec.ts', '**/*.spec.tsx', '**/*.test.ts', '**/*.test.tsx'],
+    languageOptions: {
+      parserOptions: {
+        project: true,
+        tsconfigRootDir: import.meta.dirname,
+      },
+    },
+    rules: {
+      // Enable unbound-method rule to catch interface typing issues
+      // This helps ensure methods in interfaces use arrow function syntax
+      // instead of method syntax when they don't use 'this'
+      '@typescript-eslint/unbound-method': 'error',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -132,7 +132,8 @@
     "typedoc": "^0.28.2",
     "typedoc-plugin-missing-exports": "^4.0.0",
     "typedoc-plugin-replace-text": "^4.2.0",
-    "typescript": "5.2.2"
+    "typescript": "5.2.2",
+    "typescript-eslint": "^8.46.2"
   },
   "dependencies": {
     "@auth0/auth0-spa-js": "2.7.0",

--- a/src/hooks/Auth0Context.ts
+++ b/src/hooks/Auth0Context.ts
@@ -39,10 +39,10 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves with the user's credentials upon successful authentication.
    * @throws {AuthError} If the authentication fails.
    */
-  authorize(
+  authorize: (
     parameters?: WebAuthorizeParameters,
     options?: NativeAuthorizeOptions
-  ): Promise<Credentials>;
+  ) => Promise<Credentials>;
 
   /**
    * Clears the user's session and logs them out.
@@ -51,10 +51,10 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves when the session has been cleared.
    * @throws {AuthError} If the logout fails.
    */
-  clearSession(
+  clearSession: (
     parameters?: ClearSessionParameters,
     options?: NativeClearSessionOptions
-  ): Promise<void>;
+  ) => Promise<void>;
 
   /**
    * Saves the user's credentials.
@@ -62,7 +62,7 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves when the credentials have been saved.
    * @throws {AuthError} If the save fails.
    */
-  saveCredentials(credentials: Credentials): Promise<void>;
+  saveCredentials: (credentials: Credentials) => Promise<void>;
 
   /**
    * Retrieves the stored credentials, refreshing them if necessary.
@@ -73,12 +73,12 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves with the user's credentials.
    * @throws {AuthError} If credentials cannot be retrieved or refreshed.
    */
-  getCredentials(
+  getCredentials: (
     scope?: string,
     minTtl?: number,
     parameters?: Record<string, unknown>,
     forceRefresh?: boolean
-  ): Promise<Credentials>;
+  ) => Promise<Credentials>;
 
   /**
    * Clears the user's credentials without clearing their web session and logs them out.
@@ -96,13 +96,13 @@ export interface Auth0ContextInterface extends AuthState {
    * @param minTtl The minimum time-to-live (in seconds) required for the access token to be considered valid. Defaults to 0.
    * @returns A promise that resolves with `true` if valid credentials exist, `false` otherwise.
    */
-  hasValidCredentials(minTtl?: number): Promise<boolean>;
+  hasValidCredentials: (minTtl?: number) => Promise<boolean>;
 
   /**
    * Cancels the ongoing web authentication process.
    * This works only on iOS. On other platforms, it will resolve without performing an action.
    */
-  cancelWebAuth(): Promise<void>;
+  cancelWebAuth: () => Promise<void>;
 
   /**
    * Authenticates a user with their username and password.
@@ -111,9 +111,9 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves with the user's credentials.
    * @throws {AuthError} If the authentication fails.
    */
-  loginWithPasswordRealm(
+  loginWithPasswordRealm: (
     parameters: PasswordRealmParameters
-  ): Promise<Credentials>;
+  ) => Promise<Credentials>;
 
   /**
    * Creates a new user in a database connection.
@@ -121,7 +121,7 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves with the new user's profile information.
    * @throws {AuthError} If the user creation fails.
    */
-  createUser(parameters: CreateUserParameters): Promise<Partial<User>>;
+  createUser: (parameters: CreateUserParameters) => Promise<Partial<User>>;
 
   /**
    * Resets the user's password.
@@ -129,7 +129,7 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves when the password has been reset.
    * @throws {AuthError} If the reset fails.
    */
-  resetPassword(parameters: ResetPasswordParameters): Promise<void>;
+  resetPassword: (parameters: ResetPasswordParameters) => Promise<void>;
 
   /**
    * Exchanges an authorization code for tokens.
@@ -138,7 +138,9 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves with the user's credentials.
    * @throws {AuthError} If the exchange fails.
    */
-  authorizeWithExchange(parameters: ExchangeParameters): Promise<Credentials>;
+  authorizeWithExchange: (
+    parameters: ExchangeParameters
+  ) => Promise<Credentials>;
 
   /**
    * Exchanges an authorization code for native social tokens.
@@ -146,16 +148,16 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves with the user's credentials.
    * @throws {AuthError} If the exchange fails.
    */
-  authorizeWithExchangeNativeSocial(
+  authorizeWithExchangeNativeSocial: (
     parameters: ExchangeNativeSocialParameters
-  ): Promise<Credentials>;
+  ) => Promise<Credentials>;
 
   /**
    * Sends a verification code to the user's email.
    * @param parameters The parameters for sending the email code.
    * @throws {AuthError} If sending the email code fails.
    */
-  sendEmailCode(parameters: PasswordlessEmailParameters): Promise<void>;
+  sendEmailCode: (parameters: PasswordlessEmailParameters) => Promise<void>;
 
   /**
    * Authorizes a user with their email.
@@ -163,7 +165,9 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves with the user's credentials.
    * @throws {AuthError} If the authorization fails.
    */
-  authorizeWithEmail(parameters: LoginEmailParameters): Promise<Credentials>;
+  authorizeWithEmail: (
+    parameters: LoginEmailParameters
+  ) => Promise<Credentials>;
 
   /**
    /**
@@ -171,7 +175,7 @@ export interface Auth0ContextInterface extends AuthState {
    * @param parameters The parameters for sending the SMS code.
    * @throws {AuthError} If sending the SMS code fails.
    */
-  sendSMSCode(parameters: PasswordlessSmsParameters): Promise<void>;
+  sendSMSCode: (parameters: PasswordlessSmsParameters) => Promise<void>;
 
   /**
    * Authorizes a user with their SMS.
@@ -179,7 +183,7 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves with the user's credentials.
    * @throws {AuthError} If the authorization fails.
    */
-  authorizeWithSMS(parameters: LoginSmsParameters): Promise<Credentials>;
+  authorizeWithSMS: (parameters: LoginSmsParameters) => Promise<Credentials>;
 
   /**
    * Sends a multifactor challenge to the user.
@@ -187,9 +191,9 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves when the challenge has been sent.
    * @throws {AuthError} If sending the challenge fails.
    */
-  sendMultifactorChallenge(
+  sendMultifactorChallenge: (
     parameters: MfaChallengeParameters
-  ): Promise<MfaChallengeResponse>;
+  ) => Promise<MfaChallengeResponse>;
 
   /**
    * Authorizes a user with out-of-band (OOB) authentication.
@@ -197,7 +201,7 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves with the user's credentials.
    * @throws {AuthError} If the authorization fails.
    */
-  authorizeWithOOB(parameters: LoginOobParameters): Promise<Credentials>;
+  authorizeWithOOB: (parameters: LoginOobParameters) => Promise<Credentials>;
 
   /**
    * Authorizes a user with a one-time password (OTP).
@@ -205,7 +209,7 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves with the user's credentials.
    * @throws {AuthError} If the authorization fails.
    */
-  authorizeWithOTP(parameters: LoginOtpParameters): Promise<Credentials>;
+  authorizeWithOTP: (parameters: LoginOtpParameters) => Promise<Credentials>;
 
   /**
    * Authorizes a user with a recovery code.
@@ -213,12 +217,12 @@ export interface Auth0ContextInterface extends AuthState {
    * @returns A promise that resolves with the user's credentials.
    * @throws {AuthError} If the authorization fails.
    */
-  authorizeWithRecoveryCode(
+  authorizeWithRecoveryCode: (
     parameters: LoginRecoveryCodeParameters
-  ): Promise<Credentials>;
+  ) => Promise<Credentials>;
 
   // Token Management
-  revokeRefreshToken(parameters: RevokeOptions): Promise<void>;
+  revokeRefreshToken: (parameters: RevokeOptions) => Promise<void>;
 
   /**
    * Generates DPoP headers for making authenticated requests to custom APIs.
@@ -244,7 +248,9 @@ export interface Auth0ContextInterface extends AuthState {
    * }
    * ```
    */
-  getDPoPHeaders(params: DPoPHeadersParams): Promise<Record<string, string>>;
+  getDPoPHeaders: (
+    params: DPoPHeadersParams
+  ) => Promise<Record<string, string>>;
 }
 
 const stub = (): any => {

--- a/src/platforms/native/bridge/NativeBridgeManager.ts
+++ b/src/platforms/native/bridge/NativeBridgeManager.ts
@@ -40,7 +40,9 @@ export class NativeBridgeManager implements INativeBridge {
 
   async hasValidInstance(clientId: string, domain: string): Promise<boolean> {
     return this.a0_call(
-      Auth0NativeModule.hasValidAuth0InstanceWithConfiguration,
+      Auth0NativeModule.hasValidAuth0InstanceWithConfiguration.bind(
+        Auth0NativeModule
+      ),
       clientId,
       domain
     );
@@ -55,7 +57,9 @@ export class NativeBridgeManager implements INativeBridge {
     // This is a new method we'd add to the native side to ensure the
     // underlying Auth0.swift/Auth0.android SDKs are configured.
     return this.a0_call(
-      Auth0NativeModule.initializeAuth0WithConfiguration,
+      Auth0NativeModule.initializeAuth0WithConfiguration.bind(
+        Auth0NativeModule
+      ),
       clientId,
       domain,
       localAuthenticationOptions,
@@ -64,7 +68,9 @@ export class NativeBridgeManager implements INativeBridge {
   }
 
   getBundleIdentifier(): Promise<string> {
-    return this.a0_call(Auth0NativeModule.getBundleIdentifier);
+    return this.a0_call(
+      Auth0NativeModule.getBundleIdentifier.bind(Auth0NativeModule)
+    );
   }
 
   async authorize(
@@ -79,7 +85,7 @@ export class NativeBridgeManager implements INativeBridge {
     const scheme =
       parameters.redirectUrl?.split('://')[0] ?? options.customScheme;
     const credential = await this.a0_call(
-      Auth0NativeModule.webAuth,
+      Auth0NativeModule.webAuth.bind(Auth0NativeModule),
       scheme,
       parameters.redirectUrl,
       parameters.state,
@@ -104,7 +110,7 @@ export class NativeBridgeManager implements INativeBridge {
     options: NativeClearSessionOptions
   ): Promise<void> {
     return this.a0_call(
-      Auth0NativeModule.webAuthLogout,
+      Auth0NativeModule.webAuthLogout.bind(Auth0NativeModule),
       options.customScheme,
       parameters.federated ?? false,
       parameters.returnToUrl
@@ -112,11 +118,16 @@ export class NativeBridgeManager implements INativeBridge {
   }
 
   async cancelWebAuth(): Promise<void> {
-    return this.a0_call(Auth0NativeModule.cancelWebAuth);
+    return this.a0_call(
+      Auth0NativeModule.cancelWebAuth.bind(Auth0NativeModule)
+    );
   }
 
   async saveCredentials(credentials: Credentials): Promise<void> {
-    return this.a0_call(Auth0NativeModule.saveCredentials, credentials);
+    return this.a0_call(
+      Auth0NativeModule.saveCredentials.bind(Auth0NativeModule),
+      credentials
+    );
   }
 
   async getCredentials(
@@ -128,7 +139,7 @@ export class NativeBridgeManager implements INativeBridge {
     // Assuming the native side can take an empty object for parameters.
     const params = parameters ?? {};
     return this.a0_call(
-      Auth0NativeModule.getCredentials,
+      Auth0NativeModule.getCredentials.bind(Auth0NativeModule),
       scope,
       minTtl ?? 0,
       params,
@@ -137,22 +148,30 @@ export class NativeBridgeManager implements INativeBridge {
   }
 
   async hasValidCredentials(minTtl?: number): Promise<boolean> {
-    return this.a0_call(Auth0NativeModule.hasValidCredentials, minTtl ?? 0);
+    return this.a0_call(
+      Auth0NativeModule.hasValidCredentials.bind(Auth0NativeModule),
+      minTtl ?? 0
+    );
   }
 
   async clearCredentials(): Promise<void> {
-    return this.a0_call(Auth0NativeModule.clearCredentials);
+    return this.a0_call(
+      Auth0NativeModule.clearCredentials.bind(Auth0NativeModule)
+    );
   }
 
   async resumeWebAuth(url: string): Promise<void> {
-    return this.a0_call(Auth0NativeModule.resumeWebAuth, url);
+    return this.a0_call(
+      Auth0NativeModule.resumeWebAuth.bind(Auth0NativeModule),
+      url
+    );
   }
 
   async getDPoPHeaders(
     params: DPoPHeadersParams
   ): Promise<Record<string, string>> {
     return this.a0_call(
-      Auth0NativeModule.getDPoPHeaders,
+      Auth0NativeModule.getDPoPHeaders.bind(Auth0NativeModule),
       params.url,
       params.method,
       params.accessToken,
@@ -162,6 +181,6 @@ export class NativeBridgeManager implements INativeBridge {
   }
 
   async clearDPoPKey(): Promise<void> {
-    return this.a0_call(Auth0NativeModule.clearDPoPKey);
+    return this.a0_call(Auth0NativeModule.clearDPoPKey.bind(Auth0NativeModule));
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4634,6 +4634,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/eslint-plugin@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/eslint-plugin@npm:8.46.2"
+  dependencies:
+    "@eslint-community/regexpp": ^4.10.0
+    "@typescript-eslint/scope-manager": 8.46.2
+    "@typescript-eslint/type-utils": 8.46.2
+    "@typescript-eslint/utils": 8.46.2
+    "@typescript-eslint/visitor-keys": 8.46.2
+    graphemer: ^1.4.0
+    ignore: ^7.0.0
+    natural-compare: ^1.4.0
+    ts-api-utils: ^2.1.0
+  peerDependencies:
+    "@typescript-eslint/parser": ^8.46.2
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 9292f1f984f50166a7d7b17d73df6a05263b40f18c88be62830f90ae3836ea7f94d15bbc035d85ddbc4793b27d9ea15829bf1b3d35771bdb1bd1cd41f0760ddb
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/eslint-plugin@npm:^8.32.0, @typescript-eslint/eslint-plugin@npm:^8.36.0":
   version: 8.46.1
   resolution: "@typescript-eslint/eslint-plugin@npm:8.46.1"
@@ -4652,6 +4673,22 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
   checksum: c2c3191632bdf62b2202e2a1c81df08e17d8128b5d5008a808a6dd39143fcc53ce4d9a7ab613aa43cac1748246e7f752b3d8d0aef1f77f605079797427db40a9
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/parser@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/parser@npm:8.46.2"
+  dependencies:
+    "@typescript-eslint/scope-manager": 8.46.2
+    "@typescript-eslint/types": 8.46.2
+    "@typescript-eslint/typescript-estree": 8.46.2
+    "@typescript-eslint/visitor-keys": 8.46.2
+    debug: ^4.3.4
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: fc65446e11cc2d21550c1848526458f1dc0ea02bad6454d6a1477f5fa997bbf2a64b4e00b289128e17c69a8b41840367091650075810b458a3cae4a9ab8736cd
   languageName: node
   linkType: hard
 
@@ -4697,6 +4734,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/project-service@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/project-service@npm:8.46.2"
+  dependencies:
+    "@typescript-eslint/tsconfig-utils": ^8.46.2
+    "@typescript-eslint/types": ^8.46.2
+    debug: ^4.3.4
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 9fb4d2eafd949f430b498a12b886cf6b5414108c84490e7906b877be711ff7e8db996f94861d47ad1bb4c0d323adbc9522100766094a47f5bc8671f1bf820368
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/scope-manager@npm:8.41.0":
   version: 8.41.0
   resolution: "@typescript-eslint/scope-manager@npm:8.41.0"
@@ -4714,6 +4764,16 @@ __metadata:
     "@typescript-eslint/types": 8.46.1
     "@typescript-eslint/visitor-keys": 8.46.1
   checksum: ab2789a571c4db5d12292e993f66f720af1f2584d950959abf007296906a038e48a443206896c535b9b4f7d225658f5886910d78ea804ed22829079d82e7ba09
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/scope-manager@npm:8.46.2"
+  dependencies:
+    "@typescript-eslint/types": 8.46.2
+    "@typescript-eslint/visitor-keys": 8.46.2
+  checksum: 2df38694957a1f4a440f97c39839989bb99871a2cb2e10d715b4c91b64cb08377b57fe39122a3d8fe8e90a9eadd48655093316c8372253db724696446c441a96
   languageName: node
   linkType: hard
 
@@ -4735,6 +4795,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/tsconfig-utils@npm:8.46.2, @typescript-eslint/tsconfig-utils@npm:^8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/tsconfig-utils@npm:8.46.2"
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: 4a8caad6e6d27d1cc5f35db201906d3b008edacea0dd880cd0a3e62cbbdcf84907c231862acfbfa5c326516d6c043f185f1db190d8d8f48f90f2bb0e699fdf8d
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/type-utils@npm:8.46.1":
   version: 8.46.1
   resolution: "@typescript-eslint/type-utils@npm:8.46.1"
@@ -4751,6 +4820,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/type-utils@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/type-utils@npm:8.46.2"
+  dependencies:
+    "@typescript-eslint/types": 8.46.2
+    "@typescript-eslint/typescript-estree": 8.46.2
+    "@typescript-eslint/utils": 8.46.2
+    debug: ^4.3.4
+    ts-api-utils: ^2.1.0
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: b16aa99d3517de0b138a5d89d5dd06ccf19f7f522fc8bb205db05c7bcef47bbbb206bb694b57feb7e8102c61d3ce580a1a6c8d3efdd788d42566b718edea97dd
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/types@npm:8.41.0, @typescript-eslint/types@npm:^8.41.0":
   version: 8.41.0
   resolution: "@typescript-eslint/types@npm:8.41.0"
@@ -4762,6 +4847,13 @@ __metadata:
   version: 8.46.1
   resolution: "@typescript-eslint/types@npm:8.46.1"
   checksum: 28ded6e2f952ccc54f54f9d880237dfccc814a8601cc56cbfbec9879e695ad831023d07bc8989ce4b9ca8891d50bb3f19af80f50a9512ee1600013b7b84b1d77
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:8.46.2, @typescript-eslint/types@npm:^8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/types@npm:8.46.2"
+  checksum: c1c1c3a99b62ed51784d35c47547c2fa30c1896edf9843dcff3d39571b18b04daab1093f4ff59ae5f65a94fe78f2e7c73d3903b68c51d195204016ba909ca0d3
   languageName: node
   linkType: hard
 
@@ -4805,6 +4897,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/typescript-estree@npm:8.46.2"
+  dependencies:
+    "@typescript-eslint/project-service": 8.46.2
+    "@typescript-eslint/tsconfig-utils": 8.46.2
+    "@typescript-eslint/types": 8.46.2
+    "@typescript-eslint/visitor-keys": 8.46.2
+    debug: ^4.3.4
+    fast-glob: ^3.3.2
+    is-glob: ^4.0.3
+    minimatch: ^9.0.4
+    semver: ^7.6.0
+    ts-api-utils: ^2.1.0
+  peerDependencies:
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: e86da0546983e7e46a388af90fbd04ba19192d5f0c32b907d684890e0b363abbcdaf24a6f9a9909d5671ecefd67f3b1bc9e867e69dbca888aa6fc6554430d9e9
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:8.46.1, @typescript-eslint/utils@npm:^8.0.0":
   version: 8.46.1
   resolution: "@typescript-eslint/utils@npm:8.46.1"
@@ -4817,6 +4929,21 @@ __metadata:
     eslint: ^8.57.0 || ^9.0.0
     typescript: ">=4.8.4 <6.0.0"
   checksum: 2268b31a50960825556ba9bd22a231b97aa65fa489b8ddd697931224448efc9f1e429492303de99f5abbfbfca58fb6495834451fdfbcaa9c4c1446d2f557c702
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/utils@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/utils@npm:8.46.2"
+  dependencies:
+    "@eslint-community/eslint-utils": ^4.7.0
+    "@typescript-eslint/scope-manager": 8.46.2
+    "@typescript-eslint/types": 8.46.2
+    "@typescript-eslint/typescript-estree": 8.46.2
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: dd3492454015340ae61e41b83ced7fe3fdcb47eeba3add1bd1ddb8a4b0551dcaf1479b4f74675074a48a36007a13dffa159258a6407fcb7aadfa637c27117b7b
   languageName: node
   linkType: hard
 
@@ -4852,6 +4979,16 @@ __metadata:
     "@typescript-eslint/types": 8.46.1
     eslint-visitor-keys: ^4.2.1
   checksum: 18ce08a42cf0e0ddbb3c48a9084d320a67991311830e29cf79f33ecfdadf4680f8d10807e86551b49df55ccf023c24868ba9c85cc688a6075374f14b6fff59c4
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:8.46.2":
+  version: 8.46.2
+  resolution: "@typescript-eslint/visitor-keys@npm:8.46.2"
+  dependencies:
+    "@typescript-eslint/types": 8.46.2
+    eslint-visitor-keys: ^4.2.1
+  checksum: 0f3a79175521c3bd99c6f000e8ec2211b8e24440a71526ae7aa2a02bea4e5226192df14c13c57fe3e6d6d568960f09f7138380e8b7cc89c9fac39fcb51ac0be8
   languageName: node
   linkType: hard
 
@@ -14619,6 +14756,7 @@ __metadata:
     typedoc-plugin-missing-exports: ^4.0.0
     typedoc-plugin-replace-text: ^4.2.0
     typescript: 5.2.2
+    typescript-eslint: ^8.46.2
     url: ^0.11.4
   peerDependencies:
     react: ">=19.0.0"
@@ -16923,6 +17061,21 @@ __metadata:
   bin:
     typedoc: bin/typedoc
   checksum: d654f9d4d5e750b169ad5cb20733017e663193536b2a6c0e92f5875009dfdf391d2d20bc601b15a8021f2499f35d1318935174db844d3317e610d68b7681b4f5
+  languageName: node
+  linkType: hard
+
+"typescript-eslint@npm:^8.46.2":
+  version: 8.46.2
+  resolution: "typescript-eslint@npm:8.46.2"
+  dependencies:
+    "@typescript-eslint/eslint-plugin": 8.46.2
+    "@typescript-eslint/parser": 8.46.2
+    "@typescript-eslint/typescript-estree": 8.46.2
+    "@typescript-eslint/utils": 8.46.2
+  peerDependencies:
+    eslint: ^8.57.0 || ^9.0.0
+    typescript: ">=4.8.4 <6.0.0"
+  checksum: ed9e4587f6b437642413699a55caf50c7c2b912c9b251e6f1d055a5adee09a7ac0cc4fb0fa96a4ea9dcf32b11e3a4f386ec1d2b20cf6ba34ecba388215a04e62
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #1334

This PR resolves TypeScript ESLint `unbound-method` errors that occurred when using strict type-checking configurations with the react-native-auth0 SDK. The issue was reported when users enabled the `recommended-type-checked` preset from `@typescript-eslint`, which flagged destructured methods from the `useAuth0()` hook.

## Changes

1. **`src/hooks/Auth0Context.ts`**
   - Converted all 21 method signatures in `Auth0ContextInterface` from method syntax (`methodName(): Type`) to arrow function property syntax (`methodName: () => Type`)
   - This change signals to TypeScript and ESLint that these methods don't depend on `this` context and are safe to destructure

2. **`src/platforms/native/bridge/NativeBridgeManager.ts`**
   - Updated all 13 native module method calls to use `.bind(Auth0NativeModule)` when passing to the `a0_call` wrapper
   - Ensures proper `this` context preservation when calling native methods

3. **`eslint.config.mjs`**
   - Added TypeScript-specific configuration block enabling the `@typescript-eslint/unbound-method` rule
   - Added `typescript-eslint` package for unified configuration
   - Configured type-checked linting for TS/TSX files (excluding test files)
   - This ensures future code changes maintain the correct interface typing pattern

4. **`package.json`**
   - Added `typescript-eslint` as a dev dependency for ESLint configuration

## Testing
- ✅ All TypeScript compilation passes
- ✅ Verified 0 `unbound-method` errors with `recommended-type-checked` config
- ✅ Tested destructuring patterns in example app
- ✅ Root project linting passes with no new errors

## Breaking Changes
None. This is a backward-compatible change that only affects type definitions to improve compatibility with strict TypeScript ESLint configurations.

## Developer Experience Impact
✅ **Positive Impact**: Developers using strict TypeScript ESLint configurations (like `recommended-type-checked`) can now use the SDK without linting errors when destructuring methods from the `useAuth0()` hook.

```typescript
// This pattern now works without ESLint errors:
const { authorize, getCredentials, clearSession } = useAuth0();