### PR TITLE
security: move npm-token from direct interpolation to environment variable

### DIFF
--- a/.github/actions/npm-publish/action.yml
+++ b/.github/actions/npm-publish/action.yml
@@ -24,8 +24,10 @@ runs:
 
     - name: Verify npm token
       shell: bash
+      env:
+        NPM_TOKEN: ${{ inputs.npm-token }}
       run: |
-        if [ -z "${{ inputs.npm-token }}" ]; then
+        if [ -z "${NPM_TOKEN}" ]; then
           echo "Error: npm-token is not provided."
           exit 1
         fi


### PR DESCRIPTION
Move npm-token from direct GitHub Actions input interpolation to environment variable to prevent potential token exposure in logs.

## Changes
- Added `env` block with `NPM_TOKEN` variable in the "Verify npm token" step
- Changed token check from `${{ inputs.npm-token }}` to `${NPM_TOKEN}` environment variable reference

## Security Impact
This change prevents the npm token from being directly interpolated in the shell command, reducing the risk of accidental token exposure in GitHub Actions logs.