### PR TITLE
fix: remove conflicting broad scheme from MainActivity to prevent Android disambiguation dialog

### DIFF
--- a/src/plugin/__tests__/withAuth0-test.ts
+++ b/src/plugin/__tests__/withAuth0-test.ts
@@ -213,6 +213,159 @@ describe(addAndroidAuth0Manifest, () => {
     expect(dataElement?.$['android:host']).toBe('sample.auth0.com');
   });
 
+  it(`should remove conflicting broad scheme from other activity intent filter`, () => {
+    const config = getConfig();
+    const mainApp = AndroidConfig.Manifest.getMainApplicationOrThrow(
+      config.modResults
+    );
+    mainApp.activity = mainApp.activity || [];
+    mainApp.activity.push({
+      '$': {
+        'android:name': '.MainActivity',
+      },
+      'intent-filter': [
+        {
+          action: [{ $: { 'android:name': 'android.intent.action.VIEW' } }],
+          category: [
+            { $: { 'android:name': 'android.intent.category.DEFAULT' } },
+            {
+              $: { 'android:name': 'android.intent.category.BROWSABLE' },
+            },
+          ],
+          data: [
+            { $: { 'android:scheme': 'smtest' } },
+            { $: { 'android:scheme': 'exp+smtest' } },
+          ],
+        },
+      ],
+    } as AndroidConfig.Manifest.ManifestActivity);
+
+    const result = addAndroidAuth0Manifest(
+      [{ domain: 'sample.auth0.com', customScheme: 'smtest' }],
+      config,
+      'com.sample.app'
+    );
+
+    const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(
+      result.modResults
+    );
+
+    // MainActivity should have 'smtest' removed but keep 'exp+smtest'
+    const mainActivity = mainApplication.activity?.find(
+      (a) => a.$['android:name'] === '.MainActivity'
+    );
+    const mainIntentFilter = mainActivity?.['intent-filter']?.[0];
+    const schemes = mainIntentFilter?.data?.map((d) => d.$['android:scheme']);
+    expect(schemes).toEqual(['exp+smtest']);
+    expect(schemes).not.toContain('smtest');
+
+    // RedirectActivity should still have the auth0 scheme
+    const redirectActivity = mainApplication.activity?.find(
+      (a) =>
+        a.$['android:name'] === 'com.auth0.android.provider.RedirectActivity'
+    );
+    const redirectIntentFilter = redirectActivity?.['intent-filter']?.[0];
+    const redirectData = redirectIntentFilter?.data?.[0];
+    expect(redirectData?.$['android:scheme']).toBe('smtest');
+    expect(redirectData?.$['android:host']).toBe('sample.auth0.com');
+    expect(redirectData?.$['android:pathPrefix']).toBe(
+      '/android/com.sample.app/callback'
+    );
+  });
+
+  it(`should not modify other activities when no scheme conflict exists`, () => {
+    const config = getConfig();
+    const mainApp = AndroidConfig.Manifest.getMainApplicationOrThrow(
+      config.modResults
+    );
+    mainApp.activity = mainApp.activity || [];
+    mainApp.activity.push({
+      '$': {
+        'android:name': '.MainActivity',
+      },
+      'intent-filter': [
+        {
+          action: [{ $: { 'android:name': 'android.intent.action.VIEW' } }],
+          category: [
+            { $: { 'android:name': 'android.intent.category.DEFAULT' } },
+            {
+              $: { 'android:name': 'android.intent.category.BROWSABLE' },
+            },
+          ],
+          data: [
+            { $: { 'android:scheme': 'myapp' } },
+            { $: { 'android:scheme': 'exp+myapp' } },
+          ],
+        },
+      ],
+    } as AndroidConfig.Manifest.ManifestActivity);
+
+    const result = addAndroidAuth0Manifest(
+      [{ domain: 'sample.auth0.com', customScheme: 'smtest' }],
+      config,
+      'com.sample.app'
+    );
+
+    const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(
+      result.modResults
+    );
+    const mainActivity = mainApplication.activity?.find(
+      (a) => a.$['android:name'] === '.MainActivity'
+    );
+    const mainIntentFilter = mainActivity?.['intent-filter']?.[0];
+    const schemes = mainIntentFilter?.data?.map((d) => d.$['android:scheme']);
+    expect(schemes).toEqual(['myapp', 'exp+myapp']);
+  });
+
+  it(`should not remove scheme data that has a host (specific match)`, () => {
+    const config = getConfig();
+    const mainApp = AndroidConfig.Manifest.getMainApplicationOrThrow(
+      config.modResults
+    );
+    mainApp.activity = mainApp.activity || [];
+    mainApp.activity.push({
+      '$': {
+        'android:name': '.MainActivity',
+      },
+      'intent-filter': [
+        {
+          action: [{ $: { 'android:name': 'android.intent.action.VIEW' } }],
+          category: [
+            { $: { 'android:name': 'android.intent.category.DEFAULT' } },
+            {
+              $: { 'android:name': 'android.intent.category.BROWSABLE' },
+            },
+          ],
+          data: [
+            {
+              $: {
+                'android:scheme': 'smtest',
+                'android:host': 'myapp.example.com',
+              },
+            },
+          ],
+        },
+      ],
+    } as AndroidConfig.Manifest.ManifestActivity);
+
+    const result = addAndroidAuth0Manifest(
+      [{ domain: 'sample.auth0.com', customScheme: 'smtest' }],
+      config,
+      'com.sample.app'
+    );
+
+    const mainApplication = AndroidConfig.Manifest.getMainApplicationOrThrow(
+      result.modResults
+    );
+    const mainActivity = mainApplication.activity?.find(
+      (a) => a.$['android:name'] === '.MainActivity'
+    );
+    const mainIntentFilter = mainActivity?.['intent-filter']?.[0];
+    const schemes = mainIntentFilter?.data?.map((d) => d.$['android:scheme']);
+    // Should keep the data element because it has a host (specific match, won't cause disambiguation)
+    expect(schemes).toEqual(['smtest']);
+  });
+
   it(`should add android:autoVerify="true" when customScheme is https`, () => {
     const config = getConfig();
     const result = addAndroidAuth0Manifest(

--- a/src/plugin/withAuth0.ts
+++ b/src/plugin/withAuth0.ts
@@ -107,6 +107,31 @@ export const addAndroidAuth0Manifest = (
     let auth0Scheme =
       config.customScheme ?? applicationId + APPLICATION_ID_SUFFIX;
 
+    // Remove conflicting broad scheme handlers from other activities to prevent
+    // Android from showing a disambiguation dialog when both MainActivity and
+    // RedirectActivity handle the same scheme. This mirrors the iOS dedup logic
+    // in addIOSAuth0ConfigInInfoPList.
+    const activities = mainApplication.activity || [];
+    activities.forEach((activity) => {
+      if (
+        activity.$['android:name'] ===
+        'com.auth0.android.provider.RedirectActivity'
+      ) {
+        return;
+      }
+      const intentFilters = activity['intent-filter'] || [];
+      intentFilters.forEach((filter) => {
+        if (!filter.data) return;
+        filter.data = filter.data.filter((dataElement) => {
+          const scheme = dataElement.$?.['android:scheme'];
+          const host = dataElement.$?.['android:host'];
+          // Remove broad scheme matchers (no host) that would conflict
+          // with RedirectActivity's more specific intent filter
+          return !(scheme === auth0Scheme && !host);
+        });
+      });
+    });
+
     const dataElement = {
       $: {
         'android:scheme': auth0Scheme,


### PR DESCRIPTION
## Summary                                                                                                                                                                                   
                                                                                                                                                                                               
  - When `customScheme` in the Auth0 plugin config matches the app's Expo `scheme` (e.g., both set to `"smtest"`), Android shows a chooser dialog during the Auth0 login callback because both  `MainActivity` (broad scheme handler added by `@expo/config-plugins`) and `RedirectActivity` (specific Auth0  callback handler) are registered for the same URL scheme                        
  - The Expo plugin (`addAndroidAuth0Manifest`) now removes conflicting broad scheme data elements (same scheme, no `android:host`) from other activities before adding the Auth0-specific intent filter to `RedirectActivity`, mirroring the existing iOS deduplication logic in `addIOSAuth0ConfigInInfoPList`                                                                        
  - Only broad matchers are removed — data elements with an `android:host` are preserved since they won't cause disambiguation                                                               
                                                                                                                                                                                               
  ## Root Cause                                                                                                                                                                                
                                                                                                                                                                                               
  Expo's `@expo/config-plugins`  adds `<data android:scheme="smtest"/>` to `MainActivity` for deep linking. The react-native-auth0 plugin then adds `<data android:scheme="smtest" android:host="..." android:pathPrefix="..."/>` to `RedirectActivity`. When Chrome Custom Tab redirects back after authentication, it finds two exported activities matching the scheme and shows a disambiguation dialog. iOS already handles this via dedup in `addIOSAuth0ConfigInInfoPList`. Android was missing the equivalent.                                     
                                                                                                                                                                                             
  ## Test plan                                                                                                                                                                               

  - [x] Added test: conflicting broad scheme is removed from `MainActivity`                                                                                                                    
  - [x] Added test: non-conflicting schemes on other activities are left untouched
  - [x] Added test: scheme data with `android:host` (specific match) is preserved                                                                                                              
  - [x] Verify Auth0 login flow completes without disambiguation dialog on Android                                                                                                             
  - [x] Verify `exp+<scheme>` deep links still work in dev mode                                                                                                                                
  - [x] Verify existing snapshot tests still pass                        