### PR TITLE
fix: exclude android gradle from SCA snyk scan

### DIFF
--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -8,10 +8,8 @@ jobs:
   snyk-cli:
     uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main
     with:
-      java-version: '17'
       node-version: '22'
       pre-scan-commands: |
         yarn install
-        printf "rootProject.name = 'react-native-auth0'\ninclude ':android'\n" > settings.gradle
-        yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "platforms;android-35" "build-tools;35.0.0" > /dev/null 2>&1 || true
+        rm -f android/build.gradle
     secrets: inherit


### PR DESCRIPTION
## Problem

The SCA (Snyk) scan was failing with exit code 2 and taking ~30+ minutes due to Gradle dependency resolution failures, while still reporting as "Success" due to `continue-on-error: true` in the upstream reusable workflow. The `send_telemetry` job was also not running since the scan didn't actually pass.

### Root Cause

```
Snyk CLI (v1.1292.0) uses `--all-projects` which discovers `android/build.gradle`
and attempts Gradle dependency resolution via:

  gradle 'snykResolvedDepsJson' '--build-file' android/build.gradle ...

However:
1. The CI runner uses Gradle 9.x which REMOVED the `--build-file` flag
   (deprecated in Gradle 8.x, removed in 9.x).
2. The `android/` directory is a React Native library module — it is NOT
   an independently buildable Gradle project. It requires rootProject ext
   properties and a consuming app context to resolve.
3. Using `additional-arguments: '--exclude=android'` does not work because
   the upstream reusable workflow single-quotes the value, breaking multi-flag
   arguments. A single `--exclude` also overrides the workflow's default
   exclude list (which excludes example/, tests/, .github/, etc.).
```

### Fix

```yaml
pre-scan-commands: |
  yarn install
  rm -f android/build.gradle
```

- `yarn install` — generates `yarn.lock` so Snyk can scan JS dependencies
- `rm -f android/build.gradle` — removes the Gradle manifest on the ephemeral
  CI runner so Snyk skips Gradle resolution entirely. The repo file is unaffected.

The Android Gradle dependencies (`com.auth0.android:auth0`, `androidx.browser`)
are not independently resolvable from this library module and would be scanned
in the context of a consuming application.