### PR TITLE
chore: update Auth0.swift to 2.16.1

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/**/*.{h,m,mm,swift}'
   s.requires_arc = true
 
-  s.dependency 'Auth0', '2.16'
+  s.dependency 'Auth0', '2.16.1'
   
   install_modules_dependencies(s)
 end

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - A0Auth0 (5.3.0):
-    - Auth0 (= 2.16)
+    - Auth0 (= 2.16.1)
     - boost
     - DoubleConversion
     - fast_float
@@ -28,7 +28,7 @@ PODS:
     - ReactCommon/turbomodule/core
     - SocketRocket
     - Yoga
-  - Auth0 (2.16.0):
+  - Auth0 (2.16.1):
     - JWTDecode (= 3.3.0)
     - SimpleKeychain (= 1.3.0)
   - boost (1.84.0)
@@ -2918,8 +2918,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  A0Auth0: 18df09ad940ea6b4a849cbc07d8ef6f5d9ec9299
-  Auth0: 6db7cf0801a5201b3c6c376f07b8dfecfac21ebe
+  A0Auth0: 30d506d65dee5cbb3556454ad26ac5bd92ed6c80
+  Auth0: b218669c4bd8c8fa873e2eae15444c43f5f6c318
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: b32c788ed9c6a8c584d114d0047beda9664e7cc6


### PR DESCRIPTION
Updates the Auth0.swift iOS dependency from `2.16` to `2.16.1`.

### 🎯 Why
This patch release includes bug fixes and improvements from Auth0.swift. By updating to the latest patch version, we ensure users benefit from the latest stability improvements while maintaining compatibility.

### 🔧 Changes
- Updated `Auth0.podspec` dependency constraint from `2.16` to `2.16.1`
- Updated `example/ios/Podfile.lock` to reflect the new version