### PR TITLE
doc: Remove EA tag for DPoP

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1319,8 +1319,6 @@ You can skip sending the `customScheme` property if you do not want to customize
 
 [DPoP](https://datatracker.ietf.org/doc/html/rfc9449) (Demonstrating Proof-of-Possession) is an OAuth 2.0 extension that cryptographically binds access and refresh tokens to a client-specific key pair. This prevents token theft and replay attacks by ensuring that even if a token is intercepted, it cannot be used from a different device.
 
-> **Note**: This feature is currently available in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). Please reach out to Auth0 support to get it enabled for your tenant.
-
 ### Enabling DPoP
 
 DPoP is enabled by default (`useDPoP: true`) when you initialize the Auth0 client:

--- a/FAQ.md
+++ b/FAQ.md
@@ -483,7 +483,6 @@ DPoP is **enabled by default** (`useDPoP: true`) in this SDK because it provides
 - ✅ Enable if you handle sensitive data or financial transactions
 - ✅ Enable if you want best-in-class security practices
 - ✅ Enable if your users access the app from multiple devices (DPoP helps prevent cross-device token abuse)
-- ⚠️ **Note**: DPoP is currently in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access) - contact Auth0 support to enable it on your tenant
 - ⚠️ **Note**: Existing users with Bearer tokens will need to log in again to get DPoP tokens (see [FAQ #13](#13-how-do-i-migrate-existing-users-to-dpop))
 
 **How to disable it (if needed):**


### PR DESCRIPTION
### Changes

This PR removes the EA tag from DPoP APIs since it has been officially announced as GA

### References

https://auth0.com/docs/secure/sender-constraining/demonstrating-proof-of-possession-dpop

### Checklist

- [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [X] All existing and new tests complete without errors
- [X] All active GitHub checks have passed
