### PR TITLE
fix: resolve EXC_BAD_ACCESS crash caused by Int32 type mismatch in native bridge

### DIFF
--- a/ios/A0Auth0.mm
+++ b/ios/A0Auth0.mm
@@ -53,12 +53,12 @@ RCT_EXPORT_METHOD(clearCredentials:(RCTPromiseResolveBlock)resolve
 
 
 RCT_EXPORT_METHOD(getCredentials:(NSString * _Nullable)scope
-                minTTL:(NSInteger)minTTL
+                minTTL:(double)minTTL
             parameters:(NSDictionary *)parameters
           forceRefresh:(BOOL)forceRefresh
                resolve:(RCTPromiseResolveBlock)resolve
                 reject:(RCTPromiseRejectBlock)reject) { 
-    [self.nativeBridge getCredentialsWithScope:scope minTTL:minTTL parameters:parameters forceRefresh:forceRefresh resolve:resolve reject:reject];
+    [self.nativeBridge getCredentialsWithScope:scope minTTL:(NSInteger)minTTL parameters:parameters forceRefresh:forceRefresh resolve:resolve reject:reject];
 }
 
 
@@ -71,19 +71,19 @@ RCT_EXPORT_METHOD(hasValidAuth0InstanceWithConfiguration:(NSString *)clientId
 }
 
 
-RCT_EXPORT_METHOD(hasValidCredentials:(NSInteger)minTTL
+RCT_EXPORT_METHOD(hasValidCredentials:(double)minTTL
                     resolve:(RCTPromiseResolveBlock)resolve
                      reject:(RCTPromiseRejectBlock)reject) { 
-    [self.nativeBridge hasValidCredentialsWithMinTTL:minTTL resolve:resolve];
+    [self.nativeBridge hasValidCredentialsWithMinTTL:(NSInteger)minTTL resolve:resolve];
 }
 
 RCT_EXPORT_METHOD(getApiCredentials: (NSString *)audience
                   scope:(NSString * _Nullable)scope
-                  minTTL:(NSInteger)minTTL
+                  minTTL:(double)minTTL
                   parameters:(NSDictionary *)parameters
                   resolve:(RCTPromiseResolveBlock)resolve
                   reject:(RCTPromiseRejectBlock)reject) {
-    [self.nativeBridge getApiCredentialsWithAudience:audience scope:scope minTTL:minTTL parameters:parameters resolve:resolve reject:reject];
+    [self.nativeBridge getApiCredentialsWithAudience:audience scope:scope minTTL:(NSInteger)minTTL parameters:parameters resolve:resolve reject:reject];
 }
 
 RCT_EXPORT_METHOD(clearApiCredentials: (NSString *)audience
@@ -134,9 +134,9 @@ safariViewControllerPresentationStyle:(nonnull NSNumber *)safariViewControllerPr
 additionalParameters:(NSDictionary * _Nullable)additionalParameters
         resolve:(RCTPromiseResolveBlock)resolve
          reject:(RCTPromiseRejectBlock)reject) { 
-    NSInteger maxAgeValue = maxAge != nil ? [maxAge integerValue] : 0;
-    NSInteger leewayValue = leeway != nil ? [leeway integerValue] : 0;
-    NSInteger safariStyleValue = safariViewControllerPresentationStyle != nil ? [safariViewControllerPresentationStyle integerValue] : 0;
+    NSInteger maxAgeValue = maxAge != nil ? (NSInteger)[maxAge doubleValue] : 0;
+    NSInteger leewayValue = leeway != nil ? (NSInteger)[leeway doubleValue] : 0;
+    NSInteger safariStyleValue = safariViewControllerPresentationStyle != nil ? (NSInteger)[safariViewControllerPresentationStyle doubleValue] : 0;
     BOOL ephemeralSessionBool = [ephemeralSession boolValue];
     
     [self.nativeBridge webAuthWithScheme:scheme state:state redirectUri:redirectUri nonce:nonce audience:audience scope:scope connection:connection maxAge:maxAgeValue organization:organization invitationUrl:invitationUrl leeway:leewayValue ephemeralSession:ephemeralSessionBool safariViewControllerPresentationStyle:safariStyleValue additionalParameters:additionalParameters resolve:resolve reject:reject];


### PR DESCRIPTION
Fixes `EXC_BAD_ACCESS (code=1, address=0x20)` crash on iOS introduced in #1414 when upgrading to React Native 0.83.0.

### Changes Made

**iOS Native Bridge (`ios/A0Auth0.mm`)**
- Changed all numeric parameters from `NSInteger` to `double` to match JavaScript's number type
- Added explicit `(NSInteger)` casts when passing values to Swift methods
- Updated parameters: `minTTL` in `getCredentials`, `hasValidCredentials`, `getApiCredentials`
- Updated `webAuth` method to use `doubleValue` instead of `integerValue` for `maxAge`, `leeway`, and `safariViewControllerPresentationStyle`

**Android**
- ✅ No changes required - Android implementation was already using `Double` type correctly

## 🧪 Testing
- [x] iOS example app builds and runs without crashes
- [x] Android example app builds and runs (no regression)
- [x] All numeric parameters pass correctly through the native bridge
- [x] Unit tests pass
- [x] TypeScript type checking passes

## 🔗 Related
- Fixes issue introduced in #1414 (React Native 0.83.0 upgrade)