### PR TITLE
feat(mfa): Implement Multi-Factor Authentication (MFA) support

### DIFF
--- a/EXAMPLES-WEB.md
+++ b/EXAMPLES-WEB.md
@@ -158,14 +158,127 @@ const App = () => {
 };
 ```
 
-## Unsupported Web Features
+## 3. MFA Flexible Factors Grant (Web)
 
-For security reasons, the web platform **does not support** direct authentication grants. The following methods from the `auth` provider will throw a `NotImplemented` error:
+The MFA Flexible Factors Grant is fully supported on the web platform. It uses the `@auth0/auth0-spa-js` MFA API under the hood.
 
-- `auth.passwordRealm()`
-- `auth.loginWithOTP()`
-- `auth.loginWithSMS()`
-- `auth.loginWithEmail()`
-- `auth.refreshToken()`
+### Using MFA with Hooks
 
-All these flows should be configured in your [Auth0 Universal Login](https://auth0.com/docs/universal-login) page and initiated via the `authorize()` method.
+```tsx
+import React, { useState } from 'react';
+import { View, Button, TextInput, Text } from 'react-native';
+import { useAuth0, MfaError, MfaErrorCodes } from 'react-native-auth0';
+
+function MfaScreen({ mfaToken }: { mfaToken: string }) {
+  const { mfa } = useAuth0();
+  const [otp, setOtp] = useState('');
+
+  const listAuthenticators = async () => {
+    try {
+      const authenticators = await mfa.getAuthenticators({ mfaToken });
+      console.log('Authenticators:', authenticators);
+    } catch (error) {
+      if (error instanceof MfaError) {
+        console.error('MFA error:', error.type, error.message);
+      }
+    }
+  };
+
+  const enrollTotp = async () => {
+    try {
+      const challenge = await mfa.enroll({ mfaToken, factorType: 'otp' });
+      if (challenge.type === 'totp') {
+        console.log('Scan QR:', challenge.barcodeUri);
+        console.log('Secret:', challenge.secret);
+      }
+    } catch (error) {
+      if (error instanceof MfaError) {
+        console.error('Enrollment error:', error.type);
+      }
+    }
+  };
+
+  const verifyOtp = async () => {
+    try {
+      const credentials = await mfa.verify({ mfaToken, otp });
+      console.log('Authenticated!', credentials.accessToken);
+    } catch (error) {
+      if (error instanceof MfaError) {
+        switch (error.type) {
+          case MfaErrorCodes.INVALID_OTP:
+            console.log('Incorrect code');
+            break;
+          case MfaErrorCodes.TOO_MANY_ATTEMPTS:
+            console.log('Too many attempts');
+            break;
+          case MfaErrorCodes.EXPIRED_MFA_TOKEN:
+            console.log('Session expired');
+            break;
+        }
+      }
+    }
+  };
+
+  return (
+    <View>
+      <Button title="List Authenticators" onPress={listAuthenticators} />
+      <Button title="Enroll TOTP" onPress={enrollTotp} />
+      <TextInput placeholder="Enter OTP" value={otp} onChangeText={setOtp} />
+      <Button title="Verify" onPress={verifyOtp} />
+    </View>
+  );
+}
+```
+
+### Using MFA with Auth0 Class
+
+```typescript
+import Auth0, { MfaError, MfaErrorCodes } from 'react-native-auth0';
+
+const auth0 = new Auth0({
+  domain: 'YOUR_AUTH0_DOMAIN',
+  clientId: 'YOUR_AUTH0_CLIENT_ID',
+});
+
+// List authenticators
+const authenticators = await auth0.mfa.getAuthenticators({
+  mfaToken: 'mfa_token',
+});
+
+// Enroll TOTP
+const challenge = await auth0.mfa.enroll({
+  mfaToken: 'mfa_token',
+  factorType: 'otp',
+});
+
+// Enroll SMS
+const smsChallenge = await auth0.mfa.enroll({
+  mfaToken: 'mfa_token',
+  factorType: 'sms',
+  phoneNumber: '+12025550135',
+});
+
+// Enroll push notification (Auth0 Guardian) — web returns barcodeUri + oobCode
+const pushChallenge = await auth0.mfa.enroll({
+  mfaToken: 'mfa_token',
+  factorType: 'push',
+});
+
+// Challenge an authenticator
+const challengeResult = await auth0.mfa.challenge({
+  mfaToken: 'mfa_token',
+  authenticatorId: 'sms|dev_123',
+});
+
+// Verify OTP
+const credentials = await auth0.mfa.verify({
+  mfaToken: 'mfa_token',
+  otp: '123456',
+});
+```
+
+## Web Platform Notes
+
+The web platform supports direct authentication grants including `auth.passwordRealm()`, `auth.createUser()`, `auth.resetPassword()`, and the MFA Flexible Factors Grant. These methods make direct HTTP calls to the Auth0 API.
+
+Token refresh is handled automatically by `credentialsManager.getCredentials()` on the web. The `auth.refreshToken()` method is not available.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -84,6 +84,10 @@
   - [Sending the Session Transfer Token](#sending-the-session-transfer-token)
     - [Option 1: As a Query Parameter](#option-1-as-a-query-parameter)
     - [Option 2: As a Cookie (WebView only)](#option-2-as-a-cookie-webview-only)
+- [MFA Flexible Factors Grant](#mfa-flexible-factors-grant)
+  - [Using MFA with Hooks](#using-mfa-with-hooks)
+  - [Using MFA with Auth0 Class](#using-mfa-with-auth0-class)
+  - [MFA Error Handling](#mfa-error-handling)
 - [Bot Protection](#bot-protection)
   - [Domain Switching](#domain-switching)
     - [Android](#android-1)
@@ -1893,6 +1897,294 @@ function WebAppView() {
 ```
 
 > **Note**: Cookie injection is platform-specific and may require additional configuration. The query parameter method is generally more straightforward and recommended for most use cases.
+
+## MFA Flexible Factors Grant
+
+The MFA Flexible Factors Grant provides programmatic control over Multi-Factor Authentication flows. Instead of relying solely on Universal Login, you can build custom MFA experiences — listing enrolled authenticators, enrolling new factors, triggering challenges, and verifying codes — all from your own UI.
+
+This feature works across all platforms (iOS, Android, and Web).
+
+### Using MFA with Hooks
+
+```tsx
+import React, { useState } from 'react';
+import { View, Button, TextInput, Text, Alert } from 'react-native';
+import { useAuth0, MfaError, MfaErrorCodes } from 'react-native-auth0';
+
+function MfaScreen({ mfaToken }: { mfaToken: string }) {
+  const { mfa } = useAuth0();
+  const [otp, setOtp] = useState('');
+
+  // List enrolled authenticators
+  const listAuthenticators = async () => {
+    try {
+      const authenticators = await mfa.getAuthenticators({ mfaToken });
+      console.log('Enrolled authenticators:', authenticators);
+    } catch (error) {
+      if (error instanceof MfaError) {
+        console.error('MFA error:', error.type, error.message);
+      }
+    }
+  };
+
+  // Enroll a new TOTP authenticator
+  const enrollTotp = async () => {
+    try {
+      const challenge = await mfa.enroll({ mfaToken, factorType: 'otp' });
+      if (challenge.type === 'totp') {
+        console.log('Scan this barcode:', challenge.barcodeUri);
+        console.log('Or enter this secret:', challenge.secret);
+      }
+    } catch (error) {
+      if (error instanceof MfaError) {
+        switch (error.type) {
+          case MfaErrorCodes.ENROLLMENT_FAILED:
+            Alert.alert('Error', 'Enrollment failed. Please try again.');
+            break;
+          case MfaErrorCodes.EXPIRED_MFA_TOKEN:
+            Alert.alert('Error', 'MFA session expired. Please start over.');
+            break;
+        }
+      }
+    }
+  };
+
+  // Enroll an SMS factor
+  const enrollSms = async () => {
+    try {
+      const challenge = await mfa.enroll({
+        mfaToken,
+        factorType: 'sms',
+        phoneNumber: '+12025550135',
+      });
+      if (challenge.type === 'oob') {
+        // Keep challenge.oobCode in component state if you need it for verify().
+      }
+    } catch (error) {
+      if (
+        error instanceof MfaError &&
+        error.type === MfaErrorCodes.INVALID_PHONE_NUMBER
+      ) {
+        Alert.alert('Error', 'Invalid phone number.');
+      }
+    }
+  };
+
+  // Trigger a challenge for an existing authenticator
+  const triggerChallenge = async (authenticatorId: string) => {
+    try {
+      const result = await mfa.challenge({ mfaToken, authenticatorId });
+      console.log('Challenge type:', result.challengeType);
+      // Keep result.oobCode in component state for the verify() step;
+      // avoid logging it.
+    } catch (error) {
+      if (error instanceof MfaError) {
+        console.error('Challenge failed:', error.type);
+      }
+    }
+  };
+
+  // Verify an OTP code - this completes authentication
+  const verifyOtp = async () => {
+    try {
+      const credentials = await mfa.verify({ mfaToken, otp });
+      console.log('Authentication complete!', credentials.accessToken);
+      // User is now logged in - state is automatically updated
+    } catch (error) {
+      if (error instanceof MfaError) {
+        switch (error.type) {
+          case MfaErrorCodes.INVALID_OTP:
+            Alert.alert('Error', 'Incorrect code. Please try again.');
+            break;
+          case MfaErrorCodes.TOO_MANY_ATTEMPTS:
+            Alert.alert('Error', 'Too many attempts. Please wait.');
+            break;
+          case MfaErrorCodes.EXPIRED_MFA_TOKEN:
+            Alert.alert('Error', 'Session expired. Please start over.');
+            break;
+        }
+      }
+    }
+  };
+
+  return (
+    <View>
+      <Button title="List Authenticators" onPress={listAuthenticators} />
+      <Button title="Enroll TOTP" onPress={enrollTotp} />
+      <Button title="Enroll SMS" onPress={enrollSms} />
+      <TextInput
+        placeholder="Enter OTP code"
+        value={otp}
+        onChangeText={setOtp}
+        keyboardType="number-pad"
+      />
+      <Button title="Verify OTP" onPress={verifyOtp} />
+    </View>
+  );
+}
+```
+
+### Using MFA with Auth0 Class
+
+```typescript
+import Auth0, { MfaError, MfaErrorCodes } from 'react-native-auth0';
+
+const auth0 = new Auth0({
+  domain: 'YOUR_AUTH0_DOMAIN',
+  clientId: 'YOUR_AUTH0_CLIENT_ID',
+});
+
+// List enrolled authenticators
+const authenticators = await auth0.mfa.getAuthenticators({
+  mfaToken: 'mfa_token_from_login',
+  // Optional: filter by factor type. Accepts the public MfaFactorType values
+  // ('otp', 'sms', 'voice', 'email', 'push'). Omit to return all authenticators.
+  factorsAllowed: ['otp', 'sms', 'email'],
+});
+
+// Enroll a TOTP authenticator
+const totpChallenge = await auth0.mfa.enroll({
+  mfaToken: 'mfa_token',
+  factorType: 'otp',
+});
+// totpChallenge.type === 'totp'
+// totpChallenge.barcodeUri - QR code URI
+// totpChallenge.secret - Manual entry secret
+
+// Enroll via SMS
+const smsChallenge = await auth0.mfa.enroll({
+  mfaToken: 'mfa_token',
+  factorType: 'sms',
+  phoneNumber: '+12025550135',
+});
+
+// Enroll via email
+const emailChallenge = await auth0.mfa.enroll({
+  mfaToken: 'mfa_token',
+  factorType: 'email',
+  email: 'user@example.com',
+});
+
+// Enroll via voice call
+// Note: native (iOS/Android) enrolls voice as SMS on the same number;
+// only the web platform supports a distinct voice channel.
+const voiceChallenge = await auth0.mfa.enroll({
+  mfaToken: 'mfa_token',
+  factorType: 'voice',
+  phoneNumber: '+12025550135',
+});
+
+// Enroll push notification (Auth0 Guardian)
+const pushChallenge = await auth0.mfa.enroll({
+  mfaToken: 'mfa_token',
+  factorType: 'push',
+});
+// pushChallenge.type === 'push'
+// pushChallenge.barcodeUri - QR code URI to pair the Guardian app
+// pushChallenge.oobCode - used to verify the enrollment (not available on Android)
+
+// Trigger an OOB challenge
+const challenge = await auth0.mfa.challenge({
+  mfaToken: 'mfa_token',
+  authenticatorId: 'sms|dev_123',
+});
+
+// Verify with OTP
+const credentials = await auth0.mfa.verify({
+  mfaToken: 'mfa_token',
+  otp: '123456',
+});
+
+// Verify with OOB code
+const credentialsOob = await auth0.mfa.verify({
+  mfaToken: 'mfa_token',
+  oobCode: 'oob_code_from_challenge',
+  bindingCode: '654321', // Optional, for SMS/email OOB
+});
+
+// Verify with recovery code
+const credentialsRecovery = await auth0.mfa.verify({
+  mfaToken: 'mfa_token',
+  recoveryCode: 'ABCDEF123456',
+});
+```
+
+### MFA Error Handling
+
+All MFA operations throw `MfaError` with a normalized, platform-agnostic `type` property:
+
+```typescript
+import { MfaError, MfaErrorCodes } from 'react-native-auth0';
+
+try {
+  await auth0.mfa.verify({ mfaToken, otp: '123456' });
+} catch (error) {
+  if (error instanceof MfaError) {
+    switch (error.type) {
+      case MfaErrorCodes.INVALID_OTP:
+        // OTP code is incorrect
+        break;
+      case MfaErrorCodes.INVALID_OOB_CODE:
+        // OOB code is incorrect
+        break;
+      case MfaErrorCodes.INVALID_RECOVERY_CODE:
+        // Recovery code is incorrect
+        break;
+      case MfaErrorCodes.EXPIRED_MFA_TOKEN:
+        // MFA token has expired - restart the MFA flow
+        break;
+      case MfaErrorCodes.INVALID_MFA_TOKEN:
+        // MFA token is invalid
+        break;
+      case MfaErrorCodes.TOO_MANY_ATTEMPTS:
+        // Rate limited - wait before retrying
+        break;
+      case MfaErrorCodes.ENROLLMENT_FAILED:
+        // Enrollment operation failed
+        break;
+      case MfaErrorCodes.INVALID_PHONE_NUMBER:
+        // Phone number is invalid for enrollment
+        break;
+      case MfaErrorCodes.INVALID_EMAIL:
+        // Email is invalid for enrollment
+        break;
+      case MfaErrorCodes.CHALLENGE_FAILED:
+        // Challenge request failed
+        break;
+      case MfaErrorCodes.AUTHENTICATOR_NOT_FOUND:
+        // Authenticator not found or not enrolled
+        break;
+      case MfaErrorCodes.UNSUPPORTED_FACTOR:
+        // MFA factor type is not supported
+        break;
+      case MfaErrorCodes.ASSOCIATION_REQUIRED:
+        // User must enroll before using the authenticator
+        break;
+      default:
+        console.error('MFA error:', error.message);
+    }
+  }
+}
+```
+
+| Error Code                | Description                                     | Auth0 API Code                 | Native Bridge Code     |
+| ------------------------- | ----------------------------------------------- | ------------------------------ | ---------------------- |
+| `INVALID_OTP`             | OTP code is incorrect                           | `invalid_otp`, `invalid_grant` |                        |
+| `INVALID_OOB_CODE`        | OOB code is incorrect                           | `invalid_oob_code`             |                        |
+| `INVALID_BINDING_CODE`    | Binding code is incorrect                       | `invalid_binding_code`         |                        |
+| `INVALID_RECOVERY_CODE`   | Recovery code is incorrect                      | `invalid_recovery_code`        |                        |
+| `ENROLLMENT_FAILED`       | MFA enrollment failed                           | `mfa_enrollment_failed`        | `MFA_ENROLLMENT_ERROR` |
+| `INVALID_PHONE_NUMBER`    | Phone number is invalid for enrollment          | `invalid_phone_number`         |                        |
+| `INVALID_EMAIL`           | Email is invalid for enrollment                 | `invalid_email`                |                        |
+| `EXPIRED_MFA_TOKEN`       | MFA token has expired                           | `expired_token`                |                        |
+| `INVALID_MFA_TOKEN`       | MFA token is invalid                            | `mfa_token_invalid`            |                        |
+| `TOO_MANY_ATTEMPTS`       | Rate limited - too many verification attempts   | `too_many_attempts`            |                        |
+| `CHALLENGE_FAILED`        | MFA challenge request failed                    | `mfa_challenge_failed`         | `MFA_CHALLENGE_ERROR`  |
+| `AUTHENTICATOR_NOT_FOUND` | Authenticator not found or not enrolled         |                                |                        |
+| `UNSUPPORTED_FACTOR`      | MFA factor type is not supported                | `unsupported_challenge_type`   |                        |
+| `ASSOCIATION_REQUIRED`    | User must enroll before using the authenticator | `association_required`         |                        |
+| `MFA_ERROR`               | Generic MFA error                               |                                | `MFA_VERIFY_ERROR`     |
+| `UNKNOWN_MFA_ERROR`       | Unknown or uncategorized MFA error              |                                |                        |
 
 ## Bot Protection
 

--- a/README.md
+++ b/README.md
@@ -755,6 +755,57 @@ try {
 | `DPOP_NOT_CONFIGURED` | `DPOP_NOT_CONFIGURED`                                                                                                                                                                                                                                                                                                                            | `dpopNotConfigured` |                                                             |
 | `DPOP_KEY_MISMATCH`   | `DPOP_KEY_MISMATCH`                                                                                                                                                                                                                                                                                                                              | `dpopKeyMismatch`   |                                                             |
 
+### MFA errors
+
+All MFA operations (via `auth0.mfa` or the `mfa` property from `useAuth0()`) throw `MfaError` with a normalized `type` property:
+
+```js
+import { MfaError, MfaErrorCodes } from 'react-native-auth0';
+
+try {
+  const credentials = await auth0.mfa.verify({ mfaToken, otp: '123456' });
+} catch (error) {
+  if (error instanceof MfaError) {
+    switch (error.type) {
+      case MfaErrorCodes.INVALID_OTP:
+        console.log('Incorrect OTP code.');
+        break;
+      case MfaErrorCodes.EXPIRED_MFA_TOKEN:
+        console.log('MFA session expired. Please start over.');
+        break;
+      case MfaErrorCodes.TOO_MANY_ATTEMPTS:
+        console.log('Too many attempts. Please wait.');
+        break;
+      case MfaErrorCodes.ENROLLMENT_FAILED:
+        console.log('MFA enrollment failed.');
+        break;
+      default:
+        console.error('MFA error:', error.message);
+    }
+  }
+}
+```
+
+| Generic Error Code        | Description                            | Auth0 API Code                 |
+| ------------------------- | -------------------------------------- | ------------------------------ |
+| `INVALID_OTP`             | OTP code is incorrect                  | `invalid_otp`, `invalid_grant` |
+| `INVALID_OOB_CODE`        | OOB code is incorrect                  | `invalid_oob_code`             |
+| `INVALID_BINDING_CODE`    | Binding code is incorrect              | `invalid_binding_code`         |
+| `INVALID_RECOVERY_CODE`   | Recovery code is incorrect             | `invalid_recovery_code`        |
+| `ENROLLMENT_FAILED`       | MFA enrollment failed                  | `mfa_enrollment_failed`        |
+| `INVALID_PHONE_NUMBER`    | Phone number is invalid for enrollment | `invalid_phone_number`         |
+| `INVALID_EMAIL`           | Email is invalid for enrollment        | `invalid_email`                |
+| `EXPIRED_MFA_TOKEN`       | MFA token has expired                  | `expired_token`                |
+| `INVALID_MFA_TOKEN`       | MFA token is invalid                   | `mfa_token_invalid`            |
+| `TOO_MANY_ATTEMPTS`       | Rate limited                           | `too_many_attempts`            |
+| `CHALLENGE_FAILED`        | MFA challenge failed                   | `mfa_challenge_failed`         |
+| `AUTHENTICATOR_NOT_FOUND` | Authenticator not found                |                                |
+| `UNSUPPORTED_FACTOR`      | Factor type not supported              | `unsupported_challenge_type`   |
+| `ASSOCIATION_REQUIRED`    | User must enroll first                 | `association_required`         |
+| `UNKNOWN_MFA_ERROR`       | Unknown MFA error                      |                                |
+
+For detailed MFA usage examples, see [EXAMPLES.md](EXAMPLES.md#mfa-flexible-factors-grant) and [EXAMPLES-WEB.md](EXAMPLES-WEB.md#3-mfa-flexible-factors-grant-web).
+
 ### WebAuth errors
 
 **Before (Platform-Specific Codes)**
@@ -873,6 +924,11 @@ This library provides a unified API across Native (iOS/Android) and Web platform
 | `auth.createUser()`                        |          ✅          |      ✅       | Calls the `/dbconnections/signup` endpoint. Works on both platforms.                                                                                                     |
 | `auth.resetPassword()`                     |          ✅          |      ✅       | Calls the `/dbconnections/change_password` endpoint. Works on both platforms.                                                                                            |
 | `users(token).patchUser()`                 |          ✅          |      ✅       | Calls the Management API. Works on any platform with a valid token, but use with caution in the browser.                                                                 |
+| **MFA Flexible Factors Grant**             |                      |               | ---                                                                                                                                                                      |
+| `mfa.getAuthenticators()`                  |          ✅          |      ✅       | Lists enrolled MFA authenticators for the user.                                                                                                                          |
+| `mfa.enroll()`                             |          ✅          |      ✅       | Enrolls a new MFA factor (OTP, SMS, email, voice, push).                                                                                                                 |
+| `mfa.challenge()`                          |          ✅          |      ✅       | Triggers an MFA challenge for an enrolled authenticator.                                                                                                                 |
+| `mfa.verify()`                             |          ✅          |      ✅       | Verifies an MFA code (OTP, OOB, recovery) and returns credentials.                                                                                                       |
 
 ## Troubleshooting
 

--- a/android/src/main/java/com/auth0/react/A0Auth0Module.kt
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.kt
@@ -26,12 +26,14 @@ import com.auth0.android.result.Credentials
 import com.auth0.android.result.PasskeyChallenge
 import com.auth0.android.result.PasskeyRegistrationChallenge
 import com.facebook.react.bridge.ActivityEventListener
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.bridge.WritableNativeArray
 import com.facebook.react.bridge.WritableNativeMap
 import com.google.gson.Gson
 import java.net.MalformedURLException
@@ -108,6 +110,7 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
     private var useDPoP: Boolean = true
 
     private var auth0: Auth0? = null
+    private var mfaClient: MfaClient? = null
     private var myAccount: MyAccount? = null
     private var passwordless: Passwordless? = null
     private lateinit var secureCredentialsManager: SecureCredentialsManager
@@ -281,6 +284,7 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
 
         this.useDPoP = useDPoP ?: true
         auth0 = Auth0.getInstance(clientId, domain)
+        mfaClient = MfaClient(auth0!!, this.useDPoP, reactContext)
         myAccount = MyAccount(auth0!!, this.useDPoP, reactContext)
         passwordless = Passwordless(auth0!!, this.useDPoP, reactContext)
 
@@ -645,6 +649,30 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
                 handleError(error, promise)
             }
         })
+    }
+
+    @ReactMethod
+    override fun getMfaAuthenticators(mfaToken: String, factorsAllowed: ReadableArray?, promise: Promise) {
+        mfaClient?.getAuthenticators(mfaToken, factorsAllowed, promise)
+            ?: promise.reject("NOT_INITIALIZED", "Auth0 not initialized")
+    }
+
+    @ReactMethod
+    override fun mfaEnroll(mfaToken: String, type: String, value: String?, promise: Promise) {
+        mfaClient?.enroll(mfaToken, type, value, promise)
+            ?: promise.reject("NOT_INITIALIZED", "Auth0 not initialized")
+    }
+
+    @ReactMethod
+    override fun mfaChallenge(mfaToken: String, authenticatorId: String, promise: Promise) {
+        mfaClient?.challenge(mfaToken, authenticatorId, promise)
+            ?: promise.reject("NOT_INITIALIZED", "Auth0 not initialized")
+    }
+
+    @ReactMethod
+    override fun mfaVerify(mfaToken: String, type: String, code: String, bindingCode: String?, scope: String?, audience: String?, promise: Promise) {
+        mfaClient?.verify(mfaToken, type, code, bindingCode, scope, audience, promise)
+            ?: promise.reject("NOT_INITIALIZED", "Auth0 not initialized")
     }
 
     @ReactMethod

--- a/android/src/main/java/com/auth0/react/MfaClient.kt
+++ b/android/src/main/java/com/auth0/react/MfaClient.kt
@@ -1,0 +1,279 @@
+package com.auth0.react
+
+import com.auth0.android.Auth0
+import com.auth0.android.authentication.AuthenticationAPIClient
+import com.auth0.android.authentication.mfa.MfaEnrollmentType
+import com.auth0.android.authentication.mfa.MfaException
+import com.auth0.android.authentication.mfa.MfaVerificationType
+import com.auth0.android.result.Authenticator
+import com.auth0.android.result.Credentials
+import com.auth0.android.result.EnrollmentChallenge
+import com.auth0.android.result.OobEnrollmentChallenge
+import com.auth0.android.result.RecoveryCodeEnrollmentChallenge
+import com.auth0.android.result.TotpEnrollmentChallenge
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.WritableNativeArray
+import com.facebook.react.bridge.WritableNativeMap
+
+enum class MfaFactorType(val value: String) {
+    PHONE("phone"),
+    EMAIL("email"),
+    OTP("otp"),
+    PUSH("push"),
+    VOICE("voice");
+
+    companion object {
+        fun fromString(type: String): MfaFactorType? =
+            entries.find { it.value == type }
+    }
+}
+
+enum class MfaVerifyType(val value: String) {
+    OTP("otp"),
+    OOB("oob"),
+    RECOVERY_CODE("recoveryCode");
+
+    companion object {
+        fun fromString(type: String): MfaVerifyType? =
+            entries.find { it.value == type }
+    }
+}
+
+class MfaClient(
+    private val auth0: Auth0,
+    private val useDPoP: Boolean,
+    private val reactContext: ReactApplicationContext
+) {
+
+    private val client: AuthenticationAPIClient by lazy {
+        AuthenticationAPIClient(auth0).apply {
+            if (useDPoP) {
+                useDPoP(reactContext)
+            }
+        }
+    }
+
+    // Maps the public MfaFactorType vocabulary (otp/sms/voice/email/push) onto
+    // the `Authenticator.type` tokens Auth0.Android 3.21.0 filters against with
+    // exact, case-sensitive equality. Note: sms and voice both surface as the
+    // `phone` type, so neither can be isolated here (narrowed later by oobChannel);
+    // otp maps to both `otp` and `totp`.
+    private fun mapFactorType(factor: String): List<String> {
+        return when (factor.lowercase()) {
+            "otp" -> listOf("otp", "totp")
+            "sms", "voice" -> listOf("phone")
+            "email" -> listOf("email")
+            "push" -> listOf("push-notification")
+            else -> emptyList()
+        }
+    }
+
+    fun getAuthenticators(mfaToken: String, factorsAllowed: ReadableArray?, promise: Promise) {
+        val mfaClient = client.mfaClient(mfaToken)
+
+        val requested = mutableListOf<String>()
+        factorsAllowed?.let {
+            for (i in 0 until it.size()) {
+                it.getString(i)?.let { factor -> requested.add(factor.lowercase()) }
+            }
+        }
+        val factors = requested.flatMap { mapFactorType(it) }.toMutableList()
+
+        // Auth0.Android 3.21.0 rejects an empty factorsAllowed list, so default to
+        // every recognized `Authenticator.type` token to match iOS/web "return all"
+        // behaviour.
+        if (factors.isEmpty()) {
+            factors.addAll(
+                listOf(
+                    "otp",
+                    "totp",
+                    "phone",
+                    "email",
+                    "push-notification",
+                    "recovery-code"
+                )
+            )
+        }
+
+        // Auth0.Android filters only on `Authenticator.type`, where sms and voice
+        // both surface as "phone" — so an sms-only (or voice-only) request still
+        // returns the other channel. Narrow phone-type results by oobChannel when
+        // the caller asked for one but not both. Empty set = no narrowing (covers
+        // the return-all default and requests that don't mention sms/voice).
+        val wantedPhoneChannels = mutableSetOf<String>()
+        if (requested.contains("sms")) wantedPhoneChannels.add("sms")
+        if (requested.contains("voice")) wantedPhoneChannels.add("voice")
+        val narrowPhoneChannels = wantedPhoneChannels.size == 1
+
+        mfaClient.getAuthenticators(factors).start(
+            object : com.auth0.android.callback.Callback<List<Authenticator>, MfaException.MfaListAuthenticatorsException> {
+                override fun onSuccess(result: List<Authenticator>) {
+                    val array = WritableNativeArray()
+                    for (authenticator in result) {
+                        if (narrowPhoneChannels && authenticator.type == "phone") {
+                            val channel = authenticator.oobChannel
+                            if (channel == null || !wantedPhoneChannels.contains(channel)) {
+                                continue
+                            }
+                        }
+                        val map = WritableNativeMap().apply {
+                            putString("id", authenticator.id)
+                            putString("type", authenticator.type)
+                            putString("authenticatorType", authenticator.authenticatorType)
+                            putBoolean("active", authenticator.active)
+                            authenticator.name?.let { putString("name", it) }
+                            authenticator.oobChannel?.let { putString("oobChannel", it) }
+                        }
+                        array.pushMap(map)
+                    }
+                    promise.resolve(array)
+                }
+
+                override fun onFailure(error: MfaException.MfaListAuthenticatorsException) {
+                    promise.reject(error.getCode(), error.getDescription(), error)
+                }
+            }
+        )
+    }
+
+    fun enroll(mfaToken: String, type: String, value: String?, promise: Promise) {
+        val mfaClient = client.mfaClient(mfaToken)
+
+        val factorType = MfaFactorType.fromString(type)
+        if (factorType == null) {
+            promise.reject("MFA_ENROLLMENT_ERROR", "Unsupported enrollment type: $type")
+            return
+        }
+
+        val enrollmentType = when (factorType) {
+            MfaFactorType.PHONE -> {
+                if (value == null) {
+                    promise.reject("MFA_ENROLLMENT_ERROR", "Phone number is required for phone enrollment")
+                    return
+                }
+                MfaEnrollmentType.Phone(value)
+            }
+            MfaFactorType.EMAIL -> {
+                if (value == null) {
+                    promise.reject("MFA_ENROLLMENT_ERROR", "Email is required for email enrollment")
+                    return
+                }
+                MfaEnrollmentType.Email(value)
+            }
+            MfaFactorType.OTP -> MfaEnrollmentType.Otp
+            MfaFactorType.PUSH -> MfaEnrollmentType.Push
+            MfaFactorType.VOICE -> {
+                if (value == null) {
+                    promise.reject("MFA_ENROLLMENT_ERROR", "Phone number is required for voice enrollment")
+                    return
+                }
+                MfaEnrollmentType.Phone(value)
+            }
+        }
+
+        mfaClient.enroll(enrollmentType).start(
+            object : com.auth0.android.callback.Callback<EnrollmentChallenge, MfaException.MfaEnrollmentException> {
+                override fun onSuccess(result: EnrollmentChallenge) {
+                    val map = WritableNativeMap()
+                    when (result) {
+                        is TotpEnrollmentChallenge -> {
+                            // Push (Guardian) enrollment is deserialized by the SDK as a
+                            // TOTP challenge because the response carries barcode_uri.
+                            // Disambiguate using the requested factor type so the JS layer
+                            // receives a dedicated push challenge with the pairing QR.
+                            if (factorType == MfaFactorType.PUSH) {
+                                map.putString("type", "push")
+                                map.putString("barcodeUri", result.barcodeUri)
+                            } else {
+                                map.putString("type", "totp")
+                                map.putString("barcodeUri", result.barcodeUri)
+                                // Auth0.Android 3.21.0: /mfa/associate returns the
+                                // manual-entry key in `secret` (manualInputCode is null
+                                // on that endpoint).
+                                map.putString("secret", result.secret)
+                                result.recoveryCodes?.let {
+                                    val codes = WritableNativeArray()
+                                    for (code in it) codes.pushString(code)
+                                    map.putArray("recoveryCodes", codes)
+                                }
+                            }
+                        }
+                        is OobEnrollmentChallenge -> {
+                            map.putString("type", "oob")
+                            map.putString("oobCode", result.oobCode)
+                            result.bindingMethod?.let { map.putString("bindingMethod", it) }
+                        }
+                        is RecoveryCodeEnrollmentChallenge -> {
+                            map.putString("type", "recovery-code")
+                            map.putString("recoveryCode", result.recoveryCode)
+                        }
+                        else -> {
+                            map.putString("type", "unknown")
+                        }
+                    }
+                    promise.resolve(map)
+                }
+
+                override fun onFailure(error: MfaException.MfaEnrollmentException) {
+                    promise.reject(error.getCode(), error.getDescription(), error)
+                }
+            }
+        )
+    }
+
+    fun challenge(mfaToken: String, authenticatorId: String, promise: Promise) {
+        val mfaClient = client.mfaClient(mfaToken)
+
+        mfaClient.challenge(authenticatorId).start(
+            object : com.auth0.android.callback.Callback<com.auth0.android.result.Challenge, MfaException.MfaChallengeException> {
+                override fun onSuccess(result: com.auth0.android.result.Challenge) {
+                    val map = WritableNativeMap().apply {
+                        putString("challengeType", result.challengeType)
+                        result.oobCode?.let { putString("oobCode", it) }
+                        result.bindingMethod?.let { putString("bindingMethod", it) }
+                    }
+                    promise.resolve(map)
+                }
+
+                override fun onFailure(error: MfaException.MfaChallengeException) {
+                    promise.reject(error.getCode(), error.getDescription(), error)
+                }
+            }
+        )
+    }
+
+    fun verify(mfaToken: String, type: String, code: String, bindingCode: String?, scope: String?, audience: String?, promise: Promise) {
+        val verifyType = MfaVerifyType.fromString(type)
+        if (verifyType == null) {
+            promise.reject("MFA_VERIFY_ERROR", "Unsupported verification type: $type")
+            return
+        }
+
+        val mfaClient = client.mfaClient(mfaToken)
+
+        val verificationType = when (verifyType) {
+            MfaVerifyType.OTP -> MfaVerificationType.Otp(code)
+            MfaVerifyType.OOB -> MfaVerificationType.Oob(oobCode = code, bindingCode = bindingCode)
+            MfaVerifyType.RECOVERY_CODE -> MfaVerificationType.RecoveryCode(code)
+        }
+
+        val verifyRequest = mfaClient.verify(verificationType)
+        scope?.let { verifyRequest.addParameter("scope", it) }
+        audience?.let { verifyRequest.addParameter("audience", it) }
+
+        verifyRequest.start(
+            object : com.auth0.android.callback.Callback<Credentials, MfaException.MfaVerifyException> {
+                override fun onSuccess(result: Credentials) {
+                    val map = CredentialsParser.toMap(result)
+                    promise.resolve(map)
+                }
+
+                override fun onFailure(error: MfaException.MfaVerifyException) {
+                    promise.reject(error.getCode(), error.getDescription(), error)
+                }
+            }
+        )
+    }
+}

--- a/android/src/main/java/com/auth0/react/MfaClient.kt
+++ b/android/src/main/java/com/auth0/react/MfaClient.kt
@@ -59,13 +59,15 @@ class MfaClient(
     // the `Authenticator.type` tokens Auth0.Android 3.21.0 filters against with
     // exact, case-sensitive equality. Note: sms and voice both surface as the
     // `phone` type, so neither can be isolated here (narrowed later by oobChannel);
-    // otp maps to both `otp` and `totp`.
+    // otp maps to both `otp` and `totp`. `recovery-code` is listable but not
+    // enrollable, so it maps through here yet is absent from the enum.
     private fun mapFactorType(factor: String): List<String> {
         return when (factor.lowercase()) {
             "otp" -> listOf("otp", "totp")
             "sms", "voice" -> listOf("phone")
             "email" -> listOf("email")
             "push" -> listOf("push-notification")
+            "recovery-code" -> listOf("recovery-code")
             else -> emptyList()
         }
     }
@@ -112,6 +114,7 @@ class MfaClient(
                 override fun onSuccess(result: List<Authenticator>) {
                     val array = WritableNativeArray()
                     for (authenticator in result) {
+                        // Drop the phone channel the caller didn't ask for.
                         if (narrowPhoneChannels && authenticator.type == "phone") {
                             val channel = authenticator.oobChannel
                             if (channel == null || !wantedPhoneChannels.contains(channel)) {

--- a/android/src/main/java/com/auth0/react/MyAccount.kt
+++ b/android/src/main/java/com/auth0/react/MyAccount.kt
@@ -294,8 +294,8 @@ class MyAccount(
             .start(object : com.auth0.android.callback.Callback<TotpEnrollmentChallenge, MyAccountException> {
                 override fun onSuccess(challenge: TotpEnrollmentChallenge) {
                     val result = WritableNativeMap().apply {
-                        putString("id", challenge.id)
-                        putString("authSession", challenge.authSession)
+                        challenge.id?.let { putString("id", it) }
+                        challenge.authSession?.let { putString("authSession", it) }
                         putString("barcodeUri", challenge.barcodeUri)
                         challenge.manualInputCode?.let { putString("manualInputCode", it) }
                     }
@@ -318,8 +318,8 @@ class MyAccount(
             .start(object : com.auth0.android.callback.Callback<TotpEnrollmentChallenge, MyAccountException> {
                 override fun onSuccess(challenge: TotpEnrollmentChallenge) {
                     val result = WritableNativeMap().apply {
-                        putString("id", challenge.id)
-                        putString("authSession", challenge.authSession)
+                        challenge.id?.let { putString("id", it) }
+                        challenge.authSession?.let { putString("authSession", it) }
                         putString("barcodeUri", challenge.barcodeUri)
                         challenge.manualInputCode?.let { putString("manualInputCode", it) }
                     }

--- a/android/src/main/oldarch/com/auth0/react/A0Auth0Spec.kt
+++ b/android/src/main/oldarch/com/auth0/react/A0Auth0Spec.kt
@@ -131,6 +131,44 @@ abstract class A0Auth0Spec(context: ReactApplicationContext) : ReactContextBaseJ
 
     @ReactMethod
     @DoNotStrip
+    abstract fun getMfaAuthenticators(
+        mfaToken: String,
+        factorsAllowed: com.facebook.react.bridge.ReadableArray?,
+        promise: Promise
+    )
+
+
+    @ReactMethod
+    @DoNotStrip
+    abstract fun mfaEnroll(
+        mfaToken: String,
+        type: String,
+        value: String?,
+        promise: Promise
+    )
+
+    @ReactMethod
+    @DoNotStrip
+    abstract fun mfaChallenge(
+        mfaToken: String,
+        authenticatorId: String,
+        promise: Promise
+    )
+
+    @ReactMethod
+    @DoNotStrip
+    abstract fun mfaVerify(
+        mfaToken: String,
+        type: String,
+        code: String,
+        bindingCode: String?,
+        scope: String?,
+        audience: String?,
+        promise: Promise
+    )
+    
+    @ReactMethod
+    @DoNotStrip
     abstract fun passkeySignupChallenge(
         email: String?,
         phoneNumber: String?,
@@ -166,8 +204,6 @@ abstract class A0Auth0Spec(context: ReactApplicationContext) : ReactContextBaseJ
         promise: Promise
     )
 
-    @ReactMethod
-    @DoNotStrip
     abstract fun passkeyEnrollmentChallenge(
         accessToken: String,
         userIdentity: String?,

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -6,6 +6,10 @@ buildscript {
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
         kotlinVersion = "2.1.20"
+        // react-native-gesture-handler resolves react-native via a `node --print`
+        // fallback that is unreliable in this monorepo layout; pin the location
+        // explicitly so its build.gradle skips the fallback.
+        REACT_NATIVE_NODE_MODULES_DIR = file("$rootDir/../node_modules/react-native")
     }
     repositories {
         google()

--- a/example/src/App.web.tsx
+++ b/example/src/App.web.tsx
@@ -6,14 +6,39 @@ import {
   Text,
   StyleSheet,
   ActivityIndicator,
+  TouchableOpacity,
+  Image,
+  Linking,
 } from 'react-native';
-import Auth0, { Auth0Provider, useAuth0, User } from 'react-native-auth0';
+import Auth0, {
+  Auth0Provider,
+  useAuth0,
+  User,
+  MfaError,
+  MfaErrorCodes,
+  MfaFactorType,
+} from 'react-native-auth0';
+import type {
+  MfaAuthenticator,
+  MfaEnrollmentChallenge,
+  MfaChallengeResult,
+} from 'react-native-auth0';
 
 import config from './auth0-configuration';
 import Button from './components/Button';
 import Header from './components/Header';
 import Result from './components/Result';
 import LabeledInput from './components/LabeledInput';
+
+type MfaStep =
+  | 'idle'
+  | 'list'
+  | 'enroll-select'
+  | 'enroll-details'
+  | 'verify'
+  | 'complete';
+
+type EnrollType = MfaFactorType;
 
 // ========================================================================
 // --- 1. HOOKS-BASED IMPLEMENTATION (Recommended) ---
@@ -29,7 +54,8 @@ const HooksAuthContent = (): React.JSX.Element => {
     getCredentials,
     createUser,
     resetPassword,
-    auth,
+    loginWithPasswordRealm,
+    mfa,
     users,
   } = useAuth0();
 
@@ -38,6 +64,41 @@ const HooksAuthContent = (): React.JSX.Element => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
+  // MFA wizard state
+  const [mfaToken, setMfaToken] = useState('');
+  const [mfaStep, setMfaStep] = useState<MfaStep>('idle');
+  const [mfaLoading, setMfaLoading] = useState(false);
+  const [authenticators, setAuthenticators] = useState<MfaAuthenticator[]>([]);
+  const [selectedAuthenticator, setSelectedAuthenticator] =
+    useState<MfaAuthenticator | null>(null);
+  const [enrollType, setEnrollType] = useState<EnrollType | null>(null);
+  const [enrollPhoneNumber, setEnrollPhoneNumber] = useState('');
+  const [enrollEmail, setEnrollEmail] = useState('');
+  const [enrollmentChallenge, setEnrollmentChallenge] =
+    useState<MfaEnrollmentChallenge | null>(null);
+  const [challengeResult, setChallengeResult] =
+    useState<MfaChallengeResult | null>(null);
+  const [verifyCode, setVerifyCode] = useState('');
+  const [verifyBindingCode, setVerifyBindingCode] = useState('');
+  const [verifyScope, setVerifyScope] = useState('');
+  const [verifyAudience, setVerifyAudience] = useState('');
+
+  const resetMfaWizard = () => {
+    setMfaStep('idle');
+    setAuthenticators([]);
+    setSelectedAuthenticator(null);
+    setEnrollType(null);
+    setEnrollPhoneNumber('');
+    setEnrollEmail('');
+    setEnrollmentChallenge(null);
+    setChallengeResult(null);
+    setVerifyCode('');
+    setVerifyBindingCode('');
+    setVerifyScope('');
+    setVerifyAudience('');
+    setMfaLoading(false);
+  };
+
   const runDemo = async (action: () => Promise<any>) => {
     setResult(null);
     setApiError(null);
@@ -45,7 +106,154 @@ const HooksAuthContent = (): React.JSX.Element => {
       const response = await action();
       setResult(response ?? { success: true });
     } catch (e) {
+      if (e instanceof MfaError) {
+        setApiError(e);
+        return;
+      }
       setApiError(e as Error);
+    }
+  };
+
+  const handleMfaError = (e: unknown, fallbackMsg: string) => {
+    if (e instanceof MfaError) {
+      if (
+        e.type === MfaErrorCodes.EXPIRED_MFA_TOKEN ||
+        e.type === MfaErrorCodes.INVALID_MFA_TOKEN
+      ) {
+        setMfaToken('');
+        resetMfaWizard();
+      }
+      setApiError(e);
+    } else {
+      setApiError(e as Error);
+    }
+  };
+
+  const onMfaStart = async () => {
+    setMfaLoading(true);
+    setApiError(null);
+    try {
+      const list = await mfa.getAuthenticators({
+        mfaToken,
+        factorsAllowed: [
+          MfaFactorType.OTP,
+          MfaFactorType.SMS,
+          MfaFactorType.VOICE,
+          MfaFactorType.EMAIL,
+          MfaFactorType.PUSH,
+        ],
+      });
+      setAuthenticators(list);
+      setMfaStep('list');
+    } catch (e) {
+      handleMfaError(e, 'Failed to list authenticators.');
+    } finally {
+      setMfaLoading(false);
+    }
+  };
+
+  const onMfaSelectAuthenticator = async (auth: MfaAuthenticator) => {
+    setSelectedAuthenticator(auth);
+    setMfaLoading(true);
+    try {
+      const res = await mfa.challenge({ mfaToken, authenticatorId: auth.id });
+      setChallengeResult(res);
+      setMfaStep('verify');
+    } catch (e) {
+      handleMfaError(e, 'Challenge failed.');
+      setMfaStep('list');
+    } finally {
+      setMfaLoading(false);
+    }
+  };
+
+  const onMfaSelectEnrollType = (type: EnrollType) => {
+    setEnrollType(type);
+    if (type === MfaFactorType.OTP || type === MfaFactorType.PUSH) {
+      onMfaEnroll(type);
+    } else {
+      setMfaStep('enroll-details');
+    }
+  };
+
+  const onMfaEnroll = async (type?: EnrollType) => {
+    const factor = type || enrollType;
+    if (!factor) return;
+    setMfaLoading(true);
+    try {
+      let challenge: MfaEnrollmentChallenge;
+      if (factor === MfaFactorType.SMS) {
+        challenge = await mfa.enroll({
+          mfaToken,
+          factorType: MfaFactorType.SMS,
+          phoneNumber: enrollPhoneNumber,
+        });
+      } else if (factor === MfaFactorType.VOICE) {
+        challenge = await mfa.enroll({
+          mfaToken,
+          factorType: MfaFactorType.VOICE,
+          phoneNumber: enrollPhoneNumber,
+        });
+      } else if (factor === MfaFactorType.EMAIL) {
+        challenge = await mfa.enroll({
+          mfaToken,
+          factorType: MfaFactorType.EMAIL,
+          email: enrollEmail,
+        });
+      } else {
+        challenge = await mfa.enroll({ mfaToken, factorType: factor });
+      }
+      setEnrollmentChallenge(challenge);
+      setMfaStep('verify');
+    } catch (e) {
+      handleMfaError(e, 'Enrollment failed.');
+    } finally {
+      setMfaLoading(false);
+    }
+  };
+
+  const onMfaVerify = async () => {
+    setMfaLoading(true);
+    try {
+      let credentials;
+      // scope/audience are optional: supply them to mint an access token for a
+      // specific API once MFA succeeds.
+      const extra = {
+        scope: verifyScope || undefined,
+        audience: verifyAudience || undefined,
+      };
+      const oobCode =
+        challengeResult?.oobCode ||
+        (enrollmentChallenge?.type === 'oob' ||
+        enrollmentChallenge?.type === 'push'
+          ? enrollmentChallenge.oobCode
+          : undefined);
+
+      if (oobCode) {
+        credentials = await mfa.verify({
+          mfaToken,
+          oobCode,
+          bindingCode: verifyBindingCode || undefined,
+          ...extra,
+        });
+      } else if (enrollmentChallenge?.type === 'recovery-code') {
+        credentials = await mfa.verify({
+          mfaToken,
+          recoveryCode: verifyCode,
+          ...extra,
+        });
+      } else {
+        credentials = await mfa.verify({ mfaToken, otp: verifyCode, ...extra });
+      }
+      setResult({
+        success: true,
+        accessToken: credentials.accessToken.substring(0, 20) + '...',
+      });
+      setMfaStep('complete');
+    } catch (e) {
+      handleMfaError(e, 'Verification failed.');
+    } finally {
+      setMfaLoading(false);
     }
   };
 
@@ -91,9 +299,9 @@ const HooksAuthContent = (): React.JSX.Element => {
               title="Log In"
             />
           </Section>
-          <Section title="User Self-Service">
+          <Section title="Database Login">
             <LabeledInput
-              label="Email"
+              label="Username or Email"
               value={email}
               onChangeText={setEmail}
               autoCapitalize="none"
@@ -105,6 +313,29 @@ const HooksAuthContent = (): React.JSX.Element => {
               onChangeText={setPassword}
               secureTextEntry
             />
+            <Button
+              onPress={() =>
+                runDemo(async () => {
+                  try {
+                    return await loginWithPasswordRealm({
+                      username: email,
+                      password: password,
+                      realm: 'Username-Password-Authentication',
+                    });
+                  } catch (e: any) {
+                    if (e?.json?.mfa_token) {
+                      setMfaToken(e.json.mfa_token);
+                    }
+                    throw e;
+                  }
+                })
+              }
+              title="Log In with Password"
+            />
+            <Text style={styles.hint}>
+              If MFA is enabled, a failed login will return an mfa_token that
+              auto-populates below.
+            </Text>
             <Button
               onPress={() =>
                 runDemo(() =>
@@ -129,15 +360,271 @@ const HooksAuthContent = (): React.JSX.Element => {
               title="Reset Password"
             />
           </Section>
-          <Section title="Unsupported Web Methods (Will Fail)">
-            <Button
-              onPress={() =>
-                runDemo(() =>
-                  auth.passwordRealm({ username: '', password: '', realm: '' })
-                )
-              }
-              title="Test auth.passwordRealm()"
-            />
+          <Section title="MFA Flexible Factors Grant">
+            {mfaStep === 'idle' && (
+              <>
+                <Text style={styles.hint}>
+                  Get an mfa_token from a password login with MFA enabled.
+                </Text>
+                <LabeledInput
+                  label="MFA Token"
+                  value={mfaToken}
+                  onChangeText={setMfaToken}
+                  placeholder="Paste mfa_token here"
+                />
+                <Button
+                  onPress={onMfaStart}
+                  title="Start MFA"
+                  disabled={!mfaToken || mfaLoading}
+                />
+              </>
+            )}
+            {mfaStep === 'list' && (
+              <>
+                <Text style={styles.sectionTitle}>
+                  Step 1: Select Authenticator
+                </Text>
+                {authenticators.length > 0 ? (
+                  authenticators.map((auth) => (
+                    <TouchableOpacity
+                      key={auth.id}
+                      style={webStyles.authItem}
+                      onPress={() => onMfaSelectAuthenticator(auth)}
+                    >
+                      <Text style={webStyles.authItemTitle}>
+                        {auth.type ?? auth.authenticatorType}
+                        {auth.oobChannel ? ` (${auth.oobChannel})` : ''}
+                      </Text>
+                      <Text style={webStyles.authItemSub}>
+                        {auth.id} · authenticatorType: {auth.authenticatorType}
+                        {auth.active ? '' : ' · inactive'}
+                      </Text>
+                    </TouchableOpacity>
+                  ))
+                ) : (
+                  <Text style={styles.hint}>No authenticators enrolled.</Text>
+                )}
+                <Button
+                  onPress={() => setMfaStep('enroll-select')}
+                  title="Enroll New Authenticator"
+                />
+                <Button onPress={resetMfaWizard} title="Back" />
+              </>
+            )}
+            {mfaStep === 'enroll-select' && (
+              <>
+                <Text style={styles.sectionTitle}>
+                  Step 2: Choose Factor Type
+                </Text>
+                <Button
+                  onPress={() => onMfaSelectEnrollType(MfaFactorType.OTP)}
+                  title="TOTP (Authenticator App)"
+                  disabled={mfaLoading}
+                />
+                <Button
+                  onPress={() => onMfaSelectEnrollType(MfaFactorType.SMS)}
+                  title="SMS"
+                  disabled={mfaLoading}
+                />
+                <Button
+                  onPress={() => onMfaSelectEnrollType(MfaFactorType.VOICE)}
+                  title="Voice"
+                  disabled={mfaLoading}
+                />
+                <Text style={styles.hint}>
+                  Voice is a distinct channel on web. On native it falls back to
+                  SMS on the same number.
+                </Text>
+                <Button
+                  onPress={() => onMfaSelectEnrollType(MfaFactorType.EMAIL)}
+                  title="Email"
+                  disabled={mfaLoading}
+                />
+                <Button
+                  onPress={() => onMfaSelectEnrollType(MfaFactorType.PUSH)}
+                  title="Push Notification"
+                  disabled={mfaLoading}
+                />
+                <Button onPress={() => setMfaStep('list')} title="Back" />
+              </>
+            )}
+            {mfaStep === 'enroll-details' && (
+              <>
+                <Text style={styles.sectionTitle}>Step 2: Enter Details</Text>
+                {(enrollType === MfaFactorType.SMS ||
+                  enrollType === MfaFactorType.VOICE) && (
+                  <>
+                    <LabeledInput
+                      label="Phone Number"
+                      value={enrollPhoneNumber}
+                      onChangeText={setEnrollPhoneNumber}
+                      placeholder="+12025550135"
+                    />
+                    <Button
+                      onPress={() => onMfaEnroll()}
+                      title={
+                        enrollType === MfaFactorType.VOICE
+                          ? 'Enroll Voice'
+                          : 'Enroll SMS'
+                      }
+                      disabled={!enrollPhoneNumber || mfaLoading}
+                    />
+                  </>
+                )}
+                {enrollType === MfaFactorType.EMAIL && (
+                  <>
+                    <LabeledInput
+                      label="Email"
+                      value={enrollEmail}
+                      onChangeText={setEnrollEmail}
+                      placeholder="user@example.com"
+                    />
+                    <Button
+                      onPress={() => onMfaEnroll()}
+                      title="Enroll Email"
+                      disabled={!enrollEmail || mfaLoading}
+                    />
+                  </>
+                )}
+                <Button
+                  onPress={() => setMfaStep('enroll-select')}
+                  title="Back"
+                />
+              </>
+            )}
+            {mfaStep === 'verify' && (
+              <>
+                <Text style={styles.sectionTitle}>Step 3: Verify</Text>
+                {enrollmentChallenge?.type === 'totp' && (
+                  <View style={webStyles.infoBox}>
+                    {enrollmentChallenge.barcodeUri && (
+                      <>
+                        <View style={webStyles.qrContainer}>
+                          <Image
+                            source={{
+                              uri: `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(enrollmentChallenge.barcodeUri)}`,
+                            }}
+                            style={webStyles.qrImage}
+                          />
+                        </View>
+                        <Button
+                          onPress={() =>
+                            Linking.openURL(enrollmentChallenge.barcodeUri!)
+                          }
+                          title="Open in Authenticator App"
+                        />
+                      </>
+                    )}
+                    <Text>Secret: {enrollmentChallenge.secret}</Text>
+                  </View>
+                )}
+                {enrollmentChallenge?.type === 'push' && (
+                  <View style={webStyles.infoBox}>
+                    <Text style={styles.hint}>
+                      Scan this QR with the Auth0 Guardian app to pair, then
+                      approve the push notification on your device.
+                    </Text>
+                    {enrollmentChallenge.barcodeUri ? (
+                      <View style={webStyles.qrContainer}>
+                        <Image
+                          source={{
+                            uri: `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(enrollmentChallenge.barcodeUri)}`,
+                          }}
+                          style={webStyles.qrImage}
+                        />
+                      </View>
+                    ) : null}
+                    <Button
+                      onPress={onMfaVerify}
+                      title="I've approved the push"
+                      disabled={mfaLoading}
+                    />
+                  </View>
+                )}
+                {enrollmentChallenge?.type === 'recovery-code' ? (
+                  <View style={webStyles.infoBox}>
+                    <Text style={styles.hint}>
+                      Save this recovery code — it is shown only once. Enter it
+                      below to complete verification.
+                    </Text>
+                    <Text selectable>
+                      Recovery Code: {enrollmentChallenge.recoveryCode}
+                    </Text>
+                    <LabeledInput
+                      label="Confirm Recovery Code"
+                      value={verifyCode}
+                      onChangeText={setVerifyCode}
+                      placeholder="Re-enter the recovery code"
+                    />
+                    <Button
+                      onPress={onMfaVerify}
+                      title="Verify"
+                      disabled={!verifyCode || mfaLoading}
+                    />
+                  </View>
+                ) : challengeResult?.challengeType === 'oob' ||
+                  enrollmentChallenge?.type === 'oob' ? (
+                  <>
+                    <Text style={styles.hint}>
+                      A code has been sent. Enter the binding code below.
+                    </Text>
+                    <LabeledInput
+                      label="Binding Code"
+                      value={verifyBindingCode}
+                      onChangeText={setVerifyBindingCode}
+                      placeholder="Code from SMS/email"
+                    />
+                    <Button
+                      onPress={onMfaVerify}
+                      title="Verify"
+                      disabled={!verifyBindingCode || mfaLoading}
+                    />
+                  </>
+                ) : (
+                  <>
+                    <LabeledInput
+                      label="OTP Code"
+                      value={verifyCode}
+                      onChangeText={setVerifyCode}
+                      placeholder="6-digit code"
+                    />
+                    <Button
+                      onPress={onMfaVerify}
+                      title="Verify"
+                      disabled={!verifyCode || mfaLoading}
+                    />
+                  </>
+                )}
+                <Text style={styles.hint}>
+                  Optional: request a scope/audience to mint an API access token
+                  on successful verification.
+                </Text>
+                <LabeledInput
+                  label="Scope (optional)"
+                  value={verifyScope}
+                  onChangeText={setVerifyScope}
+                  placeholder="openid profile email"
+                />
+                <LabeledInput
+                  label="Audience (optional)"
+                  value={verifyAudience}
+                  onChangeText={setVerifyAudience}
+                  placeholder={`https://${config.domain}/api/v2/`}
+                />
+                <Button onPress={() => setMfaStep('list')} title="Back" />
+              </>
+            )}
+            {mfaStep === 'complete' && (
+              <>
+                <Text style={webStyles.successText}>
+                  Authentication successful!
+                </Text>
+                {result && (
+                  <Result title="Credentials" error={null} result={result} />
+                )}
+                <Button onPress={resetMfaWizard} title="Done" />
+              </>
+            )}
           </Section>
         </>
       )}
@@ -158,11 +645,24 @@ const HooksApp = () => (
 interface ClassAppState {
   auth0: Auth0;
   user: User | null;
-  result: any; // Can hold credentials or other results
+  result: any;
   apiError: Error | null;
   isLoading: boolean;
   email: string;
   password: string;
+  mfaToken: string;
+  mfaStep: MfaStep;
+  mfaLoading: boolean;
+  authenticators: MfaAuthenticator[];
+  enrollType: EnrollType | null;
+  enrollPhoneNumber: string;
+  enrollEmail: string;
+  enrollmentChallenge: MfaEnrollmentChallenge | null;
+  challengeResult: MfaChallengeResult | null;
+  verifyCode: string;
+  verifyBindingCode: string;
+  verifyScope: string;
+  verifyAudience: string;
 }
 
 class ClassApp extends React.Component<{}, ClassAppState> {
@@ -174,6 +674,19 @@ class ClassApp extends React.Component<{}, ClassAppState> {
     isLoading: true,
     email: '',
     password: '',
+    mfaToken: '',
+    mfaStep: 'idle',
+    mfaLoading: false,
+    authenticators: [],
+    enrollType: null,
+    enrollPhoneNumber: '',
+    enrollEmail: '',
+    enrollmentChallenge: null,
+    challengeResult: null,
+    verifyCode: '',
+    verifyBindingCode: '',
+    verifyScope: '',
+    verifyAudience: '',
   };
 
   componentDidMount() {
@@ -239,8 +752,183 @@ class ClassApp extends React.Component<{}, ClassAppState> {
     }
   };
 
+  resetMfaWizard = () => {
+    this.setState({
+      mfaStep: 'idle',
+      authenticators: [],
+      enrollType: null,
+      enrollPhoneNumber: '',
+      enrollEmail: '',
+      enrollmentChallenge: null,
+      challengeResult: null,
+      verifyCode: '',
+      verifyBindingCode: '',
+      verifyScope: '',
+      verifyAudience: '',
+      mfaLoading: false,
+    });
+  };
+
+  onMfaStart = async () => {
+    this.setState({ mfaLoading: true, apiError: null });
+    try {
+      const list = await this.state.auth0.mfa.getAuthenticators({
+        mfaToken: this.state.mfaToken,
+        factorsAllowed: [
+          MfaFactorType.OTP,
+          MfaFactorType.SMS,
+          MfaFactorType.VOICE,
+          MfaFactorType.EMAIL,
+          MfaFactorType.PUSH,
+        ],
+      });
+      this.setState({ authenticators: list, mfaStep: 'list' });
+    } catch (e) {
+      this.setState({ apiError: e as Error });
+    } finally {
+      this.setState({ mfaLoading: false });
+    }
+  };
+
+  onMfaChallenge = async (auth: MfaAuthenticator) => {
+    this.setState({ mfaLoading: true });
+    try {
+      const res = await this.state.auth0.mfa.challenge({
+        mfaToken: this.state.mfaToken,
+        authenticatorId: auth.id,
+      });
+      this.setState({ challengeResult: res, mfaStep: 'verify' });
+    } catch (e) {
+      this.setState({ apiError: e as Error, mfaStep: 'list' });
+    } finally {
+      this.setState({ mfaLoading: false });
+    }
+  };
+
+  onMfaEnroll = async (type?: EnrollType) => {
+    const factor = type || this.state.enrollType;
+    if (!factor) return;
+    this.setState({ mfaLoading: true });
+    try {
+      let challenge: MfaEnrollmentChallenge;
+      const {
+        mfaToken,
+        enrollPhoneNumber: phone,
+        enrollEmail: em,
+      } = this.state;
+      if (factor === MfaFactorType.SMS) {
+        challenge = await this.state.auth0.mfa.enroll({
+          mfaToken,
+          factorType: MfaFactorType.SMS,
+          phoneNumber: phone,
+        });
+      } else if (factor === MfaFactorType.VOICE) {
+        challenge = await this.state.auth0.mfa.enroll({
+          mfaToken,
+          factorType: MfaFactorType.VOICE,
+          phoneNumber: phone,
+        });
+      } else if (factor === MfaFactorType.EMAIL) {
+        challenge = await this.state.auth0.mfa.enroll({
+          mfaToken,
+          factorType: MfaFactorType.EMAIL,
+          email: em,
+        });
+      } else {
+        challenge = await this.state.auth0.mfa.enroll({
+          mfaToken,
+          factorType: factor,
+        });
+      }
+      this.setState({ enrollmentChallenge: challenge, mfaStep: 'verify' });
+    } catch (e) {
+      this.setState({ apiError: e as Error });
+    } finally {
+      this.setState({ mfaLoading: false });
+    }
+  };
+
+  onMfaVerify = async () => {
+    this.setState({ mfaLoading: true });
+    try {
+      const {
+        mfaToken,
+        challengeResult,
+        enrollmentChallenge,
+        verifyCode,
+        verifyBindingCode,
+        verifyScope,
+        verifyAudience,
+      } = this.state;
+      let credentials;
+      // scope/audience are optional: supply them to mint an access token for a
+      // specific API once MFA succeeds.
+      const extra = {
+        scope: verifyScope || undefined,
+        audience: verifyAudience || undefined,
+      };
+      const oobCode =
+        challengeResult?.oobCode ||
+        (enrollmentChallenge?.type === 'oob' ||
+        enrollmentChallenge?.type === 'push'
+          ? enrollmentChallenge.oobCode
+          : undefined);
+      if (oobCode) {
+        credentials = await this.state.auth0.mfa.verify({
+          mfaToken,
+          oobCode,
+          bindingCode: verifyBindingCode || undefined,
+          ...extra,
+        });
+      } else if (enrollmentChallenge?.type === 'recovery-code') {
+        credentials = await this.state.auth0.mfa.verify({
+          mfaToken,
+          recoveryCode: verifyCode,
+          ...extra,
+        });
+      } else {
+        credentials = await this.state.auth0.mfa.verify({
+          mfaToken,
+          otp: verifyCode,
+          ...extra,
+        });
+      }
+      this.setState({
+        result: {
+          success: true,
+          accessToken: credentials.accessToken.substring(0, 20) + '...',
+        },
+        mfaStep: 'complete',
+      });
+    } catch (e) {
+      this.setState({ apiError: e as Error });
+    } finally {
+      this.setState({ mfaLoading: false });
+    }
+  };
+
   render() {
-    const { user, result, apiError, isLoading, email, password } = this.state;
+    const {
+      user,
+      result,
+      apiError,
+      isLoading,
+      email,
+      password,
+      mfaToken,
+      mfaStep,
+      mfaLoading,
+      authenticators,
+      enrollType,
+      enrollPhoneNumber,
+      enrollEmail,
+      enrollmentChallenge,
+      challengeResult,
+      verifyCode,
+      verifyBindingCode,
+      verifyScope,
+      verifyAudience,
+    } = this.state;
     if (isLoading) {
       return (
         <View style={styles.content}>
@@ -283,9 +971,9 @@ class ClassApp extends React.Component<{}, ClassAppState> {
             <Section title="Web Auth (Recommended Flow)">
               <Button onPress={this.onLogin} title="Log In" />
             </Section>
-            <Section title="User Self-Service">
+            <Section title="Database Login">
               <LabeledInput
-                label="Email"
+                label="Username or Email"
                 value={email}
                 onChangeText={(val) => this.setState({ email: val })}
                 autoCapitalize="none"
@@ -297,6 +985,29 @@ class ClassApp extends React.Component<{}, ClassAppState> {
                 onChangeText={(val) => this.setState({ password: val })}
                 secureTextEntry
               />
+              <Button
+                onPress={() =>
+                  this.runDemo(async () => {
+                    try {
+                      return await this.state.auth0.auth.passwordRealm({
+                        username: email,
+                        password,
+                        realm: 'Username-Password-Authentication',
+                      });
+                    } catch (e: any) {
+                      if (e?.json?.mfa_token) {
+                        this.setState({ mfaToken: e.json.mfa_token });
+                      }
+                      throw e;
+                    }
+                  })
+                }
+                title="Log In with Password"
+              />
+              <Text style={styles.hint}>
+                If MFA is enabled, a failed login will return an mfa_token that
+                auto-populates below.
+              </Text>
               <Button
                 onPress={() =>
                   this.runDemo(() =>
@@ -321,19 +1032,315 @@ class ClassApp extends React.Component<{}, ClassAppState> {
                 title="Reset Password"
               />
             </Section>
-            <Section title="Unsupported Web Methods (Will Fail)">
-              <Button
-                onPress={() =>
-                  this.runDemo(() =>
-                    this.state.auth0.auth.passwordRealm({
-                      username: '',
-                      password: '',
-                      realm: '',
-                    })
-                  )
-                }
-                title="Test auth.passwordRealm()"
-              />
+            <Section title="MFA Flexible Factors Grant">
+              {mfaStep === 'idle' && (
+                <>
+                  <Text style={styles.hint}>
+                    Get an mfa_token from a password login with MFA enabled.
+                  </Text>
+                  <LabeledInput
+                    label="MFA Token"
+                    value={mfaToken}
+                    onChangeText={(val: string) =>
+                      this.setState({ mfaToken: val })
+                    }
+                    placeholder="Paste mfa_token here"
+                  />
+                  <Button
+                    onPress={this.onMfaStart}
+                    title="Start MFA"
+                    disabled={!mfaToken || mfaLoading}
+                  />
+                </>
+              )}
+              {mfaStep === 'list' && (
+                <>
+                  <Text style={styles.sectionTitle}>
+                    Step 1: Select Authenticator
+                  </Text>
+                  {authenticators.length > 0 ? (
+                    authenticators.map((auth) => (
+                      <TouchableOpacity
+                        key={auth.id}
+                        style={webStyles.authItem}
+                        onPress={() => this.onMfaChallenge(auth)}
+                      >
+                        <Text style={webStyles.authItemTitle}>
+                          {auth.type ?? auth.authenticatorType}
+                          {auth.oobChannel ? ` (${auth.oobChannel})` : ''}
+                        </Text>
+                        <Text style={webStyles.authItemSub}>
+                          {auth.id} · authenticatorType:{' '}
+                          {auth.authenticatorType}
+                          {auth.active ? '' : ' · inactive'}
+                        </Text>
+                      </TouchableOpacity>
+                    ))
+                  ) : (
+                    <Text style={styles.hint}>No authenticators enrolled.</Text>
+                  )}
+                  <Button
+                    onPress={() => this.setState({ mfaStep: 'enroll-select' })}
+                    title="Enroll New Authenticator"
+                  />
+                  <Button onPress={this.resetMfaWizard} title="Back" />
+                </>
+              )}
+              {mfaStep === 'enroll-select' && (
+                <>
+                  <Text style={styles.sectionTitle}>
+                    Step 2: Choose Factor Type
+                  </Text>
+                  <Button
+                    onPress={() => {
+                      this.setState({ enrollType: MfaFactorType.OTP });
+                      this.onMfaEnroll(MfaFactorType.OTP);
+                    }}
+                    title="TOTP (Authenticator App)"
+                    disabled={mfaLoading}
+                  />
+                  <Button
+                    onPress={() =>
+                      this.setState({
+                        enrollType: MfaFactorType.SMS,
+                        mfaStep: 'enroll-details',
+                      })
+                    }
+                    title="SMS"
+                    disabled={mfaLoading}
+                  />
+                  <Button
+                    onPress={() =>
+                      this.setState({
+                        enrollType: MfaFactorType.VOICE,
+                        mfaStep: 'enroll-details',
+                      })
+                    }
+                    title="Voice"
+                    disabled={mfaLoading}
+                  />
+                  <Text style={styles.hint}>
+                    Voice is a distinct channel on web. On native it falls back
+                    to SMS on the same number.
+                  </Text>
+                  <Button
+                    onPress={() =>
+                      this.setState({
+                        enrollType: MfaFactorType.EMAIL,
+                        mfaStep: 'enroll-details',
+                      })
+                    }
+                    title="Email"
+                    disabled={mfaLoading}
+                  />
+                  <Button
+                    onPress={() => {
+                      this.setState({ enrollType: MfaFactorType.PUSH });
+                      this.onMfaEnroll(MfaFactorType.PUSH);
+                    }}
+                    title="Push Notification"
+                    disabled={mfaLoading}
+                  />
+                  <Button
+                    onPress={() => this.setState({ mfaStep: 'list' })}
+                    title="Back"
+                  />
+                </>
+              )}
+              {mfaStep === 'enroll-details' && (
+                <>
+                  <Text style={styles.sectionTitle}>Step 2: Enter Details</Text>
+                  {(enrollType === MfaFactorType.SMS ||
+                    enrollType === MfaFactorType.VOICE) && (
+                    <>
+                      <LabeledInput
+                        label="Phone Number"
+                        value={enrollPhoneNumber}
+                        onChangeText={(val: string) =>
+                          this.setState({ enrollPhoneNumber: val })
+                        }
+                        placeholder="+12025550135"
+                      />
+                      <Button
+                        onPress={() => this.onMfaEnroll()}
+                        title={
+                          enrollType === MfaFactorType.VOICE
+                            ? 'Enroll Voice'
+                            : 'Enroll SMS'
+                        }
+                        disabled={!enrollPhoneNumber || mfaLoading}
+                      />
+                    </>
+                  )}
+                  {enrollType === MfaFactorType.EMAIL && (
+                    <>
+                      <LabeledInput
+                        label="Email"
+                        value={enrollEmail}
+                        onChangeText={(val: string) =>
+                          this.setState({ enrollEmail: val })
+                        }
+                        placeholder="user@example.com"
+                      />
+                      <Button
+                        onPress={() => this.onMfaEnroll()}
+                        title="Enroll Email"
+                        disabled={!enrollEmail || mfaLoading}
+                      />
+                    </>
+                  )}
+                  <Button
+                    onPress={() => this.setState({ mfaStep: 'enroll-select' })}
+                    title="Back"
+                  />
+                </>
+              )}
+              {mfaStep === 'verify' && (
+                <>
+                  <Text style={styles.sectionTitle}>Step 3: Verify</Text>
+                  {enrollmentChallenge?.type === 'totp' && (
+                    <View style={webStyles.infoBox}>
+                      {enrollmentChallenge.barcodeUri && (
+                        <>
+                          <View style={webStyles.qrContainer}>
+                            <Image
+                              source={{
+                                uri: `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(enrollmentChallenge.barcodeUri)}`,
+                              }}
+                              style={webStyles.qrImage}
+                            />
+                          </View>
+                          <Button
+                            onPress={() =>
+                              Linking.openURL(enrollmentChallenge.barcodeUri!)
+                            }
+                            title="Open in Authenticator App"
+                          />
+                        </>
+                      )}
+                      <Text>Secret: {enrollmentChallenge.secret}</Text>
+                    </View>
+                  )}
+                  {enrollmentChallenge?.type === 'push' && (
+                    <View style={webStyles.infoBox}>
+                      <Text style={styles.hint}>
+                        Scan this QR with the Auth0 Guardian app to pair, then
+                        approve the push notification on your device.
+                      </Text>
+                      {enrollmentChallenge.barcodeUri ? (
+                        <View style={webStyles.qrContainer}>
+                          <Image
+                            source={{
+                              uri: `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(enrollmentChallenge.barcodeUri)}`,
+                            }}
+                            style={webStyles.qrImage}
+                          />
+                        </View>
+                      ) : null}
+                      <Button
+                        onPress={this.onMfaVerify}
+                        title="I've approved the push"
+                        disabled={mfaLoading}
+                      />
+                    </View>
+                  )}
+                  {enrollmentChallenge?.type === 'recovery-code' ? (
+                    <View style={webStyles.infoBox}>
+                      <Text style={styles.hint}>
+                        Save this recovery code — it is shown only once. Enter
+                        it below to complete verification.
+                      </Text>
+                      <Text selectable>
+                        Recovery Code: {enrollmentChallenge.recoveryCode}
+                      </Text>
+                      <LabeledInput
+                        label="Confirm Recovery Code"
+                        value={verifyCode}
+                        onChangeText={(val: string) =>
+                          this.setState({ verifyCode: val })
+                        }
+                        placeholder="Re-enter the recovery code"
+                      />
+                      <Button
+                        onPress={this.onMfaVerify}
+                        title="Verify"
+                        disabled={!verifyCode || mfaLoading}
+                      />
+                    </View>
+                  ) : challengeResult?.challengeType === 'oob' ||
+                    enrollmentChallenge?.type === 'oob' ? (
+                    <>
+                      <Text style={styles.hint}>
+                        A code has been sent. Enter the binding code below.
+                      </Text>
+                      <LabeledInput
+                        label="Binding Code"
+                        value={verifyBindingCode}
+                        onChangeText={(val: string) =>
+                          this.setState({ verifyBindingCode: val })
+                        }
+                        placeholder="Code from SMS/email"
+                      />
+                      <Button
+                        onPress={this.onMfaVerify}
+                        title="Verify"
+                        disabled={!verifyBindingCode || mfaLoading}
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <LabeledInput
+                        label="OTP Code"
+                        value={verifyCode}
+                        onChangeText={(val: string) =>
+                          this.setState({ verifyCode: val })
+                        }
+                        placeholder="6-digit code"
+                      />
+                      <Button
+                        onPress={this.onMfaVerify}
+                        title="Verify"
+                        disabled={!verifyCode || mfaLoading}
+                      />
+                    </>
+                  )}
+                  <Text style={styles.hint}>
+                    Optional: request a scope/audience to mint an API access
+                    token on successful verification.
+                  </Text>
+                  <LabeledInput
+                    label="Scope (optional)"
+                    value={verifyScope}
+                    onChangeText={(val: string) =>
+                      this.setState({ verifyScope: val })
+                    }
+                    placeholder="openid profile email"
+                  />
+                  <LabeledInput
+                    label="Audience (optional)"
+                    value={verifyAudience}
+                    onChangeText={(val: string) =>
+                      this.setState({ verifyAudience: val })
+                    }
+                    placeholder={`https://${config.domain}/api/v2/`}
+                  />
+                  <Button
+                    onPress={() => this.setState({ mfaStep: 'list' })}
+                    title="Back"
+                  />
+                </>
+              )}
+              {mfaStep === 'complete' && (
+                <>
+                  <Text style={webStyles.successText}>
+                    Authentication successful!
+                  </Text>
+                  {result && (
+                    <Result title="Credentials" error={null} result={result} />
+                  )}
+                  <Button onPress={this.resetMfaWizard} title="Done" />
+                </>
+              )}
             </Section>
           </>
         )}
@@ -402,6 +1409,7 @@ const styles = StyleSheet.create({
   },
   sectionTitle: { fontSize: 18, fontWeight: 'bold', marginBottom: 12 },
   buttonGroup: { gap: 10 },
+  hint: { fontSize: 12, color: '#888', fontStyle: 'italic', marginBottom: 8 },
   toggleContainer: {
     padding: 16,
     alignItems: 'center',
@@ -410,6 +1418,34 @@ const styles = StyleSheet.create({
     backgroundColor: '#fafafa',
   },
   toggleButton: { backgroundColor: '#6c757d' },
+});
+
+const webStyles = StyleSheet.create({
+  authItem: {
+    borderWidth: 1,
+    borderColor: '#CCC',
+    borderRadius: 6,
+    padding: 12,
+    backgroundColor: '#F9F9F9',
+    marginBottom: 8,
+  },
+  authItemTitle: { fontSize: 14, fontWeight: '600' },
+  authItemSub: { fontSize: 11, color: '#666', marginTop: 2 },
+  infoBox: {
+    backgroundColor: '#F0F4FF',
+    borderRadius: 6,
+    padding: 10,
+    marginBottom: 8,
+  },
+  successText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2E7D32',
+    textAlign: 'center',
+    marginBottom: 12,
+  },
+  qrContainer: { alignItems: 'center', marginVertical: 12 },
+  qrImage: { width: 200, height: 200 },
 });
 
 export default App;

--- a/example/src/screens/class-based/ClassApiTests.tsx
+++ b/example/src/screens/class-based/ClassApiTests.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { RouteProp } from '@react-navigation/native';
-import { MfaFactorType } from 'react-native-auth0';
 import auth0 from '../../api/auth0';
 import Button from '../../components/Button';
 import Header from '../../components/Header';
@@ -25,31 +24,7 @@ const ClassApiTestsScreen = ({ route }: Props) => {
   const [password, setPassword] = useState('P@ssword123'); // dummy password
   const [mfaToken, setMfaToken] = useState('');
   const [otp, setOtp] = useState('');
-  const [authenticatorId, setAuthenticatorId] = useState('');
   const [refreshToken, setRefreshToken] = useState('');
-  const [enrollPhone, setEnrollPhone] = useState('');
-  const [enrollEmailMfa, setEnrollEmailMfa] = useState('');
-  const [oobCode, setOobCode] = useState('');
-  const [bindingCode, setBindingCode] = useState('');
-  const [recoveryCode, setRecoveryCode] = useState('');
-  const [verifyScope, setVerifyScope] = useState('');
-  const [verifyAudience, setVerifyAudience] = useState('');
-
-  // mfa.verify() returns credentials; redact tokens before they reach the
-  // logged/displayed result panel. The refresh token is carried into state for
-  // subsequent tests but omitted from the returned object so runTest doesn't
-  // overwrite that state with a redacted placeholder.
-  const sanitizeCredentialResult = (res: Record<string, unknown>) => {
-    const { accessToken, refreshToken, idToken, ...safe } = res;
-    if (typeof refreshToken === 'string') {
-      setRefreshToken(refreshToken);
-    }
-    return {
-      ...safe,
-      ...(accessToken ? { accessToken: '[REDACTED]' } : {}),
-      ...(idToken ? { idToken: '[REDACTED]' } : {}),
-    };
-  };
 
   const runTest = async (testFn: () => Promise<any>, title: string) => {
     setError(null);
@@ -66,9 +41,6 @@ const ClassApiTestsScreen = ({ route }: Props) => {
       // If we got credentials, update our state for subsequent tests
       if (res?.mfa_token) setMfaToken(res.mfa_token);
       if (res?.refreshToken) setRefreshToken(res.refreshToken);
-      // Carry an oobCode forward from a challenge/enroll result so the verify
-      // call below can use it without manual copy/paste.
-      if (res?.oobCode) setOobCode(res.oobCode);
     } catch (e) {
       console.log('Error:', e);
       setError(e as Error);
@@ -154,169 +126,12 @@ const ClassApiTestsScreen = ({ route }: Props) => {
           />
         </Section>
 
-        <Section title="MFA Flexible Factors Grant">
-          <Text style={styles.hint}>
-            Uses auth0.mfa class-based API for flexible MFA operations.
-          </Text>
+        <Section title="Legacy MFA & Tokens">
           <LabeledInput
             label="MFA Token"
             value={mfaToken}
             onChangeText={setMfaToken}
             placeholder="From a failed password login"
-          />
-          <Button
-            onPress={() =>
-              runTest(
-                () =>
-                  auth0.mfa.getAuthenticators({
-                    mfaToken,
-                    factorsAllowed: [
-                      MfaFactorType.OTP,
-                      MfaFactorType.SMS,
-                      MfaFactorType.VOICE,
-                      MfaFactorType.EMAIL,
-                      MfaFactorType.PUSH,
-                    ],
-                  }),
-                'List Authenticators'
-              )
-            }
-            title="mfa.getAuthenticators()"
-            disabled={!mfaToken}
-          />
-          <Text style={styles.hint}>
-            Each authenticator carries a `type`
-            (otp/phone/email/push-notification) alongside `authenticatorType`
-            and `oobChannel`.
-          </Text>
-
-          <Text style={styles.subTitle}>Enroll a factor</Text>
-          <Button
-            onPress={() =>
-              runTest(
-                () =>
-                  auth0.mfa.enroll({ mfaToken, factorType: MfaFactorType.OTP }),
-                'Enroll TOTP'
-              )
-            }
-            title="mfa.enroll(otp)"
-            disabled={!mfaToken}
-          />
-          <Button
-            onPress={() =>
-              runTest(
-                () =>
-                  auth0.mfa.enroll({
-                    mfaToken,
-                    factorType: MfaFactorType.PUSH,
-                  }),
-                'Enroll Push'
-              )
-            }
-            title="mfa.enroll(push)"
-            disabled={!mfaToken}
-          />
-          <LabeledInput
-            label="Phone Number (SMS / Voice)"
-            value={enrollPhone}
-            onChangeText={setEnrollPhone}
-            placeholder="+12025550135"
-            keyboardType="phone-pad"
-          />
-          <Button
-            onPress={() =>
-              runTest(
-                () =>
-                  auth0.mfa.enroll({
-                    mfaToken,
-                    factorType: MfaFactorType.SMS,
-                    phoneNumber: enrollPhone,
-                  }),
-                'Enroll SMS'
-              )
-            }
-            title="mfa.enroll(sms)"
-            disabled={!mfaToken || !enrollPhone}
-          />
-          <Button
-            onPress={() =>
-              runTest(
-                () =>
-                  auth0.mfa.enroll({
-                    mfaToken,
-                    factorType: MfaFactorType.VOICE,
-                    phoneNumber: enrollPhone,
-                  }),
-                'Enroll Voice'
-              )
-            }
-            title="mfa.enroll(voice)"
-            disabled={!mfaToken || !enrollPhone}
-          />
-          <Text style={styles.hint}>
-            Voice is a distinct channel on web only. On native it falls back to
-            SMS on the same number.
-          </Text>
-          <LabeledInput
-            label="Email (MFA enroll)"
-            value={enrollEmailMfa}
-            onChangeText={setEnrollEmailMfa}
-            placeholder="user@example.com"
-            autoCapitalize="none"
-            keyboardType="email-address"
-          />
-          <Button
-            onPress={() =>
-              runTest(
-                () =>
-                  auth0.mfa.enroll({
-                    mfaToken,
-                    factorType: MfaFactorType.EMAIL,
-                    email: enrollEmailMfa,
-                  }),
-                'Enroll Email'
-              )
-            }
-            title="mfa.enroll(email)"
-            disabled={!mfaToken || !enrollEmailMfa}
-          />
-
-          <Text style={styles.subTitle}>Challenge</Text>
-          <LabeledInput
-            label="Authenticator ID"
-            value={authenticatorId}
-            onChangeText={setAuthenticatorId}
-            placeholder="e.g. sms|dev_123"
-          />
-          <Button
-            onPress={() =>
-              runTest(
-                () => auth0.mfa.challenge({ mfaToken, authenticatorId }),
-                'Challenge'
-              )
-            }
-            title="mfa.challenge()"
-            disabled={!mfaToken || !authenticatorId}
-          />
-
-          <Text style={styles.subTitle}>Verify</Text>
-          <Text style={styles.hint}>
-            Scope/audience are optional; supply them to mint an API access token
-            on successful verification.
-          </Text>
-          <LabeledInput
-            label="Scope (optional)"
-            value={verifyScope}
-            onChangeText={setVerifyScope}
-            placeholder="openid profile email"
-            autoCapitalize="none"
-          />
-          <LabeledInput
-            label="Audience (optional)"
-            value={verifyAudience}
-            onChangeText={setVerifyAudience}
-            placeholder="https://your-api/"
-            autoCapitalize="none"
           />
           <LabeledInput
             label="OTP Code"
@@ -327,90 +142,12 @@ const ClassApiTestsScreen = ({ route }: Props) => {
           <Button
             onPress={() =>
               runTest(
-                async () =>
-                  sanitizeCredentialResult(
-                    (await auth0.mfa.verify({
-                      mfaToken,
-                      otp,
-                      scope: verifyScope || undefined,
-                      audience: verifyAudience || undefined,
-                    })) as Record<string, unknown>
-                  ),
-                'Verify OTP'
-              )
-            }
-            title="mfa.verify(otp)"
-            disabled={!mfaToken || !otp}
-          />
-          <LabeledInput
-            label="OOB Code"
-            value={oobCode}
-            onChangeText={setOobCode}
-            placeholder="From challenge/enroll result"
-          />
-          <LabeledInput
-            label="Binding Code (SMS/Voice/Email)"
-            value={bindingCode}
-            onChangeText={setBindingCode}
-            keyboardType="numeric"
-            placeholder="Code from SMS/email/voice"
-          />
-          <Button
-            onPress={() =>
-              runTest(
-                async () =>
-                  sanitizeCredentialResult(
-                    (await auth0.mfa.verify({
-                      mfaToken,
-                      oobCode,
-                      bindingCode: bindingCode || undefined,
-                      scope: verifyScope || undefined,
-                      audience: verifyAudience || undefined,
-                    })) as Record<string, unknown>
-                  ),
-                'Verify OOB'
-              )
-            }
-            title="mfa.verify(oob)"
-            disabled={!mfaToken || !oobCode}
-          />
-          <LabeledInput
-            label="Recovery Code"
-            value={recoveryCode}
-            onChangeText={setRecoveryCode}
-            placeholder="Recovery code"
-            autoCapitalize="none"
-          />
-          <Button
-            onPress={() =>
-              runTest(
-                async () =>
-                  sanitizeCredentialResult(
-                    (await auth0.mfa.verify({
-                      mfaToken,
-                      recoveryCode,
-                      scope: verifyScope || undefined,
-                      audience: verifyAudience || undefined,
-                    })) as Record<string, unknown>
-                  ),
-                'Verify Recovery Code'
-              )
-            }
-            title="mfa.verify(recoveryCode)"
-            disabled={!mfaToken || !recoveryCode}
-          />
-        </Section>
-
-        <Section title="Legacy MFA & Tokens">
-          <Button
-            onPress={() =>
-              runTest(
                 () => auth0.auth.loginWithOTP({ mfaToken, otp }),
                 'Login with OTP'
               )
             }
             title="auth.loginWithOTP()"
-            disabled={!mfaToken}
+            disabled={!mfaToken || !otp}
           />
           <LabeledInput
             label="Refresh Token"
@@ -480,13 +217,6 @@ const styles = StyleSheet.create({
   },
   buttonGroup: {
     gap: 10,
-  },
-  hint: { fontSize: 12, color: '#888', fontStyle: 'italic' },
-  subTitle: {
-    fontSize: 14,
-    fontWeight: '700',
-    color: '#333',
-    marginTop: 8,
   },
 });
 

--- a/example/src/screens/class-based/ClassApiTests.tsx
+++ b/example/src/screens/class-based/ClassApiTests.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { RouteProp } from '@react-navigation/native';
+import { MfaFactorType } from 'react-native-auth0';
 import auth0 from '../../api/auth0';
 import Button from '../../components/Button';
 import Header from '../../components/Header';
@@ -24,7 +25,31 @@ const ClassApiTestsScreen = ({ route }: Props) => {
   const [password, setPassword] = useState('P@ssword123'); // dummy password
   const [mfaToken, setMfaToken] = useState('');
   const [otp, setOtp] = useState('');
+  const [authenticatorId, setAuthenticatorId] = useState('');
   const [refreshToken, setRefreshToken] = useState('');
+  const [enrollPhone, setEnrollPhone] = useState('');
+  const [enrollEmailMfa, setEnrollEmailMfa] = useState('');
+  const [oobCode, setOobCode] = useState('');
+  const [bindingCode, setBindingCode] = useState('');
+  const [recoveryCode, setRecoveryCode] = useState('');
+  const [verifyScope, setVerifyScope] = useState('');
+  const [verifyAudience, setVerifyAudience] = useState('');
+
+  // mfa.verify() returns credentials; redact tokens before they reach the
+  // logged/displayed result panel. The refresh token is carried into state for
+  // subsequent tests but omitted from the returned object so runTest doesn't
+  // overwrite that state with a redacted placeholder.
+  const sanitizeCredentialResult = (res: Record<string, unknown>) => {
+    const { accessToken, refreshToken, idToken, ...safe } = res;
+    if (typeof refreshToken === 'string') {
+      setRefreshToken(refreshToken);
+    }
+    return {
+      ...safe,
+      ...(accessToken ? { accessToken: '[REDACTED]' } : {}),
+      ...(idToken ? { idToken: '[REDACTED]' } : {}),
+    };
+  };
 
   const runTest = async (testFn: () => Promise<any>, title: string) => {
     setError(null);
@@ -41,6 +66,9 @@ const ClassApiTestsScreen = ({ route }: Props) => {
       // If we got credentials, update our state for subsequent tests
       if (res?.mfa_token) setMfaToken(res.mfa_token);
       if (res?.refreshToken) setRefreshToken(res.refreshToken);
+      // Carry an oobCode forward from a challenge/enroll result so the verify
+      // call below can use it without manual copy/paste.
+      if (res?.oobCode) setOobCode(res.oobCode);
     } catch (e) {
       console.log('Error:', e);
       setError(e as Error);
@@ -126,12 +154,169 @@ const ClassApiTestsScreen = ({ route }: Props) => {
           />
         </Section>
 
-        <Section title="MFA & Tokens">
+        <Section title="MFA Flexible Factors Grant">
+          <Text style={styles.hint}>
+            Uses auth0.mfa class-based API for flexible MFA operations.
+          </Text>
           <LabeledInput
             label="MFA Token"
             value={mfaToken}
             onChangeText={setMfaToken}
             placeholder="From a failed password login"
+          />
+          <Button
+            onPress={() =>
+              runTest(
+                () =>
+                  auth0.mfa.getAuthenticators({
+                    mfaToken,
+                    factorsAllowed: [
+                      MfaFactorType.OTP,
+                      MfaFactorType.SMS,
+                      MfaFactorType.VOICE,
+                      MfaFactorType.EMAIL,
+                      MfaFactorType.PUSH,
+                    ],
+                  }),
+                'List Authenticators'
+              )
+            }
+            title="mfa.getAuthenticators()"
+            disabled={!mfaToken}
+          />
+          <Text style={styles.hint}>
+            Each authenticator carries a `type`
+            (otp/phone/email/push-notification) alongside `authenticatorType`
+            and `oobChannel`.
+          </Text>
+
+          <Text style={styles.subTitle}>Enroll a factor</Text>
+          <Button
+            onPress={() =>
+              runTest(
+                () =>
+                  auth0.mfa.enroll({ mfaToken, factorType: MfaFactorType.OTP }),
+                'Enroll TOTP'
+              )
+            }
+            title="mfa.enroll(otp)"
+            disabled={!mfaToken}
+          />
+          <Button
+            onPress={() =>
+              runTest(
+                () =>
+                  auth0.mfa.enroll({
+                    mfaToken,
+                    factorType: MfaFactorType.PUSH,
+                  }),
+                'Enroll Push'
+              )
+            }
+            title="mfa.enroll(push)"
+            disabled={!mfaToken}
+          />
+          <LabeledInput
+            label="Phone Number (SMS / Voice)"
+            value={enrollPhone}
+            onChangeText={setEnrollPhone}
+            placeholder="+12025550135"
+            keyboardType="phone-pad"
+          />
+          <Button
+            onPress={() =>
+              runTest(
+                () =>
+                  auth0.mfa.enroll({
+                    mfaToken,
+                    factorType: MfaFactorType.SMS,
+                    phoneNumber: enrollPhone,
+                  }),
+                'Enroll SMS'
+              )
+            }
+            title="mfa.enroll(sms)"
+            disabled={!mfaToken || !enrollPhone}
+          />
+          <Button
+            onPress={() =>
+              runTest(
+                () =>
+                  auth0.mfa.enroll({
+                    mfaToken,
+                    factorType: MfaFactorType.VOICE,
+                    phoneNumber: enrollPhone,
+                  }),
+                'Enroll Voice'
+              )
+            }
+            title="mfa.enroll(voice)"
+            disabled={!mfaToken || !enrollPhone}
+          />
+          <Text style={styles.hint}>
+            Voice is a distinct channel on web only. On native it falls back to
+            SMS on the same number.
+          </Text>
+          <LabeledInput
+            label="Email (MFA enroll)"
+            value={enrollEmailMfa}
+            onChangeText={setEnrollEmailMfa}
+            placeholder="user@example.com"
+            autoCapitalize="none"
+            keyboardType="email-address"
+          />
+          <Button
+            onPress={() =>
+              runTest(
+                () =>
+                  auth0.mfa.enroll({
+                    mfaToken,
+                    factorType: MfaFactorType.EMAIL,
+                    email: enrollEmailMfa,
+                  }),
+                'Enroll Email'
+              )
+            }
+            title="mfa.enroll(email)"
+            disabled={!mfaToken || !enrollEmailMfa}
+          />
+
+          <Text style={styles.subTitle}>Challenge</Text>
+          <LabeledInput
+            label="Authenticator ID"
+            value={authenticatorId}
+            onChangeText={setAuthenticatorId}
+            placeholder="e.g. sms|dev_123"
+          />
+          <Button
+            onPress={() =>
+              runTest(
+                () => auth0.mfa.challenge({ mfaToken, authenticatorId }),
+                'Challenge'
+              )
+            }
+            title="mfa.challenge()"
+            disabled={!mfaToken || !authenticatorId}
+          />
+
+          <Text style={styles.subTitle}>Verify</Text>
+          <Text style={styles.hint}>
+            Scope/audience are optional; supply them to mint an API access token
+            on successful verification.
+          </Text>
+          <LabeledInput
+            label="Scope (optional)"
+            value={verifyScope}
+            onChangeText={setVerifyScope}
+            placeholder="openid profile email"
+            autoCapitalize="none"
+          />
+          <LabeledInput
+            label="Audience (optional)"
+            value={verifyAudience}
+            onChangeText={setVerifyAudience}
+            placeholder="https://your-api/"
+            autoCapitalize="none"
           />
           <LabeledInput
             label="OTP Code"
@@ -139,6 +324,84 @@ const ClassApiTestsScreen = ({ route }: Props) => {
             onChangeText={setOtp}
             keyboardType="numeric"
           />
+          <Button
+            onPress={() =>
+              runTest(
+                async () =>
+                  sanitizeCredentialResult(
+                    (await auth0.mfa.verify({
+                      mfaToken,
+                      otp,
+                      scope: verifyScope || undefined,
+                      audience: verifyAudience || undefined,
+                    })) as Record<string, unknown>
+                  ),
+                'Verify OTP'
+              )
+            }
+            title="mfa.verify(otp)"
+            disabled={!mfaToken || !otp}
+          />
+          <LabeledInput
+            label="OOB Code"
+            value={oobCode}
+            onChangeText={setOobCode}
+            placeholder="From challenge/enroll result"
+          />
+          <LabeledInput
+            label="Binding Code (SMS/Voice/Email)"
+            value={bindingCode}
+            onChangeText={setBindingCode}
+            keyboardType="numeric"
+            placeholder="Code from SMS/email/voice"
+          />
+          <Button
+            onPress={() =>
+              runTest(
+                async () =>
+                  sanitizeCredentialResult(
+                    (await auth0.mfa.verify({
+                      mfaToken,
+                      oobCode,
+                      bindingCode: bindingCode || undefined,
+                      scope: verifyScope || undefined,
+                      audience: verifyAudience || undefined,
+                    })) as Record<string, unknown>
+                  ),
+                'Verify OOB'
+              )
+            }
+            title="mfa.verify(oob)"
+            disabled={!mfaToken || !oobCode}
+          />
+          <LabeledInput
+            label="Recovery Code"
+            value={recoveryCode}
+            onChangeText={setRecoveryCode}
+            placeholder="Recovery code"
+            autoCapitalize="none"
+          />
+          <Button
+            onPress={() =>
+              runTest(
+                async () =>
+                  sanitizeCredentialResult(
+                    (await auth0.mfa.verify({
+                      mfaToken,
+                      recoveryCode,
+                      scope: verifyScope || undefined,
+                      audience: verifyAudience || undefined,
+                    })) as Record<string, unknown>
+                  ),
+                'Verify Recovery Code'
+              )
+            }
+            title="mfa.verify(recoveryCode)"
+            disabled={!mfaToken || !recoveryCode}
+          />
+        </Section>
+
+        <Section title="Legacy MFA & Tokens">
           <Button
             onPress={() =>
               runTest(
@@ -176,9 +439,6 @@ const ClassApiTestsScreen = ({ route }: Props) => {
             disabled={!refreshToken}
           />
         </Section>
-
-        {/* Other methods can be added here following the same pattern */}
-        {/* e.g., exchange, exchangeNativeSocial, other passwordless/MFA flows */}
       </ScrollView>
     </SafeAreaView>
   );
@@ -220,6 +480,13 @@ const styles = StyleSheet.create({
   },
   buttonGroup: {
     gap: 10,
+  },
+  hint: { fontSize: 12, color: '#888', fontStyle: 'italic' },
+  subTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#333',
+    marginTop: 8,
   },
 });
 

--- a/example/src/screens/class-based/ClassLogin.tsx
+++ b/example/src/screens/class-based/ClassLogin.tsx
@@ -1,5 +1,3 @@
-// example/src/screens/class-based/ClassLogin.tsx
-
 import React, { useState } from 'react';
 import {
   SafeAreaView,
@@ -8,12 +6,27 @@ import {
   Text,
   StyleSheet,
   Alert,
+  TouchableOpacity,
+  Image,
+  Linking,
   Platform,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { StackNavigationProp } from '@react-navigation/stack';
-import type { PasswordlessChallenge } from 'react-native-auth0';
-import auth0 from '../../api/auth0'; // Import our singleton instance
+import {
+  MfaError,
+  MfaErrorCodes,
+  MfaFactorType,
+  WebAuthError,
+  WebAuthErrorCodes,
+} from 'react-native-auth0';
+import type {
+  MfaAuthenticator,
+  MfaEnrollmentChallenge,
+  MfaChallengeResult,
+  PasswordlessChallenge,
+} from 'react-native-auth0';
+import auth0 from '../../api/auth0';
 import Button from '../../components/Button';
 import Header from '../../components/Header';
 import LabeledInput from '../../components/LabeledInput';
@@ -26,11 +39,27 @@ type NavigationProp = StackNavigationProp<
   'ClassLogin'
 >;
 
+type MfaStep =
+  | 'idle'
+  | 'list'
+  | 'enroll-select'
+  | 'enroll-details'
+  | 'challenge'
+  | 'verify'
+  | 'complete';
+
+type EnrollType = MfaFactorType;
+
 const ClassLoginScreen = () => {
   const [error, setError] = useState<Error | null>(null);
+  const [result, setResult] = useState<object | null>(null);
   const [loading, setLoading] = useState(false);
   const navigation = useNavigation<NavigationProp>();
 
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  // Passwordless OTP state
   const [otpMethod, setOtpMethod] = useState<'email' | 'phone'>('email');
   const [otpEmail, setOtpEmail] = useState('');
   const [otpPhone, setOtpPhone] = useState('');
@@ -38,26 +67,462 @@ const ClassLoginScreen = () => {
   const [challenge, setChallenge] = useState<PasswordlessChallenge | null>(
     null
   );
-  const [useTrustedWebActivity, setUseTrustedWebActivity] = useState(false);
 
   const onLogin = async () => {
     setLoading(true);
     setError(null);
     try {
-      const credentials = await auth0.webAuth.authorize(
-        {
-          scope: 'openid profile email offline_access',
-          audience: `https://${config.domain}/api/v2/`,
-        },
-        { useTrustedWebActivity }
-      );
+      const credentials = await auth0.webAuth.authorize({
+        scope: 'openid profile email offline_access',
+        audience: `https://${config.domain}/api/v2/`,
+      });
       // On success, we save the credentials and navigate to the profile screen.
       await auth0.credentialsManager.saveCredentials(credentials);
       navigation.replace('ClassProfile', { credentials });
     } catch (e) {
-      setError(e as Error);
+      if (e instanceof WebAuthError) {
+        switch (e.type) {
+          case WebAuthErrorCodes.USER_CANCELLED:
+            Alert.alert('Login Cancelled', 'You cancelled the login process.');
+            break;
+          case WebAuthErrorCodes.TIMEOUT_ERROR:
+            Alert.alert('Login Timeout', 'The login process timed out.');
+            break;
+          default:
+            Alert.alert('Authentication Error', e.message);
+        }
+      } else {
+        setError(e as Error);
+      }
     } finally {
       setLoading(false);
+    }
+  };
+
+  const onLoginWithPassword = async () => {
+    clearResult();
+    try {
+      const credentials = await auth0.auth.passwordRealm({
+        username: email,
+        password: password,
+        realm: 'Username-Password-Authentication',
+      });
+      await auth0.credentialsManager.saveCredentials(credentials);
+      navigation.replace('ClassProfile', { credentials });
+    } catch (e: any) {
+      if (e?.json?.mfa_token) {
+        setMfaToken(e.json.mfa_token);
+        setMfaStep('list');
+        Alert.alert(
+          'MFA Required',
+          'Multi-factor authentication is required. Follow the steps below.'
+        );
+      }
+      setError(e as Error);
+    }
+  };
+
+  const handleMfaError = (e: unknown, fallbackMsg: string) => {
+    if (e instanceof MfaError) {
+      if (
+        e.type === MfaErrorCodes.EXPIRED_MFA_TOKEN ||
+        e.type === MfaErrorCodes.INVALID_MFA_TOKEN
+      ) {
+        Alert.alert('Session Expired', 'Please log in again.');
+        setMfaToken('');
+        resetMfaWizard();
+        return;
+      }
+      Alert.alert('MFA Error', e.message);
+      setError(e);
+    } else {
+      setError(e as Error);
+      Alert.alert('Error', fallbackMsg);
+    }
+  };
+
+  const mfaClient = auth0.mfa;
+
+  const onStartMfa = async () => {
+    setMfaLoading(true);
+    clearResult();
+    try {
+      const list = await mfaClient.getAuthenticators({ mfaToken });
+      setAuthenticators(list);
+      setMfaStep('list');
+    } catch (e) {
+      handleMfaError(e, 'Failed to list authenticators.');
+    } finally {
+      setMfaLoading(false);
+    }
+  };
+
+  const onSelectAuthenticator = (auth: MfaAuthenticator) => {
+    setSelectedAuthenticator(auth);
+    setChallengeResult(null);
+    setMfaStep('challenge');
+    onChallenge(auth);
+  };
+
+  const onChallenge = async (auth: MfaAuthenticator) => {
+    setMfaLoading(true);
+    try {
+      const res = await mfaClient.challenge({
+        mfaToken,
+        authenticatorId: auth.id,
+      });
+      setChallengeResult(res);
+      setMfaStep('verify');
+    } catch (e) {
+      handleMfaError(e, 'Challenge failed.');
+      setMfaStep('list');
+    } finally {
+      setMfaLoading(false);
+    }
+  };
+
+  const onSelectEnrollType = (type: EnrollType) => {
+    setEnrollType(type);
+    if (type === MfaFactorType.OTP || type === MfaFactorType.PUSH) {
+      onEnroll(type);
+    } else {
+      setMfaStep('enroll-details');
+    }
+  };
+
+  const onEnroll = async (type?: EnrollType) => {
+    const factor = type || enrollType;
+    if (!factor) return;
+
+    setMfaLoading(true);
+    try {
+      let challenge: MfaEnrollmentChallenge;
+      if (factor === MfaFactorType.SMS) {
+        challenge = await mfaClient.enroll({
+          mfaToken,
+          factorType: MfaFactorType.SMS,
+          phoneNumber: enrollPhoneNumber,
+        });
+      } else if (factor === MfaFactorType.VOICE) {
+        challenge = await mfaClient.enroll({
+          mfaToken,
+          factorType: MfaFactorType.VOICE,
+          phoneNumber: enrollPhoneNumber,
+        });
+      } else if (factor === MfaFactorType.EMAIL) {
+        challenge = await mfaClient.enroll({
+          mfaToken,
+          factorType: MfaFactorType.EMAIL,
+          email: enrollEmail,
+        });
+      } else {
+        challenge = await mfaClient.enroll({ mfaToken, factorType: factor });
+      }
+      setEnrollmentChallenge(challenge);
+      setMfaStep('verify');
+    } catch (e) {
+      handleMfaError(e, 'Enrollment failed.');
+    } finally {
+      setMfaLoading(false);
+    }
+  };
+
+  const onVerify = async () => {
+    setMfaLoading(true);
+    try {
+      let credentials;
+      const oobCode =
+        challengeResult?.oobCode ||
+        (enrollmentChallenge?.type === 'oob' ||
+        enrollmentChallenge?.type === 'push'
+          ? enrollmentChallenge.oobCode
+          : undefined);
+
+      if (oobCode) {
+        credentials = await mfaClient.verify({
+          mfaToken,
+          oobCode,
+          bindingCode: verifyBindingCode || undefined,
+        });
+      } else {
+        credentials = await mfaClient.verify({ mfaToken, otp: verifyCode });
+      }
+      setResult({
+        success: true,
+        accessToken: credentials.accessToken.substring(0, 20) + '...',
+      });
+      setMfaStep('complete');
+    } catch (e) {
+      handleMfaError(e, 'Verification failed.');
+    } finally {
+      setMfaLoading(false);
+    }
+  };
+
+  const renderMfaWizard = () => {
+    switch (mfaStep) {
+      case 'idle':
+        return (
+          <>
+            <Text style={styles.hint}>
+              Get an mfa_token from a password login with MFA enabled, or paste
+              one manually.
+            </Text>
+            <LabeledInput
+              label="MFA Token"
+              value={mfaToken}
+              onChangeText={setMfaToken}
+              placeholder="Paste or auto-filled from password login"
+            />
+            <Button
+              onPress={onStartMfa}
+              title="Start MFA"
+              disabled={!mfaToken || mfaLoading}
+            />
+          </>
+        );
+
+      case 'list':
+        return (
+          <>
+            <Text style={styles.stepTitle}>Step 1: Select Authenticator</Text>
+            {authenticators.length > 0 ? (
+              <>
+                <Text style={styles.hint}>
+                  Select an enrolled authenticator to challenge:
+                </Text>
+                {authenticators.map((auth) => (
+                  <TouchableOpacity
+                    key={auth.id}
+                    style={styles.authItem}
+                    onPress={() => onSelectAuthenticator(auth)}
+                  >
+                    <Text style={styles.authItemTitle}>
+                      {auth.authenticatorType}
+                      {auth.oobChannel ? ` (${auth.oobChannel})` : ''}
+                    </Text>
+                    <Text style={styles.authItemSubtitle}>{auth.id}</Text>
+                  </TouchableOpacity>
+                ))}
+                <View style={styles.divider} />
+              </>
+            ) : (
+              <Text style={styles.hint}>
+                No authenticators enrolled. Enroll a new one below.
+              </Text>
+            )}
+            <Button
+              onPress={() => setMfaStep('enroll-select')}
+              title="Enroll New Authenticator"
+            />
+            <Button onPress={resetMfaWizard} title="Back" />
+          </>
+        );
+
+      case 'enroll-select':
+        return (
+          <>
+            <Text style={styles.stepTitle}>Step 2: Choose Factor Type</Text>
+            <Button
+              onPress={() => onSelectEnrollType(MfaFactorType.OTP)}
+              title="TOTP (Authenticator App)"
+              disabled={mfaLoading}
+            />
+            <Button
+              onPress={() => onSelectEnrollType(MfaFactorType.SMS)}
+              title="SMS"
+              disabled={mfaLoading}
+            />
+            <Button
+              onPress={() => onSelectEnrollType(MfaFactorType.VOICE)}
+              title="Voice"
+              disabled={mfaLoading}
+            />
+            <Text style={styles.hint}>
+              Voice is a distinct channel on web only. On native (iOS/Android)
+              it falls back to SMS on the same number.
+            </Text>
+            <Button
+              onPress={() => onSelectEnrollType(MfaFactorType.EMAIL)}
+              title="Email"
+              disabled={mfaLoading}
+            />
+            <Button
+              onPress={() => onSelectEnrollType(MfaFactorType.PUSH)}
+              title="Push Notification"
+              disabled={mfaLoading}
+            />
+            <Button onPress={() => setMfaStep('list')} title="Back" />
+          </>
+        );
+
+      case 'enroll-details':
+        return (
+          <>
+            <Text style={styles.stepTitle}>Step 2: Enter Details</Text>
+            {(enrollType === MfaFactorType.SMS ||
+              enrollType === MfaFactorType.VOICE) && (
+              <>
+                <LabeledInput
+                  label="Phone Number"
+                  value={enrollPhoneNumber}
+                  onChangeText={setEnrollPhoneNumber}
+                  placeholder="+12025550135"
+                  keyboardType="phone-pad"
+                />
+                <Button
+                  onPress={() => onEnroll()}
+                  title={
+                    enrollType === MfaFactorType.VOICE
+                      ? 'Enroll Voice'
+                      : 'Enroll SMS'
+                  }
+                  disabled={!enrollPhoneNumber || mfaLoading}
+                />
+              </>
+            )}
+            {enrollType === MfaFactorType.EMAIL && (
+              <>
+                <LabeledInput
+                  label="Email"
+                  value={enrollEmail}
+                  onChangeText={setEnrollEmail}
+                  placeholder="user@example.com"
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                />
+                <Button
+                  onPress={() => onEnroll()}
+                  title="Enroll Email"
+                  disabled={!enrollEmail || mfaLoading}
+                />
+              </>
+            )}
+            <Button onPress={() => setMfaStep('enroll-select')} title="Back" />
+          </>
+        );
+
+      case 'verify':
+        return (
+          <>
+            <Text style={styles.stepTitle}>Step 3: Verify</Text>
+            {enrollmentChallenge?.type === 'totp' && (
+              <View style={styles.infoBox}>
+                {enrollmentChallenge.barcodeUri && (
+                  <>
+                    <View style={styles.qrContainer}>
+                      <Image
+                        source={{
+                          uri: `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(enrollmentChallenge.barcodeUri)}`,
+                        }}
+                        style={styles.qrImage}
+                      />
+                    </View>
+                    <Button
+                      onPress={() =>
+                        Linking.openURL(enrollmentChallenge.barcodeUri!)
+                      }
+                      title="Open in Authenticator App"
+                    />
+                  </>
+                )}
+                <Text style={styles.infoLabel}>Secret:</Text>
+                <Text style={styles.infoValue} selectable>
+                  {enrollmentChallenge.secret}
+                </Text>
+              </View>
+            )}
+            {enrollmentChallenge?.type === 'push' && (
+              <View style={styles.infoBox}>
+                <Text style={styles.hint}>
+                  Scan this QR code with the Auth0 Guardian app to pair, then
+                  approve the push notification on your device.
+                </Text>
+                {enrollmentChallenge.barcodeUri ? (
+                  <View style={styles.qrContainer}>
+                    <Image
+                      source={{
+                        uri: `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(enrollmentChallenge.barcodeUri)}`,
+                      }}
+                      style={styles.qrImage}
+                    />
+                  </View>
+                ) : null}
+                <Button
+                  onPress={onVerify}
+                  title="I've approved the push"
+                  disabled={mfaLoading}
+                />
+              </View>
+            )}
+            {challengeResult && (
+              <View style={styles.infoBox}>
+                <Text style={styles.infoLabel}>
+                  Challenge Type: {challengeResult.challengeType}
+                </Text>
+                {challengeResult.bindingMethod && (
+                  <Text style={styles.infoLabel}>
+                    Binding Method: {challengeResult.bindingMethod}
+                  </Text>
+                )}
+              </View>
+            )}
+            {(challengeResult?.challengeType === 'oob' ||
+              enrollmentChallenge?.type === 'oob') && (
+              <>
+                <Text style={styles.hint}>
+                  A code has been sent to your device. Enter the binding code
+                  below.
+                </Text>
+                <LabeledInput
+                  label="Binding Code"
+                  value={verifyBindingCode}
+                  onChangeText={setVerifyBindingCode}
+                  keyboardType="numeric"
+                  placeholder="Code from SMS/email/push"
+                />
+                <Button
+                  onPress={onVerify}
+                  title="Verify"
+                  disabled={!verifyBindingCode || mfaLoading}
+                />
+              </>
+            )}
+            {(challengeResult?.challengeType === 'otp' ||
+              enrollmentChallenge?.type === 'totp') && (
+              <>
+                <LabeledInput
+                  label="OTP Code"
+                  value={verifyCode}
+                  onChangeText={setVerifyCode}
+                  keyboardType="numeric"
+                  placeholder="6-digit code from authenticator app"
+                />
+                <Button
+                  onPress={onVerify}
+                  title="Verify"
+                  disabled={!verifyCode || mfaLoading}
+                />
+              </>
+            )}
+            <Button onPress={() => setMfaStep('list')} title="Back" />
+          </>
+        );
+
+      case 'complete':
+        return (
+          <>
+            <Text style={styles.stepTitle}>MFA Complete</Text>
+            <Text style={styles.successText}>Authentication successful!</Text>
+            {result && (
+              <Result title="Credentials" error={null} result={result} />
+            )}
+            <Button onPress={resetMfaWizard} title="Done" />
+          </>
+        );
+
+      default:
+        return null;
     }
   };
 
@@ -117,10 +582,9 @@ const ClassLoginScreen = () => {
     <SafeAreaView style={styles.container}>
       <Header title="Class-Based Login" />
       <ScrollView contentContainerStyle={styles.content}>
-        <Result title="Error" error={error} result={null} />
+        {error && <Result title="Error" error={error} result={null} />}
 
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Web Auth</Text>
+        <Section title="Web Auth (Recommended)">
           <Button onPress={onLogin} title="Log In" loading={loading} />
           <>
             <Text style={styles.description}>
@@ -136,7 +600,31 @@ const ClassLoginScreen = () => {
               style={!useTrustedWebActivity ? styles.inactiveButton : undefined}
             />
           </>
-        </View>
+        </Section>
+
+        <Section title="Database Login">
+          <LabeledInput
+            label="Username or Email"
+            value={email}
+            onChangeText={setEmail}
+            autoCapitalize="none"
+          />
+          <LabeledInput
+            label="Password"
+            value={password}
+            onChangeText={setPassword}
+            secureTextEntry
+          />
+          <Button onPress={onLoginWithPassword} title="Log In with Password" />
+          <Text style={styles.hint}>
+            If MFA is enabled, a failed login will return an mfa_token and
+            automatically start the MFA wizard.
+          </Text>
+        </Section>
+
+        <Section title="MFA Flexible Factors Grant">
+          {renderMfaWizard()}
+        </Section>
 
         {Platform.OS !== 'web' && (
           <View style={styles.section}>
@@ -212,15 +700,22 @@ const ClassLoginScreen = () => {
   );
 };
 
+const Section = ({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) => (
+  <View style={styles.section}>
+    <Text style={styles.sectionTitle}>{title}</Text>
+    {children}
+  </View>
+);
+
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#FFFFFF',
-  },
-  content: {
-    padding: 16,
-    gap: 20,
-  },
+  container: { flex: 1, backgroundColor: '#FFFFFF' },
+  content: { padding: 16, gap: 20, paddingBottom: 50 },
   section: {
     borderWidth: 1,
     borderColor: '#E0E0E0',
@@ -229,6 +724,43 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   sectionTitle: { fontSize: 18, fontWeight: 'bold', marginBottom: 8 },
+  stepTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#333',
+    marginBottom: 4,
+  },
+  hint: { fontSize: 12, color: '#888', fontStyle: 'italic' },
+  authItem: {
+    borderWidth: 1,
+    borderColor: '#CCC',
+    borderRadius: 6,
+    padding: 12,
+    backgroundColor: '#F9F9F9',
+  },
+  authItemTitle: { fontSize: 14, fontWeight: '600' },
+  authItemSubtitle: { fontSize: 11, color: '#666', marginTop: 2 },
+  divider: {
+    height: 1,
+    backgroundColor: '#E0E0E0',
+    marginVertical: 8,
+  },
+  infoBox: {
+    backgroundColor: '#F0F4FF',
+    borderRadius: 6,
+    padding: 10,
+    gap: 4,
+  },
+  infoLabel: { fontSize: 12, fontWeight: '600', color: '#444' },
+  infoValue: { fontSize: 12, color: '#333', fontFamily: 'monospace' },
+  qrContainer: { alignItems: 'center', marginVertical: 12 },
+  qrImage: { width: 200, height: 200 },
+  successText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2E7D32',
+    textAlign: 'center',
+  },
   description: { fontSize: 13, color: '#666', marginBottom: 4 },
   row: { flexDirection: 'row', gap: 8 },
   halfButton: { flex: 1, minWidth: 0 },

--- a/example/src/screens/class-based/ClassLogin.tsx
+++ b/example/src/screens/class-based/ClassLogin.tsx
@@ -6,9 +6,6 @@ import {
   Text,
   StyleSheet,
   Alert,
-  TouchableOpacity,
-  Image,
-  Linking,
   Platform,
 } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
@@ -20,12 +17,7 @@ import {
   WebAuthError,
   WebAuthErrorCodes,
 } from 'react-native-auth0';
-import type {
-  MfaAuthenticator,
-  MfaEnrollmentChallenge,
-  MfaChallengeResult,
-  PasswordlessChallenge,
-} from 'react-native-auth0';
+import type { PasswordlessChallenge } from 'react-native-auth0';
 import auth0 from '../../api/auth0';
 import Button from '../../components/Button';
 import Header from '../../components/Header';
@@ -39,17 +31,6 @@ type NavigationProp = StackNavigationProp<
   'ClassLogin'
 >;
 
-type MfaStep =
-  | 'idle'
-  | 'list'
-  | 'enroll-select'
-  | 'enroll-details'
-  | 'challenge'
-  | 'verify'
-  | 'complete';
-
-type EnrollType = MfaFactorType;
-
 const ClassLoginScreen = () => {
   const [error, setError] = useState<Error | null>(null);
   const [result, setResult] = useState<object | null>(null);
@@ -58,6 +39,21 @@ const ClassLoginScreen = () => {
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+
+  const [useTrustedWebActivity, setUseTrustedWebActivity] = useState(true);
+
+  // MFA state (flat API-test panel)
+  const [mfaToken, setMfaToken] = useState('');
+  const [mfaOtp, setMfaOtp] = useState('');
+  const [authenticatorId, setAuthenticatorId] = useState('');
+  const [enrollPhone, setEnrollPhone] = useState('');
+  const [enrollEmailMfa, setEnrollEmailMfa] = useState('');
+  const [oobCode, setOobCode] = useState('');
+  const [bindingCode, setBindingCode] = useState('');
+  const [recoveryCode, setRecoveryCode] = useState('');
+  const [verifyScope, setVerifyScope] = useState('');
+  const [verifyAudience, setVerifyAudience] = useState('');
+  const [mfaLoading, setMfaLoading] = useState(false);
 
   // Passwordless OTP state
   const [otpMethod, setOtpMethod] = useState<'email' | 'phone'>('email');
@@ -112,417 +108,58 @@ const ClassLoginScreen = () => {
     } catch (e: any) {
       if (e?.json?.mfa_token) {
         setMfaToken(e.json.mfa_token);
-        setMfaStep('list');
         Alert.alert(
           'MFA Required',
-          'Multi-factor authentication is required. Follow the steps below.'
+          'Multi-factor authentication is required. The MFA token has been filled in below.'
         );
       }
       setError(e as Error);
     }
   };
 
-  const handleMfaError = (e: unknown, fallbackMsg: string) => {
-    if (e instanceof MfaError) {
-      if (
-        e.type === MfaErrorCodes.EXPIRED_MFA_TOKEN ||
-        e.type === MfaErrorCodes.INVALID_MFA_TOKEN
-      ) {
-        Alert.alert('Session Expired', 'Please log in again.');
-        setMfaToken('');
-        resetMfaWizard();
-        return;
-      }
-      Alert.alert('MFA Error', e.message);
-      setError(e);
-    } else {
-      setError(e as Error);
-      Alert.alert('Error', fallbackMsg);
-    }
+  const clearResult = () => {
+    setError(null);
+    setResult(null);
   };
 
   const mfaClient = auth0.mfa;
 
-  const onStartMfa = async () => {
-    setMfaLoading(true);
+  // mfa.verify() returns credentials; redact tokens before they reach the
+  // displayed result panel.
+  const sanitizeCredentialResult = (res: Record<string, unknown>) => {
+    const { accessToken, refreshToken, idToken, ...safe } = res;
+    return {
+      ...safe,
+      ...(accessToken ? { accessToken: '[REDACTED]' } : {}),
+      ...(idToken ? { idToken: '[REDACTED]' } : {}),
+      ...(refreshToken ? { refreshToken: '[REDACTED]' } : {}),
+    };
+  };
+
+  const runMfaTest = async (testFn: () => Promise<any>, title: string) => {
     clearResult();
-    try {
-      const list = await mfaClient.getAuthenticators({ mfaToken });
-      setAuthenticators(list);
-      setMfaStep('list');
-    } catch (e) {
-      handleMfaError(e, 'Failed to list authenticators.');
-    } finally {
-      setMfaLoading(false);
-    }
-  };
-
-  const onSelectAuthenticator = (auth: MfaAuthenticator) => {
-    setSelectedAuthenticator(auth);
-    setChallengeResult(null);
-    setMfaStep('challenge');
-    onChallenge(auth);
-  };
-
-  const onChallenge = async (auth: MfaAuthenticator) => {
     setMfaLoading(true);
     try {
-      const res = await mfaClient.challenge({
-        mfaToken,
-        authenticatorId: auth.id,
-      });
-      setChallengeResult(res);
-      setMfaStep('verify');
+      const res = await testFn();
+      setResult(res ?? { success: `${title} completed successfully` });
+      // Carry an oobCode forward from a challenge/enroll result so verify can
+      // use it without manual copy/paste.
+      if (res?.oobCode) setOobCode(res.oobCode);
     } catch (e) {
-      handleMfaError(e, 'Challenge failed.');
-      setMfaStep('list');
-    } finally {
-      setMfaLoading(false);
-    }
-  };
-
-  const onSelectEnrollType = (type: EnrollType) => {
-    setEnrollType(type);
-    if (type === MfaFactorType.OTP || type === MfaFactorType.PUSH) {
-      onEnroll(type);
-    } else {
-      setMfaStep('enroll-details');
-    }
-  };
-
-  const onEnroll = async (type?: EnrollType) => {
-    const factor = type || enrollType;
-    if (!factor) return;
-
-    setMfaLoading(true);
-    try {
-      let challenge: MfaEnrollmentChallenge;
-      if (factor === MfaFactorType.SMS) {
-        challenge = await mfaClient.enroll({
-          mfaToken,
-          factorType: MfaFactorType.SMS,
-          phoneNumber: enrollPhoneNumber,
-        });
-      } else if (factor === MfaFactorType.VOICE) {
-        challenge = await mfaClient.enroll({
-          mfaToken,
-          factorType: MfaFactorType.VOICE,
-          phoneNumber: enrollPhoneNumber,
-        });
-      } else if (factor === MfaFactorType.EMAIL) {
-        challenge = await mfaClient.enroll({
-          mfaToken,
-          factorType: MfaFactorType.EMAIL,
-          email: enrollEmail,
-        });
-      } else {
-        challenge = await mfaClient.enroll({ mfaToken, factorType: factor });
+      if (
+        e instanceof MfaError &&
+        (e.type === MfaErrorCodes.EXPIRED_MFA_TOKEN ||
+          e.type === MfaErrorCodes.INVALID_MFA_TOKEN)
+      ) {
+        Alert.alert(
+          'Session Expired',
+          'Please log in again to get a new MFA token.'
+        );
+        setMfaToken('');
       }
-      setEnrollmentChallenge(challenge);
-      setMfaStep('verify');
-    } catch (e) {
-      handleMfaError(e, 'Enrollment failed.');
+      setError(e as Error);
     } finally {
       setMfaLoading(false);
-    }
-  };
-
-  const onVerify = async () => {
-    setMfaLoading(true);
-    try {
-      let credentials;
-      const oobCode =
-        challengeResult?.oobCode ||
-        (enrollmentChallenge?.type === 'oob' ||
-        enrollmentChallenge?.type === 'push'
-          ? enrollmentChallenge.oobCode
-          : undefined);
-
-      if (oobCode) {
-        credentials = await mfaClient.verify({
-          mfaToken,
-          oobCode,
-          bindingCode: verifyBindingCode || undefined,
-        });
-      } else {
-        credentials = await mfaClient.verify({ mfaToken, otp: verifyCode });
-      }
-      setResult({
-        success: true,
-        accessToken: credentials.accessToken.substring(0, 20) + '...',
-      });
-      setMfaStep('complete');
-    } catch (e) {
-      handleMfaError(e, 'Verification failed.');
-    } finally {
-      setMfaLoading(false);
-    }
-  };
-
-  const renderMfaWizard = () => {
-    switch (mfaStep) {
-      case 'idle':
-        return (
-          <>
-            <Text style={styles.hint}>
-              Get an mfa_token from a password login with MFA enabled, or paste
-              one manually.
-            </Text>
-            <LabeledInput
-              label="MFA Token"
-              value={mfaToken}
-              onChangeText={setMfaToken}
-              placeholder="Paste or auto-filled from password login"
-            />
-            <Button
-              onPress={onStartMfa}
-              title="Start MFA"
-              disabled={!mfaToken || mfaLoading}
-            />
-          </>
-        );
-
-      case 'list':
-        return (
-          <>
-            <Text style={styles.stepTitle}>Step 1: Select Authenticator</Text>
-            {authenticators.length > 0 ? (
-              <>
-                <Text style={styles.hint}>
-                  Select an enrolled authenticator to challenge:
-                </Text>
-                {authenticators.map((auth) => (
-                  <TouchableOpacity
-                    key={auth.id}
-                    style={styles.authItem}
-                    onPress={() => onSelectAuthenticator(auth)}
-                  >
-                    <Text style={styles.authItemTitle}>
-                      {auth.authenticatorType}
-                      {auth.oobChannel ? ` (${auth.oobChannel})` : ''}
-                    </Text>
-                    <Text style={styles.authItemSubtitle}>{auth.id}</Text>
-                  </TouchableOpacity>
-                ))}
-                <View style={styles.divider} />
-              </>
-            ) : (
-              <Text style={styles.hint}>
-                No authenticators enrolled. Enroll a new one below.
-              </Text>
-            )}
-            <Button
-              onPress={() => setMfaStep('enroll-select')}
-              title="Enroll New Authenticator"
-            />
-            <Button onPress={resetMfaWizard} title="Back" />
-          </>
-        );
-
-      case 'enroll-select':
-        return (
-          <>
-            <Text style={styles.stepTitle}>Step 2: Choose Factor Type</Text>
-            <Button
-              onPress={() => onSelectEnrollType(MfaFactorType.OTP)}
-              title="TOTP (Authenticator App)"
-              disabled={mfaLoading}
-            />
-            <Button
-              onPress={() => onSelectEnrollType(MfaFactorType.SMS)}
-              title="SMS"
-              disabled={mfaLoading}
-            />
-            <Button
-              onPress={() => onSelectEnrollType(MfaFactorType.VOICE)}
-              title="Voice"
-              disabled={mfaLoading}
-            />
-            <Text style={styles.hint}>
-              Voice is a distinct channel on web only. On native (iOS/Android)
-              it falls back to SMS on the same number.
-            </Text>
-            <Button
-              onPress={() => onSelectEnrollType(MfaFactorType.EMAIL)}
-              title="Email"
-              disabled={mfaLoading}
-            />
-            <Button
-              onPress={() => onSelectEnrollType(MfaFactorType.PUSH)}
-              title="Push Notification"
-              disabled={mfaLoading}
-            />
-            <Button onPress={() => setMfaStep('list')} title="Back" />
-          </>
-        );
-
-      case 'enroll-details':
-        return (
-          <>
-            <Text style={styles.stepTitle}>Step 2: Enter Details</Text>
-            {(enrollType === MfaFactorType.SMS ||
-              enrollType === MfaFactorType.VOICE) && (
-              <>
-                <LabeledInput
-                  label="Phone Number"
-                  value={enrollPhoneNumber}
-                  onChangeText={setEnrollPhoneNumber}
-                  placeholder="+12025550135"
-                  keyboardType="phone-pad"
-                />
-                <Button
-                  onPress={() => onEnroll()}
-                  title={
-                    enrollType === MfaFactorType.VOICE
-                      ? 'Enroll Voice'
-                      : 'Enroll SMS'
-                  }
-                  disabled={!enrollPhoneNumber || mfaLoading}
-                />
-              </>
-            )}
-            {enrollType === MfaFactorType.EMAIL && (
-              <>
-                <LabeledInput
-                  label="Email"
-                  value={enrollEmail}
-                  onChangeText={setEnrollEmail}
-                  placeholder="user@example.com"
-                  keyboardType="email-address"
-                  autoCapitalize="none"
-                />
-                <Button
-                  onPress={() => onEnroll()}
-                  title="Enroll Email"
-                  disabled={!enrollEmail || mfaLoading}
-                />
-              </>
-            )}
-            <Button onPress={() => setMfaStep('enroll-select')} title="Back" />
-          </>
-        );
-
-      case 'verify':
-        return (
-          <>
-            <Text style={styles.stepTitle}>Step 3: Verify</Text>
-            {enrollmentChallenge?.type === 'totp' && (
-              <View style={styles.infoBox}>
-                {enrollmentChallenge.barcodeUri && (
-                  <>
-                    <View style={styles.qrContainer}>
-                      <Image
-                        source={{
-                          uri: `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(enrollmentChallenge.barcodeUri)}`,
-                        }}
-                        style={styles.qrImage}
-                      />
-                    </View>
-                    <Button
-                      onPress={() =>
-                        Linking.openURL(enrollmentChallenge.barcodeUri!)
-                      }
-                      title="Open in Authenticator App"
-                    />
-                  </>
-                )}
-                <Text style={styles.infoLabel}>Secret:</Text>
-                <Text style={styles.infoValue} selectable>
-                  {enrollmentChallenge.secret}
-                </Text>
-              </View>
-            )}
-            {enrollmentChallenge?.type === 'push' && (
-              <View style={styles.infoBox}>
-                <Text style={styles.hint}>
-                  Scan this QR code with the Auth0 Guardian app to pair, then
-                  approve the push notification on your device.
-                </Text>
-                {enrollmentChallenge.barcodeUri ? (
-                  <View style={styles.qrContainer}>
-                    <Image
-                      source={{
-                        uri: `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(enrollmentChallenge.barcodeUri)}`,
-                      }}
-                      style={styles.qrImage}
-                    />
-                  </View>
-                ) : null}
-                <Button
-                  onPress={onVerify}
-                  title="I've approved the push"
-                  disabled={mfaLoading}
-                />
-              </View>
-            )}
-            {challengeResult && (
-              <View style={styles.infoBox}>
-                <Text style={styles.infoLabel}>
-                  Challenge Type: {challengeResult.challengeType}
-                </Text>
-                {challengeResult.bindingMethod && (
-                  <Text style={styles.infoLabel}>
-                    Binding Method: {challengeResult.bindingMethod}
-                  </Text>
-                )}
-              </View>
-            )}
-            {(challengeResult?.challengeType === 'oob' ||
-              enrollmentChallenge?.type === 'oob') && (
-              <>
-                <Text style={styles.hint}>
-                  A code has been sent to your device. Enter the binding code
-                  below.
-                </Text>
-                <LabeledInput
-                  label="Binding Code"
-                  value={verifyBindingCode}
-                  onChangeText={setVerifyBindingCode}
-                  keyboardType="numeric"
-                  placeholder="Code from SMS/email/push"
-                />
-                <Button
-                  onPress={onVerify}
-                  title="Verify"
-                  disabled={!verifyBindingCode || mfaLoading}
-                />
-              </>
-            )}
-            {(challengeResult?.challengeType === 'otp' ||
-              enrollmentChallenge?.type === 'totp') && (
-              <>
-                <LabeledInput
-                  label="OTP Code"
-                  value={verifyCode}
-                  onChangeText={setVerifyCode}
-                  keyboardType="numeric"
-                  placeholder="6-digit code from authenticator app"
-                />
-                <Button
-                  onPress={onVerify}
-                  title="Verify"
-                  disabled={!verifyCode || mfaLoading}
-                />
-              </>
-            )}
-            <Button onPress={() => setMfaStep('list')} title="Back" />
-          </>
-        );
-
-      case 'complete':
-        return (
-          <>
-            <Text style={styles.stepTitle}>MFA Complete</Text>
-            <Text style={styles.successText}>Authentication successful!</Text>
-            {result && (
-              <Result title="Credentials" error={null} result={result} />
-            )}
-            <Button onPress={resetMfaWizard} title="Done" />
-          </>
-        );
-
-      default:
-        return null;
     }
   };
 
@@ -582,7 +219,9 @@ const ClassLoginScreen = () => {
     <SafeAreaView style={styles.container}>
       <Header title="Class-Based Login" />
       <ScrollView contentContainerStyle={styles.content}>
-        {error && <Result title="Error" error={error} result={null} />}
+        {(error || result) && (
+          <Result title="Last Action Result" error={error} result={result} />
+        )}
 
         <Section title="Web Auth (Recommended)">
           <Button onPress={onLogin} title="Log In" loading={loading} />
@@ -617,13 +256,273 @@ const ClassLoginScreen = () => {
           />
           <Button onPress={onLoginWithPassword} title="Log In with Password" />
           <Text style={styles.hint}>
-            If MFA is enabled, a failed login will return an mfa_token and
-            automatically start the MFA wizard.
+            If MFA is enabled, a failed login returns an mfa_token that is
+            filled into the MFA section below.
           </Text>
         </Section>
 
         <Section title="MFA Flexible Factors Grant">
-          {renderMfaWizard()}
+          <Text style={styles.hint}>
+            Uses auth0.mfa for flexible MFA operations. Get an mfa_token from a
+            failed password login above, or paste one manually.
+          </Text>
+          <LabeledInput
+            label="MFA Token"
+            value={mfaToken}
+            onChangeText={setMfaToken}
+            placeholder="From a failed password login"
+          />
+          <Button
+            onPress={() =>
+              runMfaTest(
+                () =>
+                  mfaClient.getAuthenticators({
+                    mfaToken,
+                    factorsAllowed: [
+                      MfaFactorType.OTP,
+                      MfaFactorType.SMS,
+                      MfaFactorType.VOICE,
+                      MfaFactorType.EMAIL,
+                      MfaFactorType.PUSH,
+                      'recovery-code',
+                    ],
+                  }),
+                'List Authenticators'
+              )
+            }
+            title="mfa.getAuthenticators()"
+            disabled={!mfaToken || mfaLoading}
+          />
+          <Button
+            onPress={() =>
+              runMfaTest(
+                () =>
+                  mfaClient.getAuthenticators({
+                    mfaToken,
+                    factorsAllowed: ['recovery-code'],
+                  }),
+                'List Recovery Code Only'
+              )
+            }
+            title="mfa.getAuthenticators(recovery-code)"
+            disabled={!mfaToken || mfaLoading}
+          />
+          <Text style={styles.hint}>
+            Each authenticator carries a `type`
+            (otp/phone/email/push-notification/recovery-code) alongside
+            `authenticatorType` and `oobChannel`. `recovery-code` is listable
+            (via `factorsAllowed`) but not enrollable.
+          </Text>
+
+          <Text style={styles.subTitle}>Enroll a factor</Text>
+          <Button
+            onPress={() =>
+              runMfaTest(
+                () =>
+                  mfaClient.enroll({ mfaToken, factorType: MfaFactorType.OTP }),
+                'Enroll TOTP'
+              )
+            }
+            title="mfa.enroll(otp)"
+            disabled={!mfaToken || mfaLoading}
+          />
+          <Button
+            onPress={() =>
+              runMfaTest(
+                () =>
+                  mfaClient.enroll({
+                    mfaToken,
+                    factorType: MfaFactorType.PUSH,
+                  }),
+                'Enroll Push'
+              )
+            }
+            title="mfa.enroll(push)"
+            disabled={!mfaToken || mfaLoading}
+          />
+          <LabeledInput
+            label="Phone Number (SMS / Voice)"
+            value={enrollPhone}
+            onChangeText={setEnrollPhone}
+            placeholder="+12025550135"
+            keyboardType="phone-pad"
+          />
+          <Button
+            onPress={() =>
+              runMfaTest(
+                () =>
+                  mfaClient.enroll({
+                    mfaToken,
+                    factorType: MfaFactorType.SMS,
+                    phoneNumber: enrollPhone,
+                  }),
+                'Enroll SMS'
+              )
+            }
+            title="mfa.enroll(sms)"
+            disabled={!mfaToken || !enrollPhone || mfaLoading}
+          />
+          <Button
+            onPress={() =>
+              runMfaTest(
+                () =>
+                  mfaClient.enroll({
+                    mfaToken,
+                    factorType: MfaFactorType.VOICE,
+                    phoneNumber: enrollPhone,
+                  }),
+                'Enroll Voice'
+              )
+            }
+            title="mfa.enroll(voice)"
+            disabled={!mfaToken || !enrollPhone || mfaLoading}
+          />
+          <Text style={styles.hint}>
+            Voice is a distinct channel on web only. On native it falls back to
+            SMS on the same number.
+          </Text>
+          <LabeledInput
+            label="Email (MFA enroll)"
+            value={enrollEmailMfa}
+            onChangeText={setEnrollEmailMfa}
+            placeholder="user@example.com"
+            autoCapitalize="none"
+            keyboardType="email-address"
+          />
+          <Button
+            onPress={() =>
+              runMfaTest(
+                () =>
+                  mfaClient.enroll({
+                    mfaToken,
+                    factorType: MfaFactorType.EMAIL,
+                    email: enrollEmailMfa,
+                  }),
+                'Enroll Email'
+              )
+            }
+            title="mfa.enroll(email)"
+            disabled={!mfaToken || !enrollEmailMfa || mfaLoading}
+          />
+
+          <Text style={styles.subTitle}>Challenge</Text>
+          <LabeledInput
+            label="Authenticator ID"
+            value={authenticatorId}
+            onChangeText={setAuthenticatorId}
+            placeholder="e.g. sms|dev_123"
+          />
+          <Button
+            onPress={() =>
+              runMfaTest(
+                () => mfaClient.challenge({ mfaToken, authenticatorId }),
+                'Challenge'
+              )
+            }
+            title="mfa.challenge()"
+            disabled={!mfaToken || !authenticatorId || mfaLoading}
+          />
+
+          <Text style={styles.subTitle}>Verify</Text>
+          <Text style={styles.hint}>
+            Scope/audience are optional; supply them to mint an API access token
+            on successful verification.
+          </Text>
+          <LabeledInput
+            label="Scope (optional)"
+            value={verifyScope}
+            onChangeText={setVerifyScope}
+            placeholder="openid profile email"
+            autoCapitalize="none"
+          />
+          <LabeledInput
+            label="Audience (optional)"
+            value={verifyAudience}
+            onChangeText={setVerifyAudience}
+            placeholder="https://your-api/"
+            autoCapitalize="none"
+          />
+          <LabeledInput
+            label="OTP Code"
+            value={mfaOtp}
+            onChangeText={setMfaOtp}
+            keyboardType="numeric"
+          />
+          <Button
+            onPress={() =>
+              runMfaTest(
+                async () =>
+                  sanitizeCredentialResult(
+                    (await mfaClient.verify({
+                      mfaToken,
+                      otp: mfaOtp,
+                      scope: verifyScope || undefined,
+                      audience: verifyAudience || undefined,
+                    })) as Record<string, unknown>
+                  ),
+                'Verify OTP'
+              )
+            }
+            title="mfa.verify(otp)"
+            disabled={!mfaToken || !mfaOtp || mfaLoading}
+          />
+          <LabeledInput
+            label="OOB Code"
+            value={oobCode}
+            onChangeText={setOobCode}
+            placeholder="From challenge/enroll result"
+          />
+          <LabeledInput
+            label="Binding Code (SMS/Voice/Email)"
+            value={bindingCode}
+            onChangeText={setBindingCode}
+            keyboardType="numeric"
+            placeholder="Code from SMS/email/voice"
+          />
+          <Button
+            onPress={() =>
+              runMfaTest(
+                async () =>
+                  sanitizeCredentialResult(
+                    (await mfaClient.verify({
+                      mfaToken,
+                      oobCode,
+                      bindingCode: bindingCode || undefined,
+                      scope: verifyScope || undefined,
+                      audience: verifyAudience || undefined,
+                    })) as Record<string, unknown>
+                  ),
+                'Verify OOB'
+              )
+            }
+            title="mfa.verify(oob)"
+            disabled={!mfaToken || !oobCode || mfaLoading}
+          />
+          <LabeledInput
+            label="Recovery Code"
+            value={recoveryCode}
+            onChangeText={setRecoveryCode}
+            placeholder="Recovery code"
+            autoCapitalize="none"
+          />
+          <Button
+            onPress={() =>
+              runMfaTest(
+                async () =>
+                  sanitizeCredentialResult(
+                    (await mfaClient.verify({
+                      mfaToken,
+                      recoveryCode,
+                      scope: verifyScope || undefined,
+                      audience: verifyAudience || undefined,
+                    })) as Record<string, unknown>
+                  ),
+                'Verify Recovery Code'
+              )
+            }
+            title="mfa.verify(recoveryCode)"
+            disabled={!mfaToken || !recoveryCode || mfaLoading}
+          />
         </Section>
 
         {Platform.OS !== 'web' && (
@@ -724,43 +623,13 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   sectionTitle: { fontSize: 18, fontWeight: 'bold', marginBottom: 8 },
-  stepTitle: {
-    fontSize: 16,
+  subTitle: {
+    fontSize: 14,
     fontWeight: '700',
     color: '#333',
-    marginBottom: 4,
+    marginTop: 8,
   },
   hint: { fontSize: 12, color: '#888', fontStyle: 'italic' },
-  authItem: {
-    borderWidth: 1,
-    borderColor: '#CCC',
-    borderRadius: 6,
-    padding: 12,
-    backgroundColor: '#F9F9F9',
-  },
-  authItemTitle: { fontSize: 14, fontWeight: '600' },
-  authItemSubtitle: { fontSize: 11, color: '#666', marginTop: 2 },
-  divider: {
-    height: 1,
-    backgroundColor: '#E0E0E0',
-    marginVertical: 8,
-  },
-  infoBox: {
-    backgroundColor: '#F0F4FF',
-    borderRadius: 6,
-    padding: 10,
-    gap: 4,
-  },
-  infoLabel: { fontSize: 12, fontWeight: '600', color: '#444' },
-  infoValue: { fontSize: 12, color: '#333', fontFamily: 'monospace' },
-  qrContainer: { alignItems: 'center', marginVertical: 12 },
-  qrImage: { width: 200, height: 200 },
-  successText: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#2E7D32',
-    textAlign: 'center',
-  },
   description: { fontSize: 13, color: '#666', marginBottom: 4 },
   row: { flexDirection: 'row', gap: 8 },
   halfButton: { flex: 1, minWidth: 0 },

--- a/example/src/screens/hooks/Home.tsx
+++ b/example/src/screens/hooks/Home.tsx
@@ -6,16 +6,27 @@ import {
   Text,
   StyleSheet,
   Alert,
+  TouchableOpacity,
+  Image,
+  Linking,
   Platform,
 } from 'react-native';
 import {
   useAuth0,
   WebAuthError,
   WebAuthErrorCodes,
+  MfaError,
+  MfaErrorCodes,
+  MfaFactorType,
   PasskeyError,
   PasskeyErrorCodes,
 } from 'react-native-auth0';
-import type { PasswordlessChallenge } from 'react-native-auth0';
+import type {
+  PasswordlessChallenge,
+  MfaAuthenticator,
+  MfaEnrollmentChallenge,
+  MfaChallengeResult,
+} from 'react-native-auth0';
 import Button from '../../components/Button';
 import Header from '../../components/Header';
 import LabeledInput from '../../components/LabeledInput';
@@ -27,6 +38,17 @@ import {
   PasskeyModuleErrorCodes,
 } from '../../passkey/PasskeyModule';
 
+type MfaStep =
+  | 'idle'
+  | 'list'
+  | 'enroll-select'
+  | 'enroll-details'
+  | 'challenge'
+  | 'verify'
+  | 'complete';
+
+type EnrollType = MfaFactorType;
+
 const HomeScreen = () => {
   const {
     authorize,
@@ -34,6 +56,7 @@ const HomeScreen = () => {
     loginWithPasswordRealm,
     sendEmailCode,
     authorizeWithEmail,
+    mfa,
     passkeySignupChallenge,
     passkeyLoginChallenge,
     getTokenByPasskey,
@@ -46,6 +69,7 @@ const HomeScreen = () => {
   const [otp, setOtp] = useState('');
   const [showOtpInput, setShowOtpInput] = useState(false);
   const [apiError, setApiError] = useState<Error | null>(null);
+  const [result, setResult] = useState<object | null>(null);
   const [passkeyEmail, setPasskeyEmail] = useState('');
   const [loading, setLoading] = useState(false);
   const [lastResult, setLastResult] = useState<object | null>(null);
@@ -56,6 +80,47 @@ const HomeScreen = () => {
   const [otpChallenge, setOtpChallenge] =
     useState<PasswordlessChallenge | null>(null);
   const [useTrustedWebActivity, setUseTrustedWebActivity] = useState(false);
+
+  // MFA wizard state
+  const [mfaToken, setMfaToken] = useState('');
+  const [mfaStep, setMfaStep] = useState<MfaStep>('idle');
+  const [mfaLoading, setMfaLoading] = useState(false);
+  const [authenticators, setAuthenticators] = useState<MfaAuthenticator[]>([]);
+  const [selectedAuthenticator, setSelectedAuthenticator] =
+    useState<MfaAuthenticator | null>(null);
+  const [enrollType, setEnrollType] = useState<EnrollType | null>(null);
+  const [enrollPhoneNumber, setEnrollPhoneNumber] = useState('');
+  const [enrollEmail, setEnrollEmail] = useState('');
+  const [enrollmentChallenge, setEnrollmentChallenge] =
+    useState<MfaEnrollmentChallenge | null>(null);
+  const [challengeResult, setChallengeResult] =
+    useState<MfaChallengeResult | null>(null);
+  const [verifyCode, setVerifyCode] = useState('');
+  const [verifyBindingCode, setVerifyBindingCode] = useState('');
+  const [verifyScope, setVerifyScope] = useState('');
+  const [verifyAudience, setVerifyAudience] = useState('');
+
+  const clearResult = () => {
+    setResult(null);
+    setApiError(null);
+  };
+
+  const resetMfaWizard = () => {
+    setMfaStep('idle');
+    setAuthenticators([]);
+    setSelectedAuthenticator(null);
+    setEnrollType(null);
+    setEnrollPhoneNumber('');
+    setEnrollEmail('');
+    setEnrollmentChallenge(null);
+    setChallengeResult(null);
+    setVerifyCode('');
+    setVerifyBindingCode('');
+    setVerifyScope('');
+    setVerifyAudience('');
+    setMfaLoading(false);
+    clearResult();
+  };
 
   const onLogin = async () => {
     try {
@@ -98,14 +163,74 @@ const HomeScreen = () => {
   };
 
   const onLoginWithPassword = async () => {
+    clearResult();
     try {
       await loginWithPasswordRealm({
         username: email,
         password: password,
         realm: 'Username-Password-Authentication',
       });
+    } catch (e: any) {
+      if (e?.json?.mfa_token) {
+        const token = e.json.mfa_token;
+        setMfaToken(token);
+        Alert.alert(
+          'MFA Required',
+          'Multi-factor authentication is required. Checking enrolled authenticators...'
+        );
+        await startMfaFlow(token);
+      } else {
+        setApiError(e as Error);
+      }
+    }
+  };
+
+  const startMfaFlow = async (token: string) => {
+    setMfaLoading(true);
+    clearResult();
+    try {
+      const list = await mfa.getAuthenticators({
+        mfaToken: token,
+        factorsAllowed: [
+          MfaFactorType.OTP,
+          MfaFactorType.SMS,
+          MfaFactorType.EMAIL,
+          MfaFactorType.PUSH,
+          MfaFactorType.VOICE,
+        ],
+      });
+      setAuthenticators(list);
+
+      const activeAuthenticator = list.find((auth) => auth.active);
+      if (activeAuthenticator) {
+        setSelectedAuthenticator(activeAuthenticator);
+        setMfaStep('challenge');
+        await triggerChallenge(token, activeAuthenticator);
+      } else {
+        setMfaStep('enroll-select');
+      }
     } catch (e) {
-      setApiError(e as Error);
+      handleMfaError(e, 'Failed to list authenticators.');
+      setMfaStep('idle');
+    } finally {
+      setMfaLoading(false);
+    }
+  };
+
+  const triggerChallenge = async (token: string, auth: MfaAuthenticator) => {
+    setMfaLoading(true);
+    try {
+      const res = await mfa.challenge({
+        mfaToken: token,
+        authenticatorId: auth.id,
+      });
+      setChallengeResult(res);
+      setMfaStep('verify');
+    } catch (e) {
+      handleMfaError(e, 'Challenge failed.');
+      setMfaStep('list');
+    } finally {
+      setMfaLoading(false);
     }
   };
 
@@ -124,6 +249,444 @@ const HomeScreen = () => {
       await authorizeWithEmail({ email, code: otp });
     } catch (e) {
       setApiError(e as Error);
+    }
+  };
+
+  // --- MFA Wizard Handlers ---
+
+  const handleMfaError = (e: unknown, fallbackMsg: string) => {
+    if (e instanceof MfaError) {
+      if (
+        e.type === MfaErrorCodes.EXPIRED_MFA_TOKEN ||
+        e.type === MfaErrorCodes.INVALID_MFA_TOKEN
+      ) {
+        Alert.alert('Session Expired', 'Please log in again.');
+        setMfaToken('');
+        resetMfaWizard();
+        return;
+      }
+      Alert.alert('MFA Error', e.message);
+      setApiError(e);
+    } else {
+      setApiError(e as Error);
+      Alert.alert('Error', fallbackMsg);
+    }
+  };
+
+  const onStartMfa = async () => {
+    await startMfaFlow(mfaToken);
+  };
+
+  const onSelectAuthenticator = (auth: MfaAuthenticator) => {
+    setSelectedAuthenticator(auth);
+    setChallengeResult(null);
+    setMfaStep('challenge');
+    triggerChallenge(mfaToken, auth);
+  };
+
+  const onSelectEnrollType = (type: EnrollType) => {
+    setEnrollType(type);
+    if (type === MfaFactorType.OTP || type === MfaFactorType.PUSH) {
+      onEnroll(type);
+    } else {
+      setMfaStep('enroll-details');
+    }
+  };
+
+  const onEnroll = async (type?: EnrollType) => {
+    const factor = type || enrollType;
+    if (!factor) return;
+
+    setMfaLoading(true);
+    try {
+      let challenge: MfaEnrollmentChallenge;
+      if (factor === MfaFactorType.SMS) {
+        challenge = await mfa.enroll({
+          mfaToken,
+          factorType: MfaFactorType.SMS,
+          phoneNumber: enrollPhoneNumber,
+        });
+      } else if (factor === MfaFactorType.VOICE) {
+        challenge = await mfa.enroll({
+          mfaToken,
+          factorType: MfaFactorType.VOICE,
+          phoneNumber: enrollPhoneNumber,
+        });
+      } else if (factor === MfaFactorType.EMAIL) {
+        challenge = await mfa.enroll({
+          mfaToken,
+          factorType: MfaFactorType.EMAIL,
+          email: enrollEmail,
+        });
+      } else {
+        challenge = await mfa.enroll({ mfaToken, factorType: factor });
+      }
+      setEnrollmentChallenge(challenge);
+      setMfaStep('verify');
+    } catch (e) {
+      handleMfaError(e, 'Enrollment failed.');
+    } finally {
+      setMfaLoading(false);
+    }
+  };
+
+  const onVerify = async () => {
+    setMfaLoading(true);
+    try {
+      let credentials;
+      // scope/audience are optional: supply them to mint an access token for a
+      // specific API once MFA succeeds.
+      const extra = {
+        scope: verifyScope || undefined,
+        audience: verifyAudience || undefined,
+      };
+      const oobCode =
+        challengeResult?.oobCode ||
+        (enrollmentChallenge?.type === 'oob' ||
+        enrollmentChallenge?.type === 'push'
+          ? enrollmentChallenge.oobCode
+          : undefined);
+
+      if (oobCode) {
+        credentials = await mfa.verify({
+          mfaToken,
+          oobCode,
+          bindingCode: verifyBindingCode || undefined,
+          ...extra,
+        });
+      } else if (enrollmentChallenge?.type === 'recovery-code') {
+        credentials = await mfa.verify({
+          mfaToken,
+          recoveryCode: verifyCode,
+          ...extra,
+        });
+      } else {
+        credentials = await mfa.verify({ mfaToken, otp: verifyCode, ...extra });
+      }
+      setResult({
+        success: true,
+        accessToken: credentials.accessToken.substring(0, 20) + '...',
+      });
+      setMfaStep('complete');
+    } catch (e) {
+      handleMfaError(e, 'Verification failed.');
+    } finally {
+      setMfaLoading(false);
+    }
+  };
+
+  // --- MFA Wizard UI ---
+
+  const renderMfaWizard = () => {
+    switch (mfaStep) {
+      case 'idle':
+        return (
+          <>
+            <Text style={styles.hint}>
+              Get an mfa_token from a password login with MFA enabled, or paste
+              one manually.
+            </Text>
+            <LabeledInput
+              label="MFA Token"
+              value={mfaToken}
+              onChangeText={setMfaToken}
+              placeholder="Paste or auto-filled from password login"
+            />
+            <Button
+              onPress={onStartMfa}
+              title="Start MFA"
+              disabled={!mfaToken || mfaLoading}
+            />
+          </>
+        );
+
+      case 'list':
+        return (
+          <>
+            <Text style={styles.stepTitle}>Step 1: Select Authenticator</Text>
+            {authenticators.length > 0 ? (
+              <>
+                <Text style={styles.hint}>
+                  Select an enrolled authenticator to challenge:
+                </Text>
+                {authenticators.map((auth) => (
+                  <TouchableOpacity
+                    key={auth.id}
+                    style={styles.authItem}
+                    onPress={() => onSelectAuthenticator(auth)}
+                  >
+                    <Text style={styles.authItemTitle}>
+                      {auth.type ?? auth.authenticatorType}
+                      {auth.oobChannel ? ` (${auth.oobChannel})` : ''}
+                    </Text>
+                    <Text style={styles.authItemSubtitle}>
+                      {auth.id} · authenticatorType: {auth.authenticatorType}
+                      {auth.active ? '' : ' · inactive'}
+                    </Text>
+                  </TouchableOpacity>
+                ))}
+                <View style={styles.divider} />
+              </>
+            ) : (
+              <Text style={styles.hint}>
+                No authenticators enrolled. Enroll a new one below.
+              </Text>
+            )}
+            <Button
+              onPress={() => setMfaStep('enroll-select')}
+              title="Enroll New Authenticator"
+            />
+            <Button onPress={resetMfaWizard} title="Back" />
+          </>
+        );
+
+      case 'enroll-select':
+        return (
+          <>
+            <Text style={styles.stepTitle}>Step 2: Choose Factor Type</Text>
+            <Button
+              onPress={() => onSelectEnrollType(MfaFactorType.OTP)}
+              title="TOTP (Authenticator App)"
+              disabled={mfaLoading}
+            />
+            <Button
+              onPress={() => onSelectEnrollType(MfaFactorType.SMS)}
+              title="SMS"
+              disabled={mfaLoading}
+            />
+            <Button
+              onPress={() => onSelectEnrollType(MfaFactorType.VOICE)}
+              title="Voice"
+              disabled={mfaLoading}
+            />
+            <Text style={styles.hint}>
+              Voice is a distinct channel on web only. On native (iOS/Android)
+              it falls back to SMS on the same number.
+            </Text>
+            <Button
+              onPress={() => onSelectEnrollType(MfaFactorType.EMAIL)}
+              title="Email"
+              disabled={mfaLoading}
+            />
+            <Button
+              onPress={() => onSelectEnrollType(MfaFactorType.PUSH)}
+              title="Push Notification"
+              disabled={mfaLoading}
+            />
+            <Button onPress={() => setMfaStep('list')} title="Back" />
+          </>
+        );
+
+      case 'enroll-details':
+        return (
+          <>
+            <Text style={styles.stepTitle}>Step 2: Enter Details</Text>
+            {(enrollType === MfaFactorType.SMS ||
+              enrollType === MfaFactorType.VOICE) && (
+              <>
+                <LabeledInput
+                  label="Phone Number"
+                  value={enrollPhoneNumber}
+                  onChangeText={setEnrollPhoneNumber}
+                  placeholder="+12025550135"
+                  keyboardType="phone-pad"
+                />
+                <Button
+                  onPress={() => onEnroll()}
+                  title={
+                    enrollType === MfaFactorType.VOICE
+                      ? 'Enroll Voice'
+                      : 'Enroll SMS'
+                  }
+                  disabled={!enrollPhoneNumber || mfaLoading}
+                />
+              </>
+            )}
+            {enrollType === MfaFactorType.EMAIL && (
+              <>
+                <LabeledInput
+                  label="Email"
+                  value={enrollEmail}
+                  onChangeText={setEnrollEmail}
+                  placeholder="user@example.com"
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                />
+                <Button
+                  onPress={() => onEnroll()}
+                  title="Enroll Email"
+                  disabled={!enrollEmail || mfaLoading}
+                />
+              </>
+            )}
+            <Button onPress={() => setMfaStep('enroll-select')} title="Back" />
+          </>
+        );
+
+      case 'verify':
+        return (
+          <>
+            <Text style={styles.stepTitle}>Step 3: Verify</Text>
+            {enrollmentChallenge?.type === 'totp' && (
+              <View style={styles.infoBox}>
+                {enrollmentChallenge.barcodeUri && (
+                  <>
+                    <View style={styles.qrContainer}>
+                      <Image
+                        source={{
+                          uri: `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(enrollmentChallenge.barcodeUri)}`,
+                        }}
+                        style={styles.qrImage}
+                      />
+                    </View>
+                    <Button
+                      onPress={() =>
+                        Linking.openURL(enrollmentChallenge.barcodeUri!)
+                      }
+                      title="Open in Authenticator App"
+                    />
+                  </>
+                )}
+                <Text style={styles.infoLabel}>Secret:</Text>
+                <Text style={styles.infoValue} selectable>
+                  {enrollmentChallenge.secret}
+                </Text>
+              </View>
+            )}
+            {enrollmentChallenge?.type === 'push' && (
+              <View style={styles.infoBox}>
+                <Text style={styles.hint}>
+                  Scan this QR code with the Auth0 Guardian app to pair, then
+                  approve the push notification on your device.
+                </Text>
+                {enrollmentChallenge.barcodeUri ? (
+                  <View style={styles.qrContainer}>
+                    <Image
+                      source={{
+                        uri: `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(enrollmentChallenge.barcodeUri)}`,
+                      }}
+                      style={styles.qrImage}
+                    />
+                  </View>
+                ) : null}
+                <Button
+                  onPress={onVerify}
+                  title="I've approved the push"
+                  disabled={mfaLoading}
+                />
+              </View>
+            )}
+            {challengeResult && (
+              <View style={styles.infoBox}>
+                <Text style={styles.infoLabel}>
+                  Challenge Type: {challengeResult.challengeType}
+                </Text>
+                {challengeResult.bindingMethod && (
+                  <Text style={styles.infoLabel}>
+                    Binding Method: {challengeResult.bindingMethod}
+                  </Text>
+                )}
+              </View>
+            )}
+            {(challengeResult?.challengeType === 'oob' ||
+              enrollmentChallenge?.type === 'oob') && (
+              <>
+                <Text style={styles.hint}>
+                  A code has been sent to your device. Enter the binding code
+                  below.
+                </Text>
+                <LabeledInput
+                  label="Binding Code"
+                  value={verifyBindingCode}
+                  onChangeText={setVerifyBindingCode}
+                  keyboardType="numeric"
+                  placeholder="Code from SMS/email/push"
+                />
+                <Button
+                  onPress={onVerify}
+                  title="Verify"
+                  disabled={!verifyBindingCode || mfaLoading}
+                />
+              </>
+            )}
+            {(challengeResult?.challengeType === 'otp' ||
+              enrollmentChallenge?.type === 'totp') && (
+              <>
+                <LabeledInput
+                  label="OTP Code"
+                  value={verifyCode}
+                  onChangeText={setVerifyCode}
+                  keyboardType="numeric"
+                  placeholder="6-digit code from authenticator app"
+                />
+                <Button
+                  onPress={onVerify}
+                  title="Verify"
+                  disabled={!verifyCode || mfaLoading}
+                />
+              </>
+            )}
+            {enrollmentChallenge?.type === 'recovery-code' && (
+              <View style={styles.infoBox}>
+                <Text style={styles.hint}>
+                  Save this recovery code somewhere safe — it is shown only
+                  once. Enter it below to complete verification.
+                </Text>
+                <Text style={styles.infoLabel}>Recovery Code:</Text>
+                <Text style={styles.infoValue} selectable>
+                  {enrollmentChallenge.recoveryCode}
+                </Text>
+                <LabeledInput
+                  label="Confirm Recovery Code"
+                  value={verifyCode}
+                  onChangeText={setVerifyCode}
+                  placeholder="Re-enter the recovery code"
+                  autoCapitalize="none"
+                />
+                <Button
+                  onPress={onVerify}
+                  title="Verify"
+                  disabled={!verifyCode || mfaLoading}
+                />
+              </View>
+            )}
+            <View style={styles.divider} />
+            <Text style={styles.hint}>
+              Optional: request a scope/audience to mint an API access token on
+              successful verification.
+            </Text>
+            <LabeledInput
+              label="Scope (optional)"
+              value={verifyScope}
+              onChangeText={setVerifyScope}
+              placeholder="openid profile email"
+              autoCapitalize="none"
+            />
+            <LabeledInput
+              label="Audience (optional)"
+              value={verifyAudience}
+              onChangeText={setVerifyAudience}
+              placeholder={`https://${config.domain}/api/v2/`}
+              autoCapitalize="none"
+            />
+            <Button onPress={() => setMfaStep('list')} title="Back" />
+          </>
+        );
+
+      case 'complete':
+        return (
+          <>
+            <Text style={styles.stepTitle}>MFA Complete</Text>
+            <Text style={styles.successText}>Authentication successful!</Text>
+            {result && (
+              <Result title="Credentials" error={null} result={result} />
+            )}
+            <Button onPress={resetMfaWizard} title="Done" />
+          </>
+        );
+
+      default:
+        return null;
     }
   };
 
@@ -386,6 +949,10 @@ const HomeScreen = () => {
             secureTextEntry
           />
           <Button onPress={onLoginWithPassword} title="Log In with Password" />
+          <Text style={styles.hint}>
+            If MFA is enabled, a failed login will return an mfa_token and
+            automatically start the MFA wizard.
+          </Text>
         </Section>
 
         <Section title="Passwordless (Email OTP)">
@@ -397,7 +964,6 @@ const HomeScreen = () => {
             keyboardType="email-address"
           />
           <Button onPress={onSendEmailCode} title="Send Email Code" />
-
           {showOtpInput && (
             <>
               <LabeledInput
@@ -409,6 +975,10 @@ const HomeScreen = () => {
               <Button onPress={onLoginWithEmailCode} title="Log In with Code" />
             </>
           )}
+        </Section>
+
+        <Section title="MFA Flexible Factors Grant">
+          {renderMfaWizard()}
         </Section>
 
         {Platform.OS !== 'web' && (
@@ -566,7 +1136,7 @@ const Section = ({
 
 const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: '#FFFFFF' },
-  content: { padding: 16, gap: 20 },
+  content: { padding: 16, gap: 20, paddingBottom: 50 },
   title: {
     fontSize: 24,
     fontWeight: 'bold',
@@ -581,6 +1151,33 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   sectionTitle: { fontSize: 18, fontWeight: 'bold', marginBottom: 8 },
+  stepTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#333',
+    marginBottom: 4,
+  },
+  hint: { fontSize: 12, color: '#888', fontStyle: 'italic' },
+  authItem: {
+    borderWidth: 1,
+    borderColor: '#CCC',
+    borderRadius: 6,
+    padding: 12,
+    backgroundColor: '#F9F9F9',
+  },
+  authItemTitle: { fontSize: 14, fontWeight: '600' },
+  authItemSubtitle: { fontSize: 11, color: '#666', marginTop: 2 },
+  divider: {
+    height: 1,
+    backgroundColor: '#E0E0E0',
+    marginVertical: 8,
+  },
+  infoBox: {
+    backgroundColor: '#F0F4FF',
+    borderRadius: 6,
+    padding: 10,
+    gap: 4,
+  },
   description: { fontSize: 13, color: '#666', marginBottom: 4 },
   row: { flexDirection: 'row', gap: 8 },
   halfButton: { flex: 1, minWidth: 0 },
@@ -590,6 +1187,16 @@ const styles = StyleSheet.create({
     borderRadius: 6,
     padding: 10,
     gap: 4,
+  },
+  infoLabel: { fontSize: 12, fontWeight: '600', color: '#444' },
+  infoValue: { fontSize: 12, color: '#333', fontFamily: 'monospace' },
+  qrContainer: { alignItems: 'center', marginVertical: 12 },
+  qrImage: { width: 200, height: 200 },
+  successText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#2E7D32',
+    textAlign: 'center',
   },
   resultLabel: { fontSize: 12, fontWeight: '600', color: '#333' },
   resultValue: { fontSize: 11, color: '#555', fontFamily: 'monospace' },

--- a/ios/A0Auth0.mm
+++ b/ios/A0Auth0.mm
@@ -193,6 +193,39 @@ RCT_EXPORT_METHOD(customTokenExchange:(NSString *)subjectToken
     [self.nativeBridge customTokenExchangeWithSubjectToken:subjectToken subjectTokenType:subjectTokenType audience:audience scope:scope organization:organization resolve:resolve reject:reject];
 }
 
+RCT_EXPORT_METHOD(getMfaAuthenticators:(NSString *)mfaToken
+                  factorsAllowed:(NSArray * _Nullable)factorsAllowed
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [self.nativeBridge getMfaAuthenticatorsWithMfaToken:mfaToken factorsAllowed:factorsAllowed resolve:resolve reject:reject];
+}
+
+RCT_EXPORT_METHOD(mfaEnroll:(NSString *)mfaToken
+                  type:(NSString *)type
+                  value:(NSString * _Nullable)value
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [self.nativeBridge mfaEnrollWithMfaToken:mfaToken type:type value:value resolve:resolve reject:reject];
+}
+
+RCT_EXPORT_METHOD(mfaChallenge:(NSString *)mfaToken
+                  authenticatorId:(NSString *)authenticatorId
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [self.nativeBridge mfaChallengeWithMfaToken:mfaToken authenticatorId:authenticatorId resolve:resolve reject:reject];
+}
+
+RCT_EXPORT_METHOD(mfaVerify:(NSString *)mfaToken
+                  type:(NSString *)type
+                  code:(NSString *)code
+                  bindingCode:(NSString * _Nullable)bindingCode
+                  scope:(NSString * _Nullable)scope
+                  audience:(NSString * _Nullable)audience
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [self.nativeBridge mfaVerifyWithMfaToken:mfaToken type:type code:code bindingCode:bindingCode scope:scope audience:audience resolve:resolve reject:reject];
+}
+
 RCT_EXPORT_METHOD(passkeySignupChallenge:(NSString * _Nullable)email
                   phoneNumber:(NSString * _Nullable)phoneNumber
                   username:(NSString * _Nullable)username

--- a/ios/A0MfaClient.swift
+++ b/ios/A0MfaClient.swift
@@ -1,0 +1,226 @@
+//
+//  A0MfaClient.swift
+//  A0Auth0
+//
+//  Copyright © 2025 Facebook. All rights reserved.
+//
+
+import Auth0
+import Foundation
+
+/// A dedicated bridge class for MFA (Multi-Factor Authentication) operations.
+/// Encapsulates all MFA-related native SDK interactions, keeping them separate
+/// from the main NativeBridge for better organization and maintainability.
+enum MfaFactorType: String {
+    case phone
+    case email
+    case otp
+    case push
+    case voice
+}
+
+enum MfaVerificationType: String {
+    case otp
+    case oob
+    case recoveryCode
+}
+
+class A0MfaClient {
+
+    private let clientId: String
+    private let domain: String
+    private let useDPoP: Bool
+
+    private lazy var mfaClient: MFAClient = {
+        var client = Auth0.mfa(clientId: clientId, domain: domain)
+        if useDPoP {
+            client = client.useDPoP()
+        }
+        return client
+    }()
+
+    init(clientId: String, domain: String, useDPoP: Bool) {
+        self.clientId = clientId
+        self.domain = domain
+        self.useDPoP = useDPoP
+    }
+
+    // Maps the public MfaFactorType vocabulary (otp/sms/voice/email/push) onto
+    // the challenge-type tokens Auth0.swift filters `authenticator.type` against.
+    // Note: iOS cannot distinguish sms from voice — both are the `phone` type.
+    private func mapFactorType(_ factor: String) -> [String] {
+        switch factor.lowercased() {
+        case "otp": return ["otp", "totp"]
+        case "sms", "voice": return ["phone"]
+        case "email": return ["email"]
+        case "push": return ["push-notification"]
+        default: return []
+        }
+    }
+
+    func getAuthenticators(mfaToken: String, factorsAllowed: [String]?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        let requested = (factorsAllowed ?? []).map { $0.lowercased() }
+        var allowedFactors = requested.flatMap { mapFactorType($0) }
+
+        // Auth0.swift rejects an empty factorsAllowed list, so default to every
+        // recognized challenge-type token to match Android/web "return all" behaviour.
+        if allowedFactors.isEmpty {
+            allowedFactors = ["otp", "totp", "phone", "email", "push-notification", "recovery-code"]
+        }
+
+        // Auth0.swift filters only on `authenticator.type`, where sms and voice
+        // both surface as "phone" — so an sms-only (or voice-only) request still
+        // returns the other channel. Narrow phone-type results by oobChannel when
+        // the caller asked for one but not both. Empty set = no narrowing (covers
+        // the return-all default and requests that don't mention sms/voice).
+        var wantedPhoneChannels = Set<String>()
+        if requested.contains("sms") { wantedPhoneChannels.insert("sms") }
+        if requested.contains("voice") { wantedPhoneChannels.insert("voice") }
+        let narrowPhoneChannels = wantedPhoneChannels.count == 1
+
+        mfaClient.getAuthenticators(mfaToken: mfaToken, factorsAllowed: allowedFactors).start { result in
+            switch result {
+            case .success(let authenticators):
+                let list = authenticators.compactMap { authenticator -> [String: Any]? in
+                    if narrowPhoneChannels, authenticator.type == "phone",
+                       let channel = authenticator.oobChannel,
+                       !wantedPhoneChannels.contains(channel) {
+                        return nil
+                    }
+                    var dict: [String: Any] = [
+                        "id": authenticator.id,
+                        "type": authenticator.type,
+                        "authenticatorType": authenticator.authenticatorType,
+                        "active": authenticator.active
+                    ]
+                    if let name = authenticator.name { dict["name"] = name }
+                    if let oobChannel = authenticator.oobChannel { dict["oobChannel"] = oobChannel }
+                    return dict
+                }
+                resolve(list)
+            case .failure(let error):
+                reject(error.code, error.localizedDescription, error)
+            }
+        }
+    }
+
+    func enroll(mfaToken: String, type: String, value: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        guard let factorType = MfaFactorType(rawValue: type) else {
+            reject("MFA_ENROLLMENT_ERROR", "Unsupported enrollment type: \(type)", nil)
+            return
+        }
+
+        switch factorType {
+        case .phone, .voice:
+            guard let phoneNumber = value else {
+                reject("MFA_ENROLLMENT_ERROR", "Phone number is required for phone enrollment", nil)
+                return
+            }
+            mfaClient.enroll(mfaToken: mfaToken, phoneNumber: phoneNumber).start { result in
+                switch result {
+                case .success(let challenge):
+                    var dict: [String: Any] = ["type": "oob"]
+                    dict["oobCode"] = challenge.oobCode
+                    dict["bindingMethod"] = challenge.bindingMethod
+                    if let recoveryCodes = challenge.recoveryCodes { dict["recoveryCodes"] = recoveryCodes }
+                    resolve(dict)
+                case .failure(let error):
+                    reject(error.code, error.localizedDescription, error)
+                }
+            }
+        case .email:
+            guard let email = value else {
+                reject("MFA_ENROLLMENT_ERROR", "Email is required for email enrollment", nil)
+                return
+            }
+            mfaClient.enroll(mfaToken: mfaToken, email: email).start { result in
+                switch result {
+                case .success(let challenge):
+                    var dict: [String: Any] = ["type": "oob"]
+                    dict["oobCode"] = challenge.oobCode
+                    dict["bindingMethod"] = challenge.bindingMethod
+                    if let recoveryCodes = challenge.recoveryCodes { dict["recoveryCodes"] = recoveryCodes }
+                    resolve(dict)
+                case .failure(let error):
+                    reject(error.code, error.localizedDescription, error)
+                }
+            }
+        case .otp:
+            let request: Request<OTPMFAEnrollmentChallenge, MfaEnrollmentError> = mfaClient.enroll(mfaToken: mfaToken)
+            request.start { result in
+                switch result {
+                case .success(let challenge):
+                    var dict: [String: Any] = ["type": "totp"]
+                    dict["barcodeUri"] = challenge.barcodeUri
+                    dict["secret"] = challenge.secret
+                    if let recoveryCodes = challenge.recoveryCodes { dict["recoveryCodes"] = recoveryCodes }
+                    resolve(dict)
+                case .failure(let error):
+                    reject(error.code, error.localizedDescription, error)
+                }
+            }
+        case .push:
+            let request: Request<PushMFAEnrollmentChallenge, MfaEnrollmentError> = mfaClient.enroll(mfaToken: mfaToken)
+            request.start { result in
+                switch result {
+                case .success(let challenge):
+                    var dict: [String: Any] = ["type": "push"]
+                    dict["barcodeUri"] = challenge.barcodeUri
+                    dict["oobCode"] = challenge.oobCode
+                    dict["oobChannel"] = challenge.oobChannel
+                    if let recoveryCodes = challenge.recoveryCodes { dict["recoveryCodes"] = recoveryCodes }
+                    resolve(dict)
+                case .failure(let error):
+                    reject(error.code, error.localizedDescription, error)
+                }
+            }
+        }
+    }
+
+    func challenge(mfaToken: String, authenticatorId: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        mfaClient.challenge(with: authenticatorId, mfaToken: mfaToken).start { result in
+            switch result {
+            case .success(let challenge):
+                var dict: [String: Any] = [
+                    "challengeType": challenge.challengeType
+                ]
+                dict["oobCode"] = challenge.oobCode
+                if let bindingMethod = challenge.bindingMethod { dict["bindingMethod"] = bindingMethod }
+                resolve(dict)
+            case .failure(let error):
+                reject(error.code, error.localizedDescription, error)
+            }
+        }
+    }
+
+    func verify(mfaToken: String, type: String, code: String, bindingCode: String?, scope: String?, audience: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        guard let verificationType = MfaVerificationType(rawValue: type) else {
+            reject("MFA_VERIFY_ERROR", "Unsupported verification type: \(type)", nil)
+            return
+        }
+
+        let request: Request<Credentials, MFAVerifyError>
+        switch verificationType {
+        case .otp:
+            request = mfaClient.verify(otp: code, mfaToken: mfaToken)
+        case .oob:
+            request = mfaClient.verify(oobCode: code, bindingCode: bindingCode, mfaToken: mfaToken)
+        case .recoveryCode:
+            request = mfaClient.verify(recoveryCode: code, mfaToken: mfaToken)
+        }
+
+        var extraParameters: [String: Any] = [:]
+        if let scope = scope { extraParameters["scope"] = scope }
+        if let audience = audience { extraParameters["audience"] = audience }
+        let finalRequest = extraParameters.isEmpty ? request : request.parameters(extraParameters)
+
+        finalRequest.start { result in
+            switch result {
+            case .success(let credentials):
+                resolve(credentials.asDictionary())
+            case .failure(let error):
+                reject(error.code, error.localizedDescription, error)
+            }
+        }
+    }
+}

--- a/ios/A0MfaClient.swift
+++ b/ios/A0MfaClient.swift
@@ -48,12 +48,15 @@ class A0MfaClient {
     // Maps the public MfaFactorType vocabulary (otp/sms/voice/email/push) onto
     // the challenge-type tokens Auth0.swift filters `authenticator.type` against.
     // Note: iOS cannot distinguish sms from voice — both are the `phone` type.
+    // `recovery-code` is listable but not enrollable, so it maps through here
+    // yet is absent from the enum.
     private func mapFactorType(_ factor: String) -> [String] {
         switch factor.lowercased() {
         case "otp": return ["otp", "totp"]
         case "sms", "voice": return ["phone"]
         case "email": return ["email"]
         case "push": return ["push-notification"]
+        case "recovery-code": return ["recovery-code"]
         default: return []
         }
     }

--- a/ios/NativeBridge.swift
+++ b/ios/NativeBridge.swift
@@ -46,6 +46,9 @@ public class NativeBridge: NSObject {
     var domain: String
     var useDPoP: Bool
     var maxRetries: Int
+    private(set) lazy var mfaClient: A0MfaClient = {
+        A0MfaClient(clientId: self.clientId, domain: self.domain, useDPoP: self.useDPoP)
+    }()
     
     @objc public init(clientId: String, domain: String, localAuthenticationOptions: [String: Any]?, useDPoP: Bool, maxRetries: Int, credentialsManagerStorageKey: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         var auth0 = Auth0
@@ -411,9 +414,23 @@ public class NativeBridge: NSObject {
         }
     }
     
+    // MARK: - MFA Flexible Factors Grant
 
+    @objc public func getMfaAuthenticators(mfaToken: String, factorsAllowed: [String]?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        mfaClient.getAuthenticators(mfaToken: mfaToken, factorsAllowed: factorsAllowed, resolve: resolve, reject: reject)
+    }
 
+    @objc public func mfaEnroll(mfaToken: String, type: String, value: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        mfaClient.enroll(mfaToken: mfaToken, type: type, value: value, resolve: resolve, reject: reject)
+    }
 
+    @objc public func mfaChallenge(mfaToken: String, authenticatorId: String, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        mfaClient.challenge(mfaToken: mfaToken, authenticatorId: authenticatorId, resolve: resolve, reject: reject)
+    }
+
+    @objc public func mfaVerify(mfaToken: String, type: String, code: String, bindingCode: String?, scope: String?, audience: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        mfaClient.verify(mfaToken: mfaToken, type: type, code: code, bindingCode: bindingCode, scope: scope, audience: audience, resolve: resolve, reject: reject)
+    }
 
     // MARK: - Passkey Methods (challenge / exchange)
 

--- a/src/Auth0.ts
+++ b/src/Auth0.ts
@@ -1,4 +1,5 @@
 import type { IAuth0Client } from './core/interfaces/IAuth0Client';
+import type { IMfaClient } from './core/interfaces/IMfaClient';
 import type { TokenType } from './types/common';
 import { Auth0ClientFactory } from './factory/Auth0ClientFactory';
 import type {
@@ -157,6 +158,25 @@ class Auth0 {
     parameters: CustomTokenExchangeParameters
   ): Promise<Credentials> {
     return this.client.customTokenExchange(parameters);
+  }
+
+  /**
+   * Provides access to MFA operations using the Flexible Factors Grant.
+   *
+   * The MFA client provides methods to list authenticators, enroll new MFA
+   * factors, challenge existing factors, and verify MFA codes.
+   *
+   * @example
+   * ```typescript
+   * // List enrolled authenticators
+   * const authenticators = await auth0.mfa.getAuthenticators({ mfaToken });
+   *
+   * // Verify with OTP
+   * const credentials = await auth0.mfa.verify({ mfaToken, otp: '123456' });
+   * ```
+   */
+  get mfa(): IMfaClient {
+    return this.client.mfa;
   }
 
   /**

--- a/src/core/interfaces/IAuth0Client.ts
+++ b/src/core/interfaces/IAuth0Client.ts
@@ -4,6 +4,7 @@ import type { IAuthenticationProvider } from './IAuthenticationProvider';
 import type { IMyAccountClient } from './IMyAccountClient';
 import type { IPasswordlessClient } from './IPasswordlessClient';
 import type { IUsersClient } from './IUsersClient';
+import type { IMfaClient } from './IMfaClient';
 import type {
   DPoPHeadersParams,
   TokenType,
@@ -92,6 +93,26 @@ export interface IAuth0Client {
   customTokenExchange(
     parameters: CustomTokenExchangeParameters
   ): Promise<Credentials>;
+
+  /**
+   * Provides access to MFA operations using the Flexible Factors Grant.
+   *
+   * The MFA client provides methods to list authenticators, enroll new MFA
+   * factors, challenge existing factors, and verify MFA codes.
+   *
+   * @example
+   * ```typescript
+   * // List enrolled authenticators
+   * const authenticators = await auth0.mfa.getAuthenticators({ mfaToken });
+   *
+   * // Challenge an authenticator
+   * const challenge = await auth0.mfa.challenge({ mfaToken, authenticatorId });
+   *
+   * // Verify with OTP
+   * const credentials = await auth0.mfa.verify({ mfaToken, otp: '123456' });
+   * ```
+   */
+  readonly mfa: IMfaClient;
 
   /**
    * Requests a passkey signup challenge from Auth0.

--- a/src/core/interfaces/IMfaClient.ts
+++ b/src/core/interfaces/IMfaClient.ts
@@ -1,0 +1,55 @@
+import type {
+  Credentials,
+  MfaAuthenticator,
+  MfaEnrollmentChallenge,
+  MfaChallengeResult,
+  MfaGetAuthenticatorsParameters,
+  MfaEnrollParameters,
+  MfaChallengeWithAuthenticatorParameters,
+  MfaVerifyParameters,
+} from '../../types';
+
+/**
+ * Defines the contract for MFA operations using the Flexible Factors Grant.
+ *
+ * An MFA client is scoped to a single MFA flow, initialized with an mfaToken
+ * from an MFA_REQUIRED error. It provides methods to list authenticators,
+ * enroll new factors, challenge existing factors, and verify MFA codes.
+ */
+export interface IMfaClient {
+  /**
+   * Lists the user's enrolled MFA authenticators.
+   *
+   * @param parameters Parameters including the MFA token and optional factor filter.
+   * @returns A promise that resolves with the list of enrolled authenticators.
+   */
+  getAuthenticators(
+    parameters: MfaGetAuthenticatorsParameters
+  ): Promise<MfaAuthenticator[]>;
+
+  /**
+   * Enrolls a new MFA factor for the user.
+   *
+   * @param parameters Parameters specifying the factor type and any required values.
+   * @returns A promise that resolves with the enrollment challenge details.
+   */
+  enroll(parameters: MfaEnrollParameters): Promise<MfaEnrollmentChallenge>;
+
+  /**
+   * Requests an MFA challenge for a specific enrolled authenticator.
+   *
+   * @param parameters Parameters including the MFA token and authenticator ID.
+   * @returns A promise that resolves with the challenge details.
+   */
+  challenge(
+    parameters: MfaChallengeWithAuthenticatorParameters
+  ): Promise<MfaChallengeResult>;
+
+  /**
+   * Verifies an MFA code and returns credentials on success.
+   *
+   * @param parameters Parameters for verification (OTP, OOB, or recovery code).
+   * @returns A promise that resolves with the user's credentials.
+   */
+  verify(parameters: MfaVerifyParameters): Promise<Credentials>;
+}

--- a/src/core/interfaces/index.ts
+++ b/src/core/interfaces/index.ts
@@ -6,3 +6,4 @@ export * from './IMyAccountClient';
 export * from './IPasswordlessClient';
 export * from './IWebAuthProvider';
 export * from './IUsersClient';
+export * from './IMfaClient';

--- a/src/core/models/MfaError.ts
+++ b/src/core/models/MfaError.ts
@@ -1,0 +1,160 @@
+import { AuthError } from './AuthError';
+
+/**
+ * Platform-agnostic error code constants for MFA (Multi-Factor Authentication) operations.
+ *
+ * Use these constants for type-safe error handling when working with MFA operations
+ * like getAuthenticators, enroll, challenge, and verify.
+ * Each constant corresponds to a specific error type in the {@link MfaError.type} property.
+ *
+ * @example
+ * ```typescript
+ * import { MfaError, MfaErrorCodes } from 'react-native-auth0';
+ *
+ * try {
+ *   const credentials = await auth0.mfa.verify({ mfaToken, otp: '123456' });
+ * } catch (e) {
+ *   if (e instanceof MfaError) {
+ *     switch (e.type) {
+ *       case MfaErrorCodes.INVALID_OTP:
+ *         // OTP code is incorrect
+ *         break;
+ *       case MfaErrorCodes.EXPIRED_MFA_TOKEN:
+ *         // MFA token has expired - restart MFA flow
+ *         break;
+ *       case MfaErrorCodes.TOO_MANY_ATTEMPTS:
+ *         // Rate limited - wait before retrying
+ *         break;
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @see {@link MfaError}
+ */
+export const MfaErrorCodes = {
+  /** OTP code provided is invalid */
+  INVALID_OTP: 'INVALID_OTP',
+  /** OOB code provided is invalid */
+  INVALID_OOB_CODE: 'INVALID_OOB_CODE',
+  /** Binding code provided is invalid */
+  INVALID_BINDING_CODE: 'INVALID_BINDING_CODE',
+  /** Recovery code provided is invalid */
+  INVALID_RECOVERY_CODE: 'INVALID_RECOVERY_CODE',
+  /** MFA enrollment failed */
+  ENROLLMENT_FAILED: 'ENROLLMENT_FAILED',
+  /** Phone number provided is invalid for enrollment */
+  INVALID_PHONE_NUMBER: 'INVALID_PHONE_NUMBER',
+  /** Email provided is invalid for enrollment */
+  INVALID_EMAIL: 'INVALID_EMAIL',
+  /** MFA token has expired - restart MFA flow */
+  EXPIRED_MFA_TOKEN: 'EXPIRED_MFA_TOKEN',
+  /** MFA token is invalid */
+  INVALID_MFA_TOKEN: 'INVALID_MFA_TOKEN',
+  /** Too many verification attempts - rate limited */
+  TOO_MANY_ATTEMPTS: 'TOO_MANY_ATTEMPTS',
+  /** MFA challenge request failed */
+  CHALLENGE_FAILED: 'CHALLENGE_FAILED',
+  /** Authenticator not found or not enrolled */
+  AUTHENTICATOR_NOT_FOUND: 'AUTHENTICATOR_NOT_FOUND',
+  /** MFA factor type is not supported */
+  UNSUPPORTED_FACTOR: 'UNSUPPORTED_FACTOR',
+  /** User must enroll before using the authenticator */
+  ASSOCIATION_REQUIRED: 'ASSOCIATION_REQUIRED',
+  /** Generic MFA error */
+  MFA_ERROR: 'MFA_ERROR',
+  /** Unknown or uncategorized MFA error */
+  UNKNOWN_MFA_ERROR: 'UNKNOWN_MFA_ERROR',
+} as const;
+
+const ERROR_CODE_MAP: Record<string, string> = {
+  // --- Auth0 API error codes (returned by both native SDKs and web) ---
+  invalid_otp: MfaErrorCodes.INVALID_OTP,
+  invalid_oob_code: MfaErrorCodes.INVALID_OOB_CODE,
+  invalid_binding_code: MfaErrorCodes.INVALID_BINDING_CODE,
+  invalid_recovery_code: MfaErrorCodes.INVALID_RECOVERY_CODE,
+  // invalid_grant is returned by the /oauth/token MFA grants for any rejected
+  // code (wrong otp, oob, or recovery), so it cannot be narrowed to INVALID_OTP.
+  // Keep it generic and let callers inspect the originating verify call.
+  invalid_grant: MfaErrorCodes.MFA_ERROR,
+  mfa_token_invalid: MfaErrorCodes.INVALID_MFA_TOKEN,
+  expired_token: MfaErrorCodes.EXPIRED_MFA_TOKEN,
+  too_many_attempts: MfaErrorCodes.TOO_MANY_ATTEMPTS,
+  unsupported_challenge_type: MfaErrorCodes.UNSUPPORTED_FACTOR,
+  association_required: MfaErrorCodes.ASSOCIATION_REQUIRED,
+  invalid_phone_number: MfaErrorCodes.INVALID_PHONE_NUMBER,
+  invalid_email: MfaErrorCodes.INVALID_EMAIL,
+
+  // --- Native bridge local validation errors ---
+  MFA_ENROLLMENT_ERROR: MfaErrorCodes.ENROLLMENT_FAILED,
+  MFA_VERIFY_ERROR: MfaErrorCodes.MFA_ERROR,
+  MFA_CHALLENGE_ERROR: MfaErrorCodes.CHALLENGE_FAILED,
+
+  // --- Web (spa-js) error codes ---
+  mfa_enrollment_failed: MfaErrorCodes.ENROLLMENT_FAILED,
+  mfa_list_authenticators_failed: MfaErrorCodes.MFA_ERROR,
+  mfa_challenge_failed: MfaErrorCodes.CHALLENGE_FAILED,
+  mfa_verify_failed: MfaErrorCodes.MFA_ERROR,
+  // spa-js raises mfa_context_not_found when no stored MFA context matches the
+  // supplied mfaToken (unknown/stale token); treat it as an invalid MFA token.
+  mfa_context_not_found: MfaErrorCodes.INVALID_MFA_TOKEN,
+  invalid_request: MfaErrorCodes.MFA_ERROR,
+
+  // --- Generic fallbacks ---
+  UNKNOWN: MfaErrorCodes.UNKNOWN_MFA_ERROR,
+  OTHER: MfaErrorCodes.UNKNOWN_MFA_ERROR,
+};
+
+/**
+ * Represents an error that occurred during MFA (Multi-Factor Authentication) operations.
+ *
+ * This class wraps authentication errors related to MFA functionality, including:
+ * - Listing enrolled authenticators
+ * - Enrolling new MFA factors (OTP, SMS, email, push)
+ * - Requesting MFA challenges
+ * - Verifying MFA codes (OTP, OOB, recovery codes)
+ *
+ * The `type` property provides a normalized, platform-agnostic error code that
+ * applications can use for consistent error handling across iOS, Android, and Web.
+ *
+ * @example
+ * ```typescript
+ * import { MfaError, MfaErrorCodes } from 'react-native-auth0';
+ *
+ * try {
+ *   const credentials = await auth0.mfa.verify({ mfaToken, otp: '123456' });
+ * } catch (error) {
+ *   if (error instanceof MfaError) {
+ *     switch (error.type) {
+ *       case MfaErrorCodes.INVALID_OTP:
+ *         // Show "incorrect code" message
+ *         break;
+ *       case MfaErrorCodes.EXPIRED_MFA_TOKEN:
+ *         // Restart MFA flow
+ *         break;
+ *       case MfaErrorCodes.TOO_MANY_ATTEMPTS:
+ *         // Show rate limit message
+ *         break;
+ *     }
+ *   }
+ * }
+ * ```
+ */
+export class MfaError extends AuthError {
+  /**
+   * A normalized error type that is consistent across platforms.
+   * This can be used for reliable error handling in application code.
+   */
+  public readonly type: string;
+
+  constructor(originalError: AuthError) {
+    super(originalError.name, originalError.message, {
+      status: originalError.status,
+      code: originalError.code,
+      json: originalError.json,
+    });
+
+    this.type =
+      ERROR_CODE_MAP[originalError.code] || MfaErrorCodes.UNKNOWN_MFA_ERROR;
+  }
+}

--- a/src/core/models/__tests__/ErrorCodes.spec.ts
+++ b/src/core/models/__tests__/ErrorCodes.spec.ts
@@ -2,6 +2,7 @@ import {
   WebAuthErrorCodes,
   CredentialsManagerErrorCodes,
   DPoPErrorCodes,
+  MfaErrorCodes,
 } from '../';
 
 describe('Error Code Constants', () => {
@@ -245,6 +246,27 @@ describe('Error Code Constants', () => {
       // No overlaps expected
       expect(webAuthOverlaps).toEqual([]);
       expect(credentialsOverlaps).toEqual([]);
+    });
+
+    it('should not have overlapping error codes between MFA and other error types', () => {
+      const mfaArray = Object.values(MfaErrorCodes);
+      const webAuthArray = Object.values(WebAuthErrorCodes);
+      const credentialsArray = Object.values(CredentialsManagerErrorCodes);
+      const dpopArray = Object.values(DPoPErrorCodes);
+
+      const webAuthOverlaps = mfaArray.filter((code) =>
+        webAuthArray.includes(code as any)
+      );
+      const credentialsOverlaps = mfaArray.filter((code) =>
+        credentialsArray.includes(code as any)
+      );
+      const dpopOverlaps = mfaArray.filter((code) =>
+        dpopArray.includes(code as any)
+      );
+
+      expect(webAuthOverlaps).toEqual([]);
+      expect(credentialsOverlaps).toEqual([]);
+      expect(dpopOverlaps).toEqual([]);
     });
   });
 

--- a/src/core/models/__tests__/MfaError.spec.ts
+++ b/src/core/models/__tests__/MfaError.spec.ts
@@ -1,0 +1,137 @@
+import { AuthError, MfaError, MfaErrorCodes } from '../';
+
+describe('MfaError', () => {
+  it('should be an instance of AuthError', () => {
+    const original = new AuthError('invalid_otp', 'Invalid OTP code', {
+      code: 'invalid_otp',
+      status: 403,
+    });
+    const error = new MfaError(original);
+    expect(error).toBeInstanceOf(AuthError);
+    expect(error).toBeInstanceOf(MfaError);
+  });
+
+  it('should preserve the original error properties', () => {
+    const original = new AuthError('invalid_otp', 'Invalid OTP code', {
+      code: 'invalid_otp',
+      status: 403,
+      json: { error: 'invalid_otp' },
+    });
+    const error = new MfaError(original);
+
+    expect(error.name).toBe('invalid_otp');
+    expect(error.message).toBe('Invalid OTP code');
+    expect(error.code).toBe('invalid_otp');
+    expect(error.status).toBe(403);
+    expect(error.json).toEqual({ error: 'invalid_otp' });
+  });
+
+  describe('error code mapping', () => {
+    const testCases: [string, string, string][] = [
+      ['invalid_otp', 'INVALID_OTP', 'Auth0 API OTP error'],
+      ['invalid_oob_code', 'INVALID_OOB_CODE', 'Auth0 API OOB error'],
+      [
+        'invalid_binding_code',
+        'INVALID_BINDING_CODE',
+        'Auth0 API binding code error',
+      ],
+      [
+        'invalid_recovery_code',
+        'INVALID_RECOVERY_CODE',
+        'Auth0 API recovery code error',
+      ],
+      [
+        'invalid_grant',
+        'MFA_ERROR',
+        'Auth0 API generic grant error for MFA (ambiguous across otp/oob/recovery)',
+      ],
+      ['mfa_token_invalid', 'INVALID_MFA_TOKEN', 'invalid MFA token'],
+      ['expired_token', 'EXPIRED_MFA_TOKEN', 'expired MFA token'],
+      ['too_many_attempts', 'TOO_MANY_ATTEMPTS', 'rate limit'],
+      [
+        'unsupported_challenge_type',
+        'UNSUPPORTED_FACTOR',
+        'unsupported factor',
+      ],
+      ['association_required', 'ASSOCIATION_REQUIRED', 'association required'],
+      ['invalid_phone_number', 'INVALID_PHONE_NUMBER', 'invalid phone'],
+      ['invalid_email', 'INVALID_EMAIL', 'invalid email'],
+      ['MFA_ENROLLMENT_ERROR', 'ENROLLMENT_FAILED', 'native enrollment error'],
+      ['MFA_VERIFY_ERROR', 'MFA_ERROR', 'native verify error'],
+      ['MFA_CHALLENGE_ERROR', 'CHALLENGE_FAILED', 'native challenge error'],
+      ['mfa_enrollment_failed', 'ENROLLMENT_FAILED', 'web enrollment error'],
+      ['mfa_list_authenticators_failed', 'MFA_ERROR', 'web list error'],
+      ['mfa_challenge_failed', 'CHALLENGE_FAILED', 'web challenge error'],
+      ['mfa_verify_failed', 'MFA_ERROR', 'web verify error'],
+      [
+        'mfa_context_not_found',
+        'INVALID_MFA_TOKEN',
+        'spa-js stale/unknown MFA token',
+      ],
+      ['invalid_request', 'MFA_ERROR', 'spa-js invalid request'],
+    ];
+
+    it.each(testCases)(
+      'should map code "%s" to type "%s" (%s)',
+      (code, expectedType) => {
+        const original = new AuthError('error', 'message', { code });
+        const error = new MfaError(original);
+        expect(error.type).toBe(expectedType);
+      }
+    );
+
+    it('should fall back to UNKNOWN_MFA_ERROR for unmapped codes', () => {
+      const original = new AuthError('some_error', 'Something', {
+        code: 'completely_unknown_code',
+      });
+      const error = new MfaError(original);
+      expect(error.type).toBe(MfaErrorCodes.UNKNOWN_MFA_ERROR);
+    });
+  });
+});
+
+describe('MfaErrorCodes', () => {
+  it('should export all expected error code constants', () => {
+    expect(MfaErrorCodes.INVALID_OTP).toBe('INVALID_OTP');
+    expect(MfaErrorCodes.INVALID_OOB_CODE).toBe('INVALID_OOB_CODE');
+    expect(MfaErrorCodes.INVALID_BINDING_CODE).toBe('INVALID_BINDING_CODE');
+    expect(MfaErrorCodes.INVALID_RECOVERY_CODE).toBe('INVALID_RECOVERY_CODE');
+    expect(MfaErrorCodes.ENROLLMENT_FAILED).toBe('ENROLLMENT_FAILED');
+    expect(MfaErrorCodes.INVALID_PHONE_NUMBER).toBe('INVALID_PHONE_NUMBER');
+    expect(MfaErrorCodes.INVALID_EMAIL).toBe('INVALID_EMAIL');
+    expect(MfaErrorCodes.EXPIRED_MFA_TOKEN).toBe('EXPIRED_MFA_TOKEN');
+    expect(MfaErrorCodes.INVALID_MFA_TOKEN).toBe('INVALID_MFA_TOKEN');
+    expect(MfaErrorCodes.TOO_MANY_ATTEMPTS).toBe('TOO_MANY_ATTEMPTS');
+    expect(MfaErrorCodes.CHALLENGE_FAILED).toBe('CHALLENGE_FAILED');
+    expect(MfaErrorCodes.AUTHENTICATOR_NOT_FOUND).toBe(
+      'AUTHENTICATOR_NOT_FOUND'
+    );
+    expect(MfaErrorCodes.UNSUPPORTED_FACTOR).toBe('UNSUPPORTED_FACTOR');
+    expect(MfaErrorCodes.ASSOCIATION_REQUIRED).toBe('ASSOCIATION_REQUIRED');
+    expect(MfaErrorCodes.MFA_ERROR).toBe('MFA_ERROR');
+    expect(MfaErrorCodes.UNKNOWN_MFA_ERROR).toBe('UNKNOWN_MFA_ERROR');
+  });
+
+  it('should have exactly 16 error codes', () => {
+    const keys = Object.keys(MfaErrorCodes);
+    expect(keys).toHaveLength(16);
+  });
+
+  it('should be usable in switch statements', () => {
+    const testErrorType = 'INVALID_OTP';
+    let result = '';
+
+    switch (testErrorType) {
+      case MfaErrorCodes.INVALID_OTP:
+        result = 'invalid_otp';
+        break;
+      case MfaErrorCodes.EXPIRED_MFA_TOKEN:
+        result = 'expired';
+        break;
+      default:
+        result = 'unknown';
+    }
+
+    expect(result).toBe('invalid_otp');
+  });
+});

--- a/src/core/models/index.ts
+++ b/src/core/models/index.ts
@@ -9,5 +9,6 @@ export {
 } from './CredentialsManagerError';
 export { WebAuthError, WebAuthErrorCodes } from './WebAuthError';
 export { DPoPError, DPoPErrorCodes } from './DPoPError';
+export { MfaError, MfaErrorCodes } from './MfaError';
 export { PasskeyError, PasskeyErrorCodes } from './PasskeyError';
 export { MyAccountError } from './MyAccountError';

--- a/src/hooks/Auth0Context.ts
+++ b/src/hooks/Auth0Context.ts
@@ -28,6 +28,7 @@ import type {
   DPoPHeadersParams,
   SessionTransferCredentials,
 } from '../types';
+import type { IMfaClient } from '../core/interfaces/IMfaClient';
 import type { IMyAccountClient } from '../core/interfaces';
 import type {
   PasswordlessChallenge,
@@ -467,6 +468,27 @@ export interface Auth0ContextInterface extends AuthState {
   ) => Promise<SessionTransferCredentials>;
 
   /**
+   * Provides access to MFA operations using the Flexible Factors Grant.
+   *
+   * The MFA client provides methods to list authenticators, enroll new MFA
+   * factors, challenge existing factors, and verify MFA codes.
+   *
+   * On successful verification via `mfa.verify()`, the user state is updated automatically.
+   *
+   * @example
+   * ```typescript
+   * const { mfa } = useAuth0();
+   *
+   * // List enrolled authenticators
+   * const authenticators = await mfa.getAuthenticators({ mfaToken });
+   *
+   * // Verify with OTP
+   * const credentials = await mfa.verify({ mfaToken, otp: '123456' });
+   * ```
+   */
+  mfa: IMfaClient;
+
+  /**
    * Exchanges a refresh token for session transfer credentials via the Authentication API.
    *
    * @remarks
@@ -550,6 +572,12 @@ const initialContext: Auth0ContextInterface = {
   getDPoPHeaders: stub,
   getSSOCredentials: stub,
   ssoExchange: stub,
+  mfa: {
+    getAuthenticators: stub,
+    enroll: stub,
+    challenge: stub,
+    verify: stub,
+  },
 };
 
 export const Auth0Context =

--- a/src/hooks/Auth0Provider.tsx
+++ b/src/hooks/Auth0Provider.tsx
@@ -36,6 +36,7 @@ import type {
   PasswordlessChallengePhoneParameters,
   PasswordlessLoginOtpParameters,
 } from '../types';
+import type { IMfaClient } from '../core/interfaces/IMfaClient';
 import type {
   NativeAuthorizeOptions,
   NativeClearSessionOptions,
@@ -492,6 +493,52 @@ export const Auth0Provider = ({
     [client]
   );
 
+  const mfa = useMemo<IMfaClient>(() => {
+    const mfaClient = client.mfa;
+    return {
+      getAuthenticators: async (parameters) => {
+        try {
+          return await mfaClient.getAuthenticators(parameters);
+        } catch (e) {
+          const error = e as AuthError;
+          dispatch({ type: 'ERROR', error });
+          throw error;
+        }
+      },
+      enroll: async (parameters) => {
+        try {
+          return await mfaClient.enroll(parameters);
+        } catch (e) {
+          const error = e as AuthError;
+          dispatch({ type: 'ERROR', error });
+          throw error;
+        }
+      },
+      challenge: async (parameters) => {
+        try {
+          return await mfaClient.challenge(parameters);
+        } catch (e) {
+          const error = e as AuthError;
+          dispatch({ type: 'ERROR', error });
+          throw error;
+        }
+      },
+      verify: async (parameters) => {
+        try {
+          const credentials = await mfaClient.verify(parameters);
+          const user = Auth0User.fromIdToken(credentials.idToken);
+          await client.credentialsManager.saveCredentials(credentials);
+          dispatch({ type: 'LOGIN_COMPLETE', user });
+          return credentials;
+        } catch (e) {
+          const error = e as AuthError;
+          dispatch({ type: 'ERROR', error });
+          throw error;
+        }
+      },
+    };
+  }, [client]);
+
   const contextValue = useMemo<Auth0ContextInterface>(
     () => ({
       ...state,
@@ -528,6 +575,7 @@ export const Auth0Provider = ({
       revokeRefreshToken,
       getDPoPHeaders,
       ssoExchange,
+      mfa,
     }),
     [
       state,
@@ -564,6 +612,7 @@ export const Auth0Provider = ({
       revokeRefreshToken,
       getDPoPHeaders,
       ssoExchange,
+      mfa,
     ]
   );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,13 +6,15 @@ export {
   WebAuthErrorCodes,
   DPoPError,
   DPoPErrorCodes,
+  MfaError,
+  MfaErrorCodes,
   PasskeyError,
   PasskeyErrorCodes,
   MyAccountError,
 } from './core/models';
 export { TimeoutError } from './core/utils/fetchWithTimeout';
 export { parseIdToken } from './core/utils';
-export { TokenType } from './types/common';
+export { TokenType, MfaFactorType } from './types/common';
 export { Auth0Provider } from './hooks/Auth0Provider';
 export { useAuth0 } from './hooks/useAuth0';
 export * from './types';
@@ -22,6 +24,7 @@ export {
   LocalAuthenticationStrategy,
 } from './types/platform-specific';
 export type { LocalAuthenticationOptions } from './types/platform-specific';
+export type { IMfaClient } from './core/interfaces/IMfaClient';
 
 // Re-export Auth0 as default
 export { default } from './Auth0';

--- a/src/platforms/native/adapters/NativeAuth0Client.ts
+++ b/src/platforms/native/adapters/NativeAuth0Client.ts
@@ -4,6 +4,7 @@ import type {
   IMyAccountClient,
   IPasswordlessClient,
   IUsersClient,
+  IMfaClient,
 } from '../../../core/interfaces';
 import type { NativeAuth0Options } from '../../../types/platform-specific';
 import type {
@@ -17,6 +18,7 @@ import type {
 } from '../../../types';
 import { NativeWebAuthProvider } from './NativeWebAuthProvider';
 import { NativeCredentialsManager } from './NativeCredentialsManager';
+import { NativeMfaClient } from './NativeMfaClient';
 import { NativeMyAccountClient } from './NativeMyAccountClient';
 import { NativePasswordlessClient } from './NativePasswordlessClient';
 import { type INativeBridge, NativeBridgeManager } from '../bridge';
@@ -33,6 +35,7 @@ export class NativeAuth0Client implements IAuth0Client {
   readonly webAuth: NativeWebAuthProvider;
   readonly credentialsManager: NativeCredentialsManager;
   readonly auth: IAuthenticationProvider;
+  readonly mfa: IMfaClient;
   readonly passwordless: IPasswordlessClient;
   private ready: Promise<void>;
   private readonly httpClient: HttpClient;
@@ -96,6 +99,7 @@ export class NativeAuth0Client implements IAuth0Client {
 
     this.webAuth = new NativeWebAuthProvider(guardedBridge, options.domain);
     this.credentialsManager = new NativeCredentialsManager(guardedBridge);
+    this.mfa = new NativeMfaClient(guardedBridge);
     this.myAccount = new NativeMyAccountClient(guardedBridge);
     this.passwordless = new NativePasswordlessClient(guardedBridge);
   }

--- a/src/platforms/native/adapters/NativeMfaClient.ts
+++ b/src/platforms/native/adapters/NativeMfaClient.ts
@@ -1,0 +1,116 @@
+import type { IMfaClient } from '../../../core/interfaces';
+import type { INativeBridge } from '../bridge';
+import type {
+  Credentials,
+  MfaAuthenticator,
+  MfaEnrollmentChallenge,
+  MfaChallengeResult,
+  MfaGetAuthenticatorsParameters,
+  MfaEnrollParameters,
+  MfaEnrollSmsParameters,
+  MfaEnrollVoiceParameters,
+  MfaEnrollEmailParameters,
+  MfaChallengeWithAuthenticatorParameters,
+  MfaVerifyParameters,
+  MfaVerifyOtpParameters,
+  MfaVerifyOobParameters,
+  MfaVerifyRecoveryCodeParameters,
+} from '../../../types';
+import { AuthError, MfaError } from '../../../core/models';
+
+export class NativeMfaClient implements IMfaClient {
+  private readonly bridge: INativeBridge;
+
+  constructor(bridge: INativeBridge) {
+    this.bridge = bridge;
+  }
+
+  async getAuthenticators(
+    parameters: MfaGetAuthenticatorsParameters
+  ): Promise<MfaAuthenticator[]> {
+    try {
+      return await this.bridge.getMfaAuthenticators(
+        parameters.mfaToken,
+        parameters.factorsAllowed
+      );
+    } catch (e) {
+      throw e instanceof AuthError ? new MfaError(e) : e;
+    }
+  }
+
+  async enroll(
+    parameters: MfaEnrollParameters
+  ): Promise<MfaEnrollmentChallenge> {
+    const { mfaToken, factorType } = parameters;
+    let type: string = factorType;
+    let value: string | undefined;
+
+    if (factorType === 'sms' || factorType === 'voice') {
+      type = factorType === 'sms' ? 'phone' : 'voice';
+      value = (parameters as MfaEnrollSmsParameters | MfaEnrollVoiceParameters)
+        .phoneNumber;
+    } else if (factorType === 'email') {
+      value = (parameters as MfaEnrollEmailParameters).email;
+    }
+
+    try {
+      return await this.bridge.mfaEnroll(mfaToken, type, value);
+    } catch (e) {
+      throw e instanceof AuthError ? new MfaError(e) : e;
+    }
+  }
+
+  async challenge(
+    parameters: MfaChallengeWithAuthenticatorParameters
+  ): Promise<MfaChallengeResult> {
+    try {
+      return await this.bridge.mfaChallenge(
+        parameters.mfaToken,
+        parameters.authenticatorId
+      );
+    } catch (e) {
+      throw e instanceof AuthError ? new MfaError(e) : e;
+    }
+  }
+
+  async verify(parameters: MfaVerifyParameters): Promise<Credentials> {
+    const { mfaToken, scope, audience } = parameters;
+
+    try {
+      if ('otp' in parameters) {
+        return await this.bridge.mfaVerify(
+          mfaToken,
+          'otp',
+          (parameters as MfaVerifyOtpParameters).otp,
+          undefined,
+          scope,
+          audience
+        );
+      }
+
+      if ('oobCode' in parameters) {
+        const oobParams = parameters as MfaVerifyOobParameters;
+        return await this.bridge.mfaVerify(
+          mfaToken,
+          'oob',
+          oobParams.oobCode,
+          oobParams.bindingCode,
+          scope,
+          audience
+        );
+      }
+
+      const recoveryParams = parameters as MfaVerifyRecoveryCodeParameters;
+      return await this.bridge.mfaVerify(
+        mfaToken,
+        'recoveryCode',
+        recoveryParams.recoveryCode,
+        undefined,
+        scope,
+        audience
+      );
+    } catch (e) {
+      throw e instanceof AuthError ? new MfaError(e) : e;
+    }
+  }
+}

--- a/src/platforms/native/adapters/__tests__/NativeMfaClient.spec.ts
+++ b/src/platforms/native/adapters/__tests__/NativeMfaClient.spec.ts
@@ -1,0 +1,406 @@
+import { NativeMfaClient } from '../NativeMfaClient';
+import type { INativeBridge } from '../../bridge';
+import { AuthError, MfaError, MfaErrorCodes } from '../../../../core/models';
+
+const mockBridge: jest.Mocked<INativeBridge> = {
+  getMfaAuthenticators: jest.fn(),
+  mfaEnroll: jest.fn(),
+  mfaChallenge: jest.fn(),
+  mfaVerify: jest.fn(),
+  initialize: jest.fn(),
+  hasValidInstance: jest.fn(),
+  getBundleIdentifier: jest.fn(),
+  authorize: jest.fn(),
+  clearSession: jest.fn(),
+  cancelWebAuth: jest.fn(),
+  saveCredentials: jest.fn(),
+  getCredentials: jest.fn(),
+  hasValidCredentials: jest.fn(),
+  clearCredentials: jest.fn(),
+  resumeWebAuth: jest.fn(),
+  getDPoPHeaders: jest.fn(),
+  clearDPoPKey: jest.fn(),
+  getSSOCredentials: jest.fn(),
+  getApiCredentials: jest.fn(),
+  clearApiCredentials: jest.fn(),
+  customTokenExchange: jest.fn(),
+};
+
+describe('NativeMfaClient', () => {
+  let client: NativeMfaClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new NativeMfaClient(mockBridge);
+  });
+
+  describe('getAuthenticators', () => {
+    it('should call bridge with mfaToken and factorsAllowed', async () => {
+      const authenticators = [
+        {
+          id: 'sms|dev_123',
+          authenticatorType: 'oob',
+          active: true,
+          oobChannel: 'sms',
+        },
+      ];
+      mockBridge.getMfaAuthenticators.mockResolvedValueOnce(authenticators);
+
+      const result = await client.getAuthenticators({
+        mfaToken: 'mfa_token_123',
+        factorsAllowed: ['otp', 'oob'],
+      });
+
+      expect(mockBridge.getMfaAuthenticators).toHaveBeenCalledWith(
+        'mfa_token_123',
+        ['otp', 'oob']
+      );
+      expect(result).toEqual(authenticators);
+    });
+
+    it('should call bridge with undefined factorsAllowed when not provided', async () => {
+      mockBridge.getMfaAuthenticators.mockResolvedValueOnce([]);
+
+      await client.getAuthenticators({ mfaToken: 'mfa_token_123' });
+
+      expect(mockBridge.getMfaAuthenticators).toHaveBeenCalledWith(
+        'mfa_token_123',
+        undefined
+      );
+    });
+
+    it('should wrap AuthError in MfaError', async () => {
+      const authError = new AuthError('invalid_grant', 'Token expired', {
+        code: 'expired_token',
+      });
+      mockBridge.getMfaAuthenticators.mockRejectedValueOnce(authError);
+
+      await expect(
+        client.getAuthenticators({ mfaToken: 'mfa_token_123' })
+      ).rejects.toThrow(MfaError);
+
+      try {
+        await client.getAuthenticators({ mfaToken: 'mfa_token_123' });
+      } catch {
+        // Re-mock since first call consumed it
+      }
+      // Use a fresh mock to verify type
+      mockBridge.getMfaAuthenticators.mockRejectedValueOnce(authError);
+      try {
+        await client.getAuthenticators({ mfaToken: 'mfa_token_123' });
+      } catch (e) {
+        expect(e).toBeInstanceOf(MfaError);
+        expect((e as MfaError).type).toBe(MfaErrorCodes.EXPIRED_MFA_TOKEN);
+      }
+    });
+
+    it('should rethrow non-AuthError errors as-is', async () => {
+      const error = new Error('Network error');
+      mockBridge.getMfaAuthenticators.mockRejectedValueOnce(error);
+
+      await expect(
+        client.getAuthenticators({ mfaToken: 'mfa_token_123' })
+      ).rejects.toThrow(error);
+    });
+  });
+
+  describe('enroll', () => {
+    it('should enroll sms factor with phoneNumber', async () => {
+      const challenge = { type: 'oob' as const, oobCode: 'oob_123' };
+      mockBridge.mfaEnroll.mockResolvedValueOnce(challenge);
+
+      const result = await client.enroll({
+        mfaToken: 'mfa_token_123',
+        factorType: 'sms',
+        phoneNumber: '+12025550135',
+      });
+
+      expect(mockBridge.mfaEnroll).toHaveBeenCalledWith(
+        'mfa_token_123',
+        'phone',
+        '+12025550135'
+      );
+      expect(result).toEqual(challenge);
+    });
+
+    it('should enroll voice factor with phoneNumber', async () => {
+      const challenge = { type: 'oob' as const, oobCode: 'oob_voice' };
+      mockBridge.mfaEnroll.mockResolvedValueOnce(challenge);
+
+      const result = await client.enroll({
+        mfaToken: 'mfa_token_123',
+        factorType: 'voice',
+        phoneNumber: '+12025550135',
+      });
+
+      expect(mockBridge.mfaEnroll).toHaveBeenCalledWith(
+        'mfa_token_123',
+        'voice',
+        '+12025550135'
+      );
+      expect(result).toEqual(challenge);
+    });
+
+    it('should enroll email factor with email', async () => {
+      const challenge = { type: 'oob' as const, oobCode: 'oob_456' };
+      mockBridge.mfaEnroll.mockResolvedValueOnce(challenge);
+
+      const result = await client.enroll({
+        mfaToken: 'mfa_token_123',
+        factorType: 'email',
+        email: 'user@example.com',
+      });
+
+      expect(mockBridge.mfaEnroll).toHaveBeenCalledWith(
+        'mfa_token_123',
+        'email',
+        'user@example.com'
+      );
+      expect(result).toEqual(challenge);
+    });
+
+    it('should enroll otp factor', async () => {
+      const challenge = {
+        type: 'totp' as const,
+        barcodeUri: 'otpauth://totp/...',
+        secret: 'JBSWY3DPEHPK3PXP',
+      };
+      mockBridge.mfaEnroll.mockResolvedValueOnce(challenge);
+
+      const result = await client.enroll({
+        mfaToken: 'mfa_token_123',
+        factorType: 'otp',
+      });
+
+      expect(mockBridge.mfaEnroll).toHaveBeenCalledWith(
+        'mfa_token_123',
+        'otp',
+        undefined
+      );
+      expect(result).toEqual(challenge);
+    });
+
+    it('should enroll push factor', async () => {
+      const challenge = { type: 'oob' as const, oobCode: 'oob_789' };
+      mockBridge.mfaEnroll.mockResolvedValueOnce(challenge);
+
+      const result = await client.enroll({
+        mfaToken: 'mfa_token_123',
+        factorType: 'push',
+      });
+
+      expect(mockBridge.mfaEnroll).toHaveBeenCalledWith(
+        'mfa_token_123',
+        'push',
+        undefined
+      );
+      expect(result).toEqual(challenge);
+    });
+
+    it('should wrap AuthError in MfaError', async () => {
+      const authError = new AuthError('enrollment_error', 'Enrollment failed', {
+        code: 'MFA_ENROLLMENT_ERROR',
+      });
+      mockBridge.mfaEnroll.mockRejectedValueOnce(authError);
+
+      try {
+        await client.enroll({ mfaToken: 'mfa_token_123', factorType: 'otp' });
+        fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(MfaError);
+        expect((e as MfaError).type).toBe(MfaErrorCodes.ENROLLMENT_FAILED);
+      }
+    });
+
+    it('should rethrow non-AuthError errors as-is', async () => {
+      const error = new Error('Enrollment failed');
+      mockBridge.mfaEnroll.mockRejectedValueOnce(error);
+
+      await expect(
+        client.enroll({ mfaToken: 'mfa_token_123', factorType: 'otp' })
+      ).rejects.toThrow(error);
+    });
+  });
+
+  describe('challenge', () => {
+    it('should call bridge with mfaToken and authenticatorId', async () => {
+      const challengeResult = {
+        challengeType: 'oob',
+        oobCode: 'oob_challenge_123',
+      };
+      mockBridge.mfaChallenge.mockResolvedValueOnce(challengeResult);
+
+      const result = await client.challenge({
+        mfaToken: 'mfa_token_123',
+        authenticatorId: 'sms|dev_123',
+      });
+
+      expect(mockBridge.mfaChallenge).toHaveBeenCalledWith(
+        'mfa_token_123',
+        'sms|dev_123'
+      );
+      expect(result).toEqual(challengeResult);
+    });
+
+    it('should wrap AuthError in MfaError', async () => {
+      const authError = new AuthError('challenge_error', 'Challenge failed', {
+        code: 'mfa_challenge_failed',
+      });
+      mockBridge.mfaChallenge.mockRejectedValueOnce(authError);
+
+      try {
+        await client.challenge({
+          mfaToken: 'mfa_token_123',
+          authenticatorId: 'sms|dev_123',
+        });
+        fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(MfaError);
+        expect((e as MfaError).type).toBe(MfaErrorCodes.CHALLENGE_FAILED);
+      }
+    });
+
+    it('should rethrow non-AuthError errors as-is', async () => {
+      const error = new Error('Challenge failed');
+      mockBridge.mfaChallenge.mockRejectedValueOnce(error);
+
+      await expect(
+        client.challenge({
+          mfaToken: 'mfa_token_123',
+          authenticatorId: 'sms|dev_123',
+        })
+      ).rejects.toThrow(error);
+    });
+  });
+
+  describe('verify', () => {
+    const mockCredentials = {
+      idToken: 'id_token',
+      accessToken: 'access_token',
+      tokenType: 'Bearer',
+      expiresAt: 1234567890,
+    };
+
+    it('should verify OTP code', async () => {
+      mockBridge.mfaVerify.mockResolvedValueOnce(mockCredentials);
+
+      const result = await client.verify({
+        mfaToken: 'mfa_token_123',
+        otp: '123456',
+      });
+
+      expect(mockBridge.mfaVerify).toHaveBeenCalledWith(
+        'mfa_token_123',
+        'otp',
+        '123456',
+        undefined,
+        undefined,
+        undefined
+      );
+      expect(result).toEqual(mockCredentials);
+    });
+
+    it('should verify OOB code without binding code', async () => {
+      mockBridge.mfaVerify.mockResolvedValueOnce(mockCredentials);
+
+      const result = await client.verify({
+        mfaToken: 'mfa_token_123',
+        oobCode: 'oob_code_123',
+      });
+
+      expect(mockBridge.mfaVerify).toHaveBeenCalledWith(
+        'mfa_token_123',
+        'oob',
+        'oob_code_123',
+        undefined,
+        undefined,
+        undefined
+      );
+      expect(result).toEqual(mockCredentials);
+    });
+
+    it('should verify OOB code with binding code', async () => {
+      mockBridge.mfaVerify.mockResolvedValueOnce(mockCredentials);
+
+      const result = await client.verify({
+        mfaToken: 'mfa_token_123',
+        oobCode: 'oob_code_123',
+        bindingCode: '654321',
+      });
+
+      expect(mockBridge.mfaVerify).toHaveBeenCalledWith(
+        'mfa_token_123',
+        'oob',
+        'oob_code_123',
+        '654321',
+        undefined,
+        undefined
+      );
+      expect(result).toEqual(mockCredentials);
+    });
+
+    it('should verify recovery code', async () => {
+      mockBridge.mfaVerify.mockResolvedValueOnce(mockCredentials);
+
+      const result = await client.verify({
+        mfaToken: 'mfa_token_123',
+        recoveryCode: 'RECOVERY_CODE_123',
+      });
+
+      expect(mockBridge.mfaVerify).toHaveBeenCalledWith(
+        'mfa_token_123',
+        'recoveryCode',
+        'RECOVERY_CODE_123',
+        undefined,
+        undefined,
+        undefined
+      );
+      expect(result).toEqual(mockCredentials);
+    });
+
+    it('should forward scope and audience to the bridge', async () => {
+      mockBridge.mfaVerify.mockResolvedValueOnce(mockCredentials);
+
+      const result = await client.verify({
+        mfaToken: 'mfa_token_123',
+        otp: '123456',
+        scope: 'openid profile',
+        audience: 'https://api.example.com',
+      });
+
+      expect(mockBridge.mfaVerify).toHaveBeenCalledWith(
+        'mfa_token_123',
+        'otp',
+        '123456',
+        undefined,
+        'openid profile',
+        'https://api.example.com'
+      );
+      expect(result).toEqual(mockCredentials);
+    });
+
+    it('should wrap AuthError in MfaError for invalid_otp', async () => {
+      const authError = new AuthError('invalid_otp', 'Invalid OTP', {
+        code: 'invalid_otp',
+      });
+      mockBridge.mfaVerify.mockRejectedValueOnce(authError);
+
+      try {
+        await client.verify({ mfaToken: 'mfa_token_123', otp: '000000' });
+        fail('Should have thrown');
+      } catch (e) {
+        expect(e).toBeInstanceOf(MfaError);
+        expect((e as MfaError).type).toBe(MfaErrorCodes.INVALID_OTP);
+      }
+    });
+
+    it('should rethrow non-AuthError errors as-is', async () => {
+      const error = new Error('Verification failed');
+      mockBridge.mfaVerify.mockRejectedValueOnce(error);
+
+      await expect(
+        client.verify({ mfaToken: 'mfa_token_123', otp: '123456' })
+      ).rejects.toThrow(error);
+    });
+  });
+});

--- a/src/platforms/native/adapters/index.ts
+++ b/src/platforms/native/adapters/index.ts
@@ -1,4 +1,5 @@
 export * from './NativeAuth0Client';
 export * from './NativeWebAuthProvider';
 export * from './NativeCredentialsManager';
+export * from './NativeMfaClient';
 export * from './NativeMyAccountClient';

--- a/src/platforms/native/bridge/INativeBridge.ts
+++ b/src/platforms/native/bridge/INativeBridge.ts
@@ -5,6 +5,9 @@ import type {
   ClearSessionParameters,
   DPoPHeadersParams,
   SessionTransferCredentials,
+  MfaAuthenticator,
+  MfaEnrollmentChallenge,
+  MfaChallengeResult,
   PasskeyChallengeResponse,
 } from '../../../types';
 import type {
@@ -214,6 +217,64 @@ export interface INativeBridge {
     audience?: string,
     scope?: string,
     organization?: string
+  ): Promise<Credentials>;
+
+  /**
+   * Lists enrolled MFA authenticators.
+   *
+   * @param mfaToken The MFA token from an MFA_REQUIRED error.
+   * @param factorsAllowed Optional list of factor types to filter by.
+   * @returns A promise that resolves with the list of enrolled authenticators.
+   */
+  getMfaAuthenticators(
+    mfaToken: string,
+    factorsAllowed?: string[]
+  ): Promise<MfaAuthenticator[]>;
+
+  /**
+   * Enrolls a new MFA factor.
+   *
+   * @param mfaToken The MFA token from an MFA_REQUIRED error.
+   * @param type The factor type: 'phone', 'email', 'otp', or 'push'.
+   * @param value The phone number or email (required for 'phone' and 'email').
+   * @returns A promise that resolves with the enrollment challenge details.
+   */
+  mfaEnroll(
+    mfaToken: string,
+    type: string,
+    value?: string
+  ): Promise<MfaEnrollmentChallenge>;
+
+  /**
+   * Requests an MFA challenge for an enrolled authenticator.
+   *
+   * @param mfaToken The MFA token from an MFA_REQUIRED error.
+   * @param authenticatorId The ID of the enrolled authenticator.
+   * @returns A promise that resolves with the challenge details.
+   */
+  mfaChallenge(
+    mfaToken: string,
+    authenticatorId: string
+  ): Promise<MfaChallengeResult>;
+
+  /**
+   * Verifies an MFA code and returns credentials on success.
+   *
+   * @param mfaToken The MFA token.
+   * @param type The verification type: 'otp', 'oob', or 'recoveryCode'.
+   * @param code The OTP code, OOB code, or recovery code.
+   * @param bindingCode Optional binding code for OOB verification.
+   * @param scope Optional space-separated OAuth 2.0 scopes for the returned credentials.
+   * @param audience Optional API audience for the returned credentials.
+   * @returns A promise that resolves with credentials on successful verification.
+   */
+  mfaVerify(
+    mfaToken: string,
+    type: string,
+    code: string,
+    bindingCode?: string,
+    scope?: string,
+    audience?: string
   ): Promise<Credentials>;
 
   /**

--- a/src/platforms/native/bridge/NativeBridgeManager.ts
+++ b/src/platforms/native/bridge/NativeBridgeManager.ts
@@ -7,6 +7,9 @@ import type {
   NativeClearSessionOptions,
   DPoPHeadersParams,
   SessionTransferCredentials,
+  MfaAuthenticator,
+  MfaEnrollmentChallenge,
+  MfaChallengeResult,
   PasskeyChallengeResponse,
 } from '../../../types';
 import {
@@ -264,6 +267,61 @@ export class NativeBridgeManager implements INativeBridge {
         { code: 'custom_token_exchange_failed', json: e }
       );
     }
+  }
+
+  async getMfaAuthenticators(
+    mfaToken: string,
+    factorsAllowed?: string[]
+  ): Promise<MfaAuthenticator[]> {
+    return this.a0_call(
+      Auth0NativeModule.getMfaAuthenticators.bind(Auth0NativeModule),
+      mfaToken,
+      factorsAllowed
+    ) as Promise<MfaAuthenticator[]>;
+  }
+
+  async mfaEnroll(
+    mfaToken: string,
+    type: string,
+    value?: string
+  ): Promise<MfaEnrollmentChallenge> {
+    return this.a0_call(
+      Auth0NativeModule.mfaEnroll.bind(Auth0NativeModule),
+      mfaToken,
+      type,
+      value
+    ) as Promise<MfaEnrollmentChallenge>;
+  }
+
+  async mfaChallenge(
+    mfaToken: string,
+    authenticatorId: string
+  ): Promise<MfaChallengeResult> {
+    return this.a0_call(
+      Auth0NativeModule.mfaChallenge.bind(Auth0NativeModule),
+      mfaToken,
+      authenticatorId
+    ) as Promise<MfaChallengeResult>;
+  }
+
+  async mfaVerify(
+    mfaToken: string,
+    type: string,
+    code: string,
+    bindingCode?: string,
+    scope?: string,
+    audience?: string
+  ): Promise<Credentials> {
+    const credential = await this.a0_call(
+      Auth0NativeModule.mfaVerify.bind(Auth0NativeModule),
+      mfaToken,
+      type,
+      code,
+      bindingCode,
+      scope,
+      audience
+    );
+    return new CredentialsModel(credential);
   }
 
   async passkeySignupChallenge(

--- a/src/platforms/web/adapters/WebAuth0Client.ts
+++ b/src/platforms/web/adapters/WebAuth0Client.ts
@@ -9,6 +9,7 @@ import type {
   IMyAccountClient,
   IPasswordlessClient,
   IUsersClient,
+  IMfaClient,
 } from '../../../core/interfaces';
 import type { WebAuth0Options } from '../../../types/platform-specific';
 import type {
@@ -22,6 +23,7 @@ import type {
 } from '../../../types';
 import { WebWebAuthProvider } from './WebWebAuthProvider';
 import { WebCredentialsManager } from './WebCredentialsManager';
+import { WebMfaClient } from './WebMfaClient';
 import { WebMyAccountClient } from './WebMyAccountClient';
 import { WebPasswordlessClient } from './WebPasswordlessClient';
 import { ssoExchangeNotSupported } from './WebAuthenticationProvider';
@@ -37,6 +39,7 @@ export class WebAuth0Client implements IAuth0Client {
   readonly webAuth: WebWebAuthProvider;
   readonly credentialsManager: WebCredentialsManager;
   readonly auth: IAuthenticationProvider;
+  readonly mfa: IMfaClient;
 
   private readonly httpClient: HttpClient;
   private readonly tokenType: TokenType;
@@ -127,6 +130,7 @@ export class WebAuth0Client implements IAuth0Client {
 
     this.webAuth = new WebWebAuthProvider(this.client);
     this.credentialsManager = new WebCredentialsManager(this.client);
+    this.mfa = new WebMfaClient(this.client.mfa, this.tokenType);
   }
 
   users(token: string, tokenType?: TokenType): IUsersClient {

--- a/src/platforms/web/adapters/WebMfaClient.ts
+++ b/src/platforms/web/adapters/WebMfaClient.ts
@@ -95,6 +95,8 @@ export class WebMfaClient implements IMfaClient {
         return type === 'email';
       case 'push':
         return type === 'push-notification';
+      case 'recovery-code':
+        return type === 'recovery-code';
       default:
         return false;
     }

--- a/src/platforms/web/adapters/WebMfaClient.ts
+++ b/src/platforms/web/adapters/WebMfaClient.ts
@@ -1,0 +1,320 @@
+import type { MfaApiClient } from '@auth0/auth0-spa-js';
+import type { IMfaClient } from '../../../core/interfaces';
+import type {
+  Credentials,
+  MfaAuthenticator,
+  MfaEnrollmentChallenge,
+  MfaChallengeResult,
+  MfaGetAuthenticatorsParameters,
+  MfaEnrollParameters,
+  MfaEnrollSmsParameters,
+  MfaEnrollVoiceParameters,
+  MfaEnrollEmailParameters,
+  MfaChallengeWithAuthenticatorParameters,
+  MfaVerifyParameters,
+} from '../../../types';
+import { AuthError, MfaError } from '../../../core/models';
+
+export class WebMfaClient implements IMfaClient {
+  private readonly spaMfa: MfaApiClient;
+  private readonly tokenType: string;
+
+  constructor(spaMfa: MfaApiClient, tokenType: string) {
+    this.spaMfa = spaMfa;
+    this.tokenType = tokenType;
+  }
+
+  // IDs are type-prefixed (e.g. "otp|dev_x"). Authenticator apps use 'otp';
+  // all out-of-band factors (sms/voice/email/push) use 'oob'.
+  private static challengeTypeFor(authenticatorId: string): 'otp' | 'oob' {
+    const prefix = authenticatorId.split('|')[0];
+    return prefix === 'otp' || prefix === 'totp' ? 'otp' : 'oob';
+  }
+
+  // spa-js reads `oob_channels` (plural) but /mfa/authenticators returns
+  // `oob_channel` (singular), so its mapped `oobChannels` is always undefined.
+  // Fall back to any explicit channel, then to the type-prefixed id.
+  private static readonly CHANNEL_ID_PREFIXES = [
+    'sms',
+    'voice',
+    'email',
+    'auth0',
+  ];
+
+  private static resolveOobChannel(authenticator: {
+    id?: string;
+    oobChannels?: string[];
+    oobChannel?: string;
+    oob_channel?: string;
+  }): string | undefined {
+    const explicit =
+      authenticator.oobChannels?.[0] ??
+      authenticator.oobChannel ??
+      authenticator.oob_channel;
+    if (explicit) return explicit;
+    const prefix = authenticator.id?.split('|')[0];
+    return prefix && WebMfaClient.CHANNEL_ID_PREFIXES.includes(prefix)
+      ? prefix
+      : undefined;
+  }
+
+  // Match against the requested factor via `type` (the discriminator native
+  // also uses; spa-js maps it correctly). sms and voice both surface as `phone`,
+  // so they're narrowed by resolved channel; an unresolved channel matches
+  // either to avoid dropping a usable factor.
+  private static matchesFactor(
+    authenticator: {
+      authenticatorType: string;
+      type?: string;
+      oobChannels?: string[];
+      oobChannel?: string;
+      oob_channel?: string;
+      id?: string;
+    },
+    factor: string
+  ): boolean {
+    const type = authenticator.type;
+    switch (factor) {
+      case 'otp':
+        return (
+          type === 'otp' ||
+          type === 'totp' ||
+          authenticator.authenticatorType === 'otp'
+        );
+      case 'sms': {
+        if (type !== 'phone') return false;
+        const channel = WebMfaClient.resolveOobChannel(authenticator);
+        return channel === undefined || channel === 'sms';
+      }
+      case 'voice': {
+        if (type !== 'phone') return false;
+        const channel = WebMfaClient.resolveOobChannel(authenticator);
+        return channel === undefined || channel === 'voice';
+      }
+      case 'email':
+        return type === 'email';
+      case 'push':
+        return type === 'push-notification';
+      default:
+        return false;
+    }
+  }
+
+  // spa-js filters by the challenge types in its MFA context, which is only
+  // populated by its own login flow. Here the mfa_token comes from outside
+  // spa-js, so the context is empty and getAuthenticators throws
+  // "challengeType is required". Seed a permissive context to get all
+  // authenticators, then apply our own factorsAllowed filter.
+  private static readonly ALL_CHALLENGE_TYPES = [
+    { type: 'otp' },
+    { type: 'totp' },
+    { type: 'phone' },
+    { type: 'email' },
+    { type: 'push-notification' },
+    { type: 'recovery-code' },
+  ];
+
+  async getAuthenticators(
+    parameters: MfaGetAuthenticatorsParameters
+  ): Promise<MfaAuthenticator[]> {
+    try {
+      let authenticators;
+      try {
+        authenticators = await this.spaMfa.getAuthenticators(
+          parameters.mfaToken
+        );
+      } catch (inner: any) {
+        // Only synthesize when spa-js reports the context is missing, so a real
+        // one from its own login flow is preserved.
+        if (inner?.error !== 'invalid_request') throw inner;
+        this.spaMfa.setMFAAuthDetails(
+          parameters.mfaToken,
+          undefined,
+          undefined,
+          {
+            challenge: WebMfaClient.ALL_CHALLENGE_TYPES,
+          }
+        );
+        authenticators = await this.spaMfa.getAuthenticators(
+          parameters.mfaToken
+        );
+      }
+
+      const { factorsAllowed } = parameters;
+      const filtered =
+        factorsAllowed && factorsAllowed.length > 0
+          ? authenticators.filter((a) =>
+              factorsAllowed.some((factor) =>
+                WebMfaClient.matchesFactor(a as any, factor)
+              )
+            )
+          : authenticators;
+
+      return filtered.map((a) => ({
+        id: a.id,
+        type: (a as { type?: string }).type,
+        authenticatorType: a.authenticatorType,
+        active: a.active,
+        name: a.name,
+        oobChannel: WebMfaClient.resolveOobChannel(a as any),
+      }));
+    } catch (e: any) {
+      const authError = new AuthError(
+        e.error ?? 'mfa_list_authenticators_failed',
+        e.error_description ?? e.message,
+        {
+          status: e.status,
+          code: e.error ?? 'mfa_list_authenticators_failed',
+          json: e,
+        }
+      );
+      throw new MfaError(authError);
+    }
+  }
+
+  async enroll(
+    parameters: MfaEnrollParameters
+  ): Promise<MfaEnrollmentChallenge> {
+    try {
+      const { factorType } = parameters;
+      let spaParams: any = {
+        mfaToken: parameters.mfaToken,
+        factorType,
+      };
+
+      if (factorType === 'sms' || factorType === 'voice') {
+        spaParams.phoneNumber = (
+          parameters as MfaEnrollSmsParameters | MfaEnrollVoiceParameters
+        ).phoneNumber;
+      } else if (factorType === 'email') {
+        spaParams.email = (parameters as MfaEnrollEmailParameters).email;
+      }
+
+      const response = await this.spaMfa.enroll(spaParams);
+
+      if (response.authenticatorType === 'otp') {
+        return {
+          type: 'totp',
+          barcodeUri: response.barcodeUri,
+          secret: response.secret,
+          recoveryCodes: response.recoveryCodes,
+        };
+      }
+
+      // Push enrolls as OOB but returns a barcodeUri for QR pairing; surface
+      // it as a dedicated push type.
+      if (factorType === 'push') {
+        return {
+          type: 'push',
+          barcodeUri: response.barcodeUri ?? '',
+          oobCode: response.oobCode,
+          oobChannel: response.oobChannel,
+          recoveryCodes: response.recoveryCodes,
+        };
+      }
+
+      return {
+        type: 'oob',
+        oobCode: response.oobCode ?? '',
+        bindingMethod: response.bindingMethod,
+        recoveryCodes: response.recoveryCodes,
+      };
+    } catch (e: any) {
+      if (e instanceof MfaError) throw e;
+      const authError = new AuthError(
+        e.error ?? 'mfa_enrollment_failed',
+        e.error_description ?? e.message,
+        {
+          status: e.status,
+          code: e.error ?? 'mfa_enrollment_failed',
+          json: e,
+        }
+      );
+      throw new MfaError(authError);
+    }
+  }
+
+  async challenge(
+    parameters: MfaChallengeWithAuthenticatorParameters
+  ): Promise<MfaChallengeResult> {
+    try {
+      const response = await this.spaMfa.challenge({
+        mfaToken: parameters.mfaToken,
+        challengeType: WebMfaClient.challengeTypeFor(
+          parameters.authenticatorId
+        ),
+        authenticatorId: parameters.authenticatorId,
+      });
+
+      return {
+        challengeType: response.challengeType,
+        oobCode: response.oobCode,
+        bindingMethod: response.bindingMethod,
+      };
+    } catch (e: any) {
+      if (e instanceof MfaError) throw e;
+      const authError = new AuthError(
+        e.error ?? 'mfa_challenge_failed',
+        e.error_description ?? e.message,
+        {
+          status: e.status,
+          code: e.error ?? 'mfa_challenge_failed',
+          json: e,
+        }
+      );
+      throw new MfaError(authError);
+    }
+  }
+
+  async verify(parameters: MfaVerifyParameters): Promise<Credentials> {
+    try {
+      // spa-js reads scope/audience from the stored context, not verify()
+      // params, so seed it when either is supplied. Omitting both preserves
+      // whatever spa-js's login flow set.
+      if (parameters.scope !== undefined || parameters.audience !== undefined) {
+        this.spaMfa.setMFAAuthDetails(
+          parameters.mfaToken,
+          parameters.scope,
+          parameters.audience
+        );
+      }
+
+      const spaParams: any = { mfaToken: parameters.mfaToken };
+
+      if ('otp' in parameters) {
+        spaParams.otp = parameters.otp;
+      } else if ('oobCode' in parameters) {
+        spaParams.oobCode = parameters.oobCode;
+        if ('bindingCode' in parameters) {
+          spaParams.bindingCode = parameters.bindingCode;
+        }
+      } else if ('recoveryCode' in parameters) {
+        spaParams.recoveryCode = parameters.recoveryCode;
+      }
+
+      const response = await this.spaMfa.verify(spaParams);
+
+      const expiresAt = Math.floor(Date.now() / 1000) + response.expires_in;
+      return {
+        accessToken: response.access_token,
+        idToken: response.id_token,
+        tokenType: response.token_type ?? this.tokenType,
+        expiresAt,
+        scope: response.scope,
+        refreshToken: response.refresh_token,
+      };
+    } catch (e: any) {
+      if (e instanceof MfaError) throw e;
+      const authError = new AuthError(
+        e.error ?? 'mfa_verify_failed',
+        e.error_description ?? e.message,
+        {
+          status: e.status,
+          code: e.error ?? 'mfa_verify_failed',
+          json: e,
+        }
+      );
+      throw new MfaError(authError);
+    }
+  }
+}

--- a/src/platforms/web/adapters/__tests__/WebMfaClient.spec.ts
+++ b/src/platforms/web/adapters/__tests__/WebMfaClient.spec.ts
@@ -201,6 +201,26 @@ describe('WebMfaClient', () => {
       expect(result[0].id).toBe('push|dev_4');
     });
 
+    it('matches recovery-code against the recovery-code type', async () => {
+      spaMfa.getAuthenticators.mockResolvedValue([
+        {
+          id: 'recovery-code|dev_5',
+          authenticatorType: 'recovery-code',
+          active: true,
+          name: 'Recovery code',
+          type: 'recovery-code',
+        },
+      ]);
+
+      const result = await client.getAuthenticators({
+        mfaToken: 'MFA_TOKEN',
+        factorsAllowed: ['recovery-code'],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('recovery-code|dev_5');
+    });
+
     it('supports multiple factors at once', async () => {
       spaMfa.getAuthenticators.mockResolvedValue(authenticators);
 

--- a/src/platforms/web/adapters/__tests__/WebMfaClient.spec.ts
+++ b/src/platforms/web/adapters/__tests__/WebMfaClient.spec.ts
@@ -1,0 +1,454 @@
+import { WebMfaClient } from '../WebMfaClient';
+import { MfaError } from '../../../../core/models';
+import { TokenType } from '../../../../types/common';
+
+type MockMfa = {
+  setMFAAuthDetails: jest.Mock;
+  getAuthenticators: jest.Mock;
+  enroll: jest.Mock;
+  challenge: jest.Mock;
+  verify: jest.Mock;
+};
+
+const createMockMfa = (): MockMfa => ({
+  setMFAAuthDetails: jest.fn(),
+  getAuthenticators: jest.fn(),
+  enroll: jest.fn(),
+  challenge: jest.fn(),
+  verify: jest.fn(),
+});
+
+describe('WebMfaClient', () => {
+  let spaMfa: MockMfa;
+  let client: WebMfaClient;
+
+  beforeEach(() => {
+    spaMfa = createMockMfa();
+    client = new WebMfaClient(spaMfa as any, TokenType.bearer);
+  });
+
+  describe('getAuthenticators', () => {
+    // Mirrors the real /mfa/authenticators shape as mapped by spa-js: `type` is
+    // the reliable discriminator (phone/email/otp/...) and the out-of-band
+    // channel arrives as the singular `oob_channel` key (spa-js drops it because
+    // its mapper reads the plural `oob_channels`).
+    const authenticators = [
+      {
+        id: 'otp|dev_1',
+        authenticatorType: 'otp',
+        active: true,
+        name: 'Authenticator app',
+        type: 'otp',
+      },
+      {
+        id: 'sms|dev_2',
+        authenticatorType: 'oob',
+        active: true,
+        name: 'SMS',
+        type: 'phone',
+        oob_channel: 'sms',
+      },
+      {
+        id: 'email|dev_3',
+        authenticatorType: 'oob',
+        active: false,
+        type: 'email',
+        oob_channel: 'email',
+      },
+    ];
+
+    it('does not clobber the spa-js MFA context', async () => {
+      spaMfa.getAuthenticators.mockResolvedValue(authenticators);
+
+      await client.getAuthenticators({ mfaToken: 'MFA_TOKEN' });
+
+      expect(spaMfa.setMFAAuthDetails).not.toHaveBeenCalled();
+      expect(spaMfa.getAuthenticators).toHaveBeenCalledWith('MFA_TOKEN');
+    });
+
+    it('seeds a permissive context and retries when spa-js reports a missing context', async () => {
+      spaMfa.getAuthenticators
+        .mockRejectedValueOnce({
+          error: 'invalid_request',
+          error_description:
+            'challengeType is required and must contain at least one challenge type, please check mfa_required error payload',
+        })
+        .mockResolvedValueOnce(authenticators);
+
+      const result = await client.getAuthenticators({ mfaToken: 'MFA_TOKEN' });
+
+      expect(spaMfa.setMFAAuthDetails).toHaveBeenCalledWith(
+        'MFA_TOKEN',
+        undefined,
+        undefined,
+        expect.objectContaining({
+          challenge: expect.arrayContaining([
+            { type: 'otp' },
+            { type: 'phone' },
+            { type: 'email' },
+            { type: 'push-notification' },
+          ]),
+        })
+      );
+      expect(spaMfa.getAuthenticators).toHaveBeenCalledTimes(2);
+      expect(result).toHaveLength(3);
+    });
+
+    it('does not retry on errors other than invalid_request', async () => {
+      spaMfa.getAuthenticators.mockRejectedValue({
+        error: 'invalid_grant',
+        error_description: 'Malformed mfa_token',
+      });
+
+      await expect(
+        client.getAuthenticators({ mfaToken: 'MFA_TOKEN' })
+      ).rejects.toBeInstanceOf(MfaError);
+
+      expect(spaMfa.setMFAAuthDetails).not.toHaveBeenCalled();
+      expect(spaMfa.getAuthenticators).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolves oobChannel from the singular oob_channel key', async () => {
+      spaMfa.getAuthenticators.mockResolvedValue(authenticators);
+
+      const result = await client.getAuthenticators({ mfaToken: 'MFA_TOKEN' });
+
+      expect(result).toEqual([
+        {
+          id: 'otp|dev_1',
+          type: 'otp',
+          authenticatorType: 'otp',
+          active: true,
+          name: 'Authenticator app',
+          oobChannel: undefined,
+        },
+        {
+          id: 'sms|dev_2',
+          type: 'phone',
+          authenticatorType: 'oob',
+          active: true,
+          name: 'SMS',
+          oobChannel: 'sms',
+        },
+        {
+          id: 'email|dev_3',
+          type: 'email',
+          authenticatorType: 'oob',
+          active: false,
+          name: undefined,
+          oobChannel: 'email',
+        },
+      ]);
+    });
+
+    it('falls back to the channel-prefixed id when no channel field is present', async () => {
+      spaMfa.getAuthenticators.mockResolvedValue([
+        {
+          id: 'voice|dev_9',
+          authenticatorType: 'oob',
+          active: true,
+          name: 'Voice',
+          type: 'phone',
+        },
+      ]);
+
+      const result = await client.getAuthenticators({ mfaToken: 'MFA_TOKEN' });
+
+      expect(result[0].oobChannel).toBe('voice');
+    });
+
+    it('filters otp by type', async () => {
+      spaMfa.getAuthenticators.mockResolvedValue(authenticators);
+
+      const result = await client.getAuthenticators({
+        mfaToken: 'MFA_TOKEN',
+        factorsAllowed: ['otp'],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('otp|dev_1');
+    });
+
+    it('filters phone-type authenticators by resolved channel', async () => {
+      spaMfa.getAuthenticators.mockResolvedValue(authenticators);
+
+      const result = await client.getAuthenticators({
+        mfaToken: 'MFA_TOKEN',
+        factorsAllowed: ['sms'],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('sms|dev_2');
+    });
+
+    it('matches push against the push-notification type', async () => {
+      spaMfa.getAuthenticators.mockResolvedValue([
+        {
+          id: 'push|dev_4',
+          authenticatorType: 'oob',
+          active: true,
+          name: 'Guardian',
+          type: 'push-notification',
+        },
+      ]);
+
+      const result = await client.getAuthenticators({
+        mfaToken: 'MFA_TOKEN',
+        factorsAllowed: ['push'],
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('push|dev_4');
+    });
+
+    it('supports multiple factors at once', async () => {
+      spaMfa.getAuthenticators.mockResolvedValue(authenticators);
+
+      const result = await client.getAuthenticators({
+        mfaToken: 'MFA_TOKEN',
+        factorsAllowed: ['otp', 'email'],
+      });
+
+      expect(result.map((a) => a.id)).toEqual(['otp|dev_1', 'email|dev_3']);
+    });
+
+    it('returns all authenticators when factorsAllowed is empty', async () => {
+      spaMfa.getAuthenticators.mockResolvedValue(authenticators);
+
+      const result = await client.getAuthenticators({
+        mfaToken: 'MFA_TOKEN',
+        factorsAllowed: [],
+      });
+
+      expect(result).toHaveLength(3);
+    });
+
+    it('wraps failures in MfaError', async () => {
+      spaMfa.getAuthenticators.mockRejectedValue({
+        error: 'invalid_token',
+        error_description: 'bad token',
+        status: 401,
+      });
+
+      await expect(
+        client.getAuthenticators({ mfaToken: 'MFA_TOKEN' })
+      ).rejects.toBeInstanceOf(MfaError);
+    });
+  });
+
+  describe('challenge', () => {
+    beforeEach(() => {
+      spaMfa.challenge.mockResolvedValue({
+        challengeType: 'oob',
+        oobCode: 'oob_123',
+        bindingMethod: 'prompt',
+      });
+    });
+
+    it("derives challengeType 'otp' for otp-prefixed authenticators", async () => {
+      await client.challenge({
+        mfaToken: 'MFA_TOKEN',
+        authenticatorId: 'otp|dev_1',
+      });
+
+      expect(spaMfa.challenge).toHaveBeenCalledWith(
+        expect.objectContaining({ challengeType: 'otp' })
+      );
+    });
+
+    it("derives challengeType 'otp' for totp-prefixed authenticators", async () => {
+      await client.challenge({
+        mfaToken: 'MFA_TOKEN',
+        authenticatorId: 'totp|dev_1',
+      });
+
+      expect(spaMfa.challenge).toHaveBeenCalledWith(
+        expect.objectContaining({ challengeType: 'otp' })
+      );
+    });
+
+    it("derives challengeType 'oob' for sms/push/email authenticators", async () => {
+      for (const id of ['sms|dev_2', 'push|dev_3', 'email|dev_4']) {
+        await client.challenge({ mfaToken: 'MFA_TOKEN', authenticatorId: id });
+        expect(spaMfa.challenge).toHaveBeenLastCalledWith(
+          expect.objectContaining({ challengeType: 'oob' })
+        );
+      }
+    });
+
+    it('does not clobber the spa-js MFA context', async () => {
+      await client.challenge({
+        mfaToken: 'MFA_TOKEN',
+        authenticatorId: 'sms|dev_2',
+      });
+
+      expect(spaMfa.setMFAAuthDetails).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('enroll', () => {
+    it('maps a TOTP enrollment response', async () => {
+      spaMfa.enroll.mockResolvedValue({
+        authenticatorType: 'otp',
+        barcodeUri: 'otpauth://totp/x',
+        secret: 'SECRET',
+        recoveryCodes: ['r1'],
+      });
+
+      const result = await client.enroll({
+        mfaToken: 'MFA_TOKEN',
+        factorType: 'otp',
+      });
+
+      expect(result).toEqual({
+        type: 'totp',
+        barcodeUri: 'otpauth://totp/x',
+        secret: 'SECRET',
+        recoveryCodes: ['r1'],
+      });
+      expect(spaMfa.setMFAAuthDetails).not.toHaveBeenCalled();
+    });
+
+    it('maps a push enrollment response with barcodeUri', async () => {
+      spaMfa.enroll.mockResolvedValue({
+        authenticatorType: 'oob',
+        oobChannel: 'auth0',
+        oobCode: 'oob_push',
+        barcodeUri: 'otpauth://totp/guardian',
+        recoveryCodes: ['r1'],
+      });
+
+      const result = await client.enroll({
+        mfaToken: 'MFA_TOKEN',
+        factorType: 'push',
+      });
+
+      expect(result).toEqual({
+        type: 'push',
+        barcodeUri: 'otpauth://totp/guardian',
+        oobCode: 'oob_push',
+        oobChannel: 'auth0',
+        recoveryCodes: ['r1'],
+      });
+    });
+
+    it('maps an OOB enrollment response', async () => {
+      spaMfa.enroll.mockResolvedValue({
+        authenticatorType: 'oob',
+        oobCode: 'oob_123',
+        bindingMethod: 'prompt',
+      });
+
+      const result = await client.enroll({
+        mfaToken: 'MFA_TOKEN',
+        factorType: 'sms',
+        phoneNumber: '+12025550135',
+      });
+
+      expect(result).toEqual({
+        type: 'oob',
+        oobCode: 'oob_123',
+        bindingMethod: 'prompt',
+        recoveryCodes: undefined,
+      });
+      expect(spaMfa.enroll).toHaveBeenCalledWith(
+        expect.objectContaining({ phoneNumber: '+12025550135' })
+      );
+    });
+  });
+
+  describe('verify', () => {
+    beforeEach(() => {
+      jest.spyOn(Date, 'now').mockReturnValue(1_000_000);
+    });
+
+    afterEach(() => {
+      (Date.now as jest.Mock).mockRestore();
+    });
+
+    it('maps a successful otp verification and preserves scope', async () => {
+      spaMfa.verify.mockResolvedValue({
+        access_token: 'at',
+        id_token: 'it',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'openid profile',
+        refresh_token: 'rt',
+      });
+
+      const result = await client.verify({ mfaToken: 'MFA_TOKEN', otp: '123' });
+
+      expect(spaMfa.verify).toHaveBeenCalledWith({
+        mfaToken: 'MFA_TOKEN',
+        otp: '123',
+      });
+      expect(spaMfa.setMFAAuthDetails).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        accessToken: 'at',
+        idToken: 'it',
+        tokenType: 'Bearer',
+        expiresAt: 1000 + 3600,
+        scope: 'openid profile',
+        refreshToken: 'rt',
+      });
+    });
+
+    it('passes oobCode and bindingCode through', async () => {
+      spaMfa.verify.mockResolvedValue({
+        access_token: 'at',
+        id_token: 'it',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      });
+
+      await client.verify({
+        mfaToken: 'MFA_TOKEN',
+        oobCode: 'oob_123',
+        bindingCode: '000000',
+      });
+
+      expect(spaMfa.verify).toHaveBeenCalledWith({
+        mfaToken: 'MFA_TOKEN',
+        oobCode: 'oob_123',
+        bindingCode: '000000',
+      });
+    });
+
+    it('seeds scope and audience via setMFAAuthDetails before verifying', async () => {
+      spaMfa.verify.mockResolvedValue({
+        access_token: 'at',
+        id_token: 'it',
+        token_type: 'Bearer',
+        expires_in: 3600,
+      });
+
+      await client.verify({
+        mfaToken: 'MFA_TOKEN',
+        otp: '123',
+        scope: 'openid profile',
+        audience: 'https://api.example.com',
+      });
+
+      expect(spaMfa.setMFAAuthDetails).toHaveBeenCalledWith(
+        'MFA_TOKEN',
+        'openid profile',
+        'https://api.example.com'
+      );
+      expect(spaMfa.verify).toHaveBeenCalledWith({
+        mfaToken: 'MFA_TOKEN',
+        otp: '123',
+      });
+    });
+
+    it('wraps failures in MfaError', async () => {
+      spaMfa.verify.mockRejectedValue({
+        error: 'invalid_grant',
+        error_description: 'wrong code',
+      });
+
+      await expect(
+        client.verify({ mfaToken: 'MFA_TOKEN', otp: 'bad' })
+      ).rejects.toBeInstanceOf(MfaError);
+    });
+  });
+});

--- a/src/platforms/web/adapters/index.ts
+++ b/src/platforms/web/adapters/index.ts
@@ -1,4 +1,5 @@
 export * from './WebAuth0Client';
 export * from './WebWebAuthProvider';
 export * from './WebCredentialsManager';
+export * from './WebMfaClient';
 export * from './WebMyAccountClient';

--- a/src/specs/NativeA0Auth0.ts
+++ b/src/specs/NativeA0Auth0.ts
@@ -171,6 +171,49 @@ export interface Spec extends TurboModule {
   ): Promise<Credentials>;
 
   /**
+   * Get enrolled MFA authenticators.
+   */
+  getMfaAuthenticators(
+    mfaToken: string,
+    factorsAllowed: string[] | undefined
+  ): Promise<Object[]>;
+
+  /**
+   * Enroll a new MFA factor.
+   * @param mfaToken The MFA token from an MFA_REQUIRED error.
+   * @param type The type of factor to enroll: 'phone', 'email', 'otp', or 'push'.
+   * @param value The phone number or email address (required for 'phone' and 'email' types).
+   */
+  mfaEnroll(
+    mfaToken: string,
+    type: string,
+    value: string | undefined
+  ): Promise<Object>;
+
+  /**
+   * Request an MFA challenge for an enrolled authenticator.
+   */
+  mfaChallenge(mfaToken: string, authenticatorId: string): Promise<Object>;
+
+  /**
+   * Verify an MFA code and obtain credentials.
+   * @param mfaToken The MFA token.
+   * @param type The verification type: 'otp', 'oob', or 'recoveryCode'.
+   * @param code The OTP code, OOB code, or recovery code.
+   * @param bindingCode The binding code for OOB verification (optional).
+   * @param scope Space-separated OAuth 2.0 scopes for the returned credentials (optional).
+   * @param audience API audience for the returned credentials (optional).
+   */
+  mfaVerify(
+    mfaToken: string,
+    type: string,
+    code: string,
+    bindingCode: string | undefined,
+    scope: string | undefined,
+    audience: string | undefined
+  ): Promise<Credentials>;
+
+  /**
    * Request a passkey signup challenge from Auth0.
    */
   passkeySignupChallenge(

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -214,6 +214,153 @@ export type MfaChallengeResponse =
   | MfaChallengeOobResponse
   | MfaChallengeOobWithBindingResponse;
 
+// ========= MFA Flexible Factors Grant Types =========
+
+/** Represents an enrolled MFA authenticator. */
+export type MfaAuthenticator = {
+  id: string;
+  /**
+   * The factor type of the authenticator, e.g. `"otp"`, `"phone"`, `"email"`,
+   * or `"push-notification"`. Use this to distinguish factors when
+   * `authenticatorType` alone is ambiguous (for example, SMS and voice both
+   * surface as the `"phone"` type — narrow further with `oobChannel`).
+   */
+  type?: string;
+  authenticatorType: string;
+  name?: string;
+  active: boolean;
+  oobChannel?: string;
+};
+
+/** Represents the response from an MFA challenge request via the MFA API. */
+export type MfaChallengeResult = {
+  challengeType: string;
+  oobCode?: string;
+  bindingMethod?: string;
+};
+
+/** Base enrollment challenge response. */
+export type MfaOobEnrollmentChallenge = {
+  type: 'oob';
+  oobCode: string;
+  bindingMethod?: string;
+  recoveryCodes?: string[];
+};
+
+/** Enrollment challenge for TOTP (authenticator app). */
+export type MfaTotpEnrollmentChallenge = {
+  type: 'totp';
+  barcodeUri: string;
+  secret: string;
+  recoveryCodes?: string[];
+};
+
+/**
+ * Enrollment challenge for push notification (Auth0 Guardian).
+ *
+ * Push enrollment returns a `barcodeUri` to render as a QR code for pairing the
+ * Guardian app, alongside an `oobCode` used to poll/verify the enrollment.
+ *
+ * @remarks
+ * On Android, the underlying Auth0.Android SDK deserializes the push response as
+ * a TOTP challenge (it keys off `barcode_uri`), so `oobCode` is not available
+ * there; `barcodeUri` is always present for pairing.
+ */
+export type MfaPushEnrollmentChallenge = {
+  type: 'push';
+  /** QR code URI to display for pairing the Auth0 Guardian app. */
+  barcodeUri: string;
+  /** Out-of-band code used to verify the enrollment. Not available on Android. */
+  oobCode?: string;
+  /** The out-of-band channel, typically `"auth0"` for Guardian push. */
+  oobChannel?: string;
+  recoveryCodes?: string[];
+};
+
+/**
+ * Enrollment challenge for a recovery code.
+ *
+ * @remarks
+ * Only emitted on Android, where the underlying Auth0.Android SDK can return a
+ * dedicated recovery-code enrollment challenge. On iOS and web, recovery codes
+ * are instead surfaced via the `recoveryCodes` array on other challenge types.
+ */
+export type MfaRecoveryCodeEnrollmentChallenge = {
+  type: 'recovery-code';
+  recoveryCode: string;
+};
+
+/** Union type for all possible enrollment challenge responses. */
+export type MfaEnrollmentChallenge =
+  | MfaOobEnrollmentChallenge
+  | MfaTotpEnrollmentChallenge
+  | MfaPushEnrollmentChallenge
+  | MfaRecoveryCodeEnrollmentChallenge;
+
+/** Structured payload extracted from an MFA_REQUIRED error. */
+export type MfaRequiredErrorPayload = {
+  mfaToken: string;
+  error: string;
+  errorDescription?: string;
+  mfaRequirements?: MfaRequirements;
+};
+
+/** Describes which MFA factors are available for enrollment and challenge. */
+export type MfaRequirements = {
+  enroll?: MfaFactor[];
+  challenge?: MfaFactor[];
+};
+
+/** Describes a single MFA factor type. */
+export type MfaFactor = {
+  type: string;
+};
+
+// ========= MFA Factor Type Constants =========
+
+/**
+ * Supported MFA factor types.
+ * Use these constants when enrolling factors, filtering authenticators, or identifying challenge types.
+ *
+ * @example
+ * ```ts
+ * import { MfaFactorType } from 'react-native-auth0';
+ *
+ * // Enroll TOTP authenticator
+ * await mfa.enroll({ mfaToken, factorType: MfaFactorType.OTP });
+ *
+ * // Enroll SMS
+ * await mfa.enroll({ mfaToken, factorType: MfaFactorType.SMS, phoneNumber: '+1234567890' });
+ *
+ * // Enroll Email
+ * await mfa.enroll({ mfaToken, factorType: MfaFactorType.EMAIL, email: 'user@example.com' });
+ *
+ * // Filter authenticators
+ * const smsAuths = authenticators.filter(a => a.oobChannel === MfaFactorType.SMS);
+ * ```
+ */
+export const MfaFactorType = {
+  /** Time-based One-Time Password (authenticator app like Google Authenticator, Authy) */
+  OTP: 'otp',
+  /** SMS-based verification */
+  SMS: 'sms',
+  /**
+   * Voice call verification.
+   *
+   * Only the **web** platform supports voice as a distinct channel. On
+   * **native** (iOS/Android) the underlying SDKs do not support a voice OOB
+   * channel: enrolling `voice` falls back to **SMS** on the same number, and
+   * voice cannot be isolated from SMS when filtering authenticators.
+   */
+  VOICE: 'voice',
+  /** Email-based verification */
+  EMAIL: 'email',
+  /** Push notification (Auth0 Guardian) */
+  PUSH: 'push',
+} as const;
+
+export type MfaFactorType = (typeof MfaFactorType)[keyof typeof MfaFactorType];
+
 // ========= DPoP Types =========
 
 /**

--- a/src/types/parameters.ts
+++ b/src/types/parameters.ts
@@ -1,4 +1,4 @@
-import type { PasswordlessChallenge, TokenType } from './common';
+import type { PasswordlessChallenge, TokenType, MfaFactorType } from './common';
 
 /** A base interface for API calls that allow passing custom headers.
  * @hidden
@@ -279,6 +279,183 @@ export interface MfaChallengeParameters extends RequestOptions {
   challengeType?: 'oob' | 'otp';
   authenticatorId?: string;
 }
+
+// ========= MFA Flexible Factors Grant Parameters =========
+
+/** Parameters for listing enrolled MFA authenticators. */
+export interface MfaGetAuthenticatorsParameters {
+  mfaToken: string;
+  /**
+   * Restrict the returned authenticators to the given factor types. Use the
+   * {@link MfaFactorType} constants as the single, platform-agnostic vocabulary;
+   * each platform maps these to its native filtering tokens. Omit or pass an
+   * empty array to return all enrolled authenticators (the SDK supplies the
+   * full set of factor types on every platform).
+   *
+   * @remarks
+   * - **Android** cannot isolate `push` — its effective channel is `auth0`,
+   *   so a `push`-only filter may not match Guardian authenticators.
+   * - **Android** cannot distinguish `sms` from `voice` when filtering — both
+   *   resolve to the `phone` type, so filtering by either returns both channels.
+   *   Inspect the {@link MfaAuthenticator.oobChannel} field to tell them apart.
+   *   (iOS narrows phone-type results by `oobChannel` when only one of
+   *   `sms`/`voice` is requested.)
+   */
+  factorsAllowed?: MfaFactorType[];
+}
+
+/**
+ * Enroll an OTP (TOTP) authenticator.
+ *
+ * @example
+ * ```ts
+ * import { MfaFactorType } from 'react-native-auth0';
+ * const result = await mfa.enroll({ mfaToken, factorType: MfaFactorType.OTP });
+ * // result.secret, result.barcodeUri
+ * ```
+ */
+export interface MfaEnrollOtpParameters {
+  mfaToken: string;
+  factorType: 'otp';
+}
+
+/**
+ * Enroll an SMS MFA factor.
+ * Requires a phone number in E.164 format.
+ *
+ * @example
+ * ```ts
+ * import { MfaFactorType } from 'react-native-auth0';
+ * await mfa.enroll({ mfaToken, factorType: MfaFactorType.SMS, phoneNumber: '+12025550135' });
+ * ```
+ */
+export interface MfaEnrollSmsParameters {
+  mfaToken: string;
+  factorType: 'sms';
+  phoneNumber: string;
+}
+
+/**
+ * Enroll a voice call MFA factor.
+ * Requires a phone number in E.164 format.
+ *
+ * @remarks
+ * Voice is only enrolled as a distinct factor on the **web** platform. On the
+ * **native** platforms (iOS/Android), the underlying Auth0.swift and
+ * Auth0.Android SDKs do not expose a voice OOB channel, so a voice request is
+ * enrolled as **SMS** on the same phone number. Use {@link MfaEnrollSmsParameters}
+ * directly on native if SMS is the intended factor.
+ *
+ * @example
+ * ```ts
+ * import { MfaFactorType } from 'react-native-auth0';
+ * await mfa.enroll({ mfaToken, factorType: MfaFactorType.VOICE, phoneNumber: '+12025550135' });
+ * ```
+ */
+export interface MfaEnrollVoiceParameters {
+  mfaToken: string;
+  factorType: 'voice';
+  phoneNumber: string;
+}
+
+/**
+ * Enroll an email MFA factor.
+ *
+ * @example
+ * ```ts
+ * import { MfaFactorType } from 'react-native-auth0';
+ * await mfa.enroll({ mfaToken, factorType: MfaFactorType.EMAIL, email: 'user@example.com' });
+ * ```
+ */
+export interface MfaEnrollEmailParameters {
+  mfaToken: string;
+  factorType: 'email';
+  email: string;
+}
+
+/**
+ * Enroll a push notification MFA factor (Auth0 Guardian).
+ *
+ * @example
+ * ```ts
+ * import { MfaFactorType } from 'react-native-auth0';
+ * await mfa.enroll({ mfaToken, factorType: MfaFactorType.PUSH });
+ * ```
+ */
+export interface MfaEnrollPushParameters {
+  mfaToken: string;
+  factorType: 'push';
+}
+
+/**
+ * Union type for all MFA enrollment parameter types.
+ * Each variant is discriminated by the `factorType` field.
+ *
+ * @example
+ * ```ts
+ * import { MfaFactorType } from 'react-native-auth0';
+ *
+ * // OTP
+ * await mfa.enroll({ mfaToken, factorType: MfaFactorType.OTP });
+ * // SMS
+ * await mfa.enroll({ mfaToken, factorType: MfaFactorType.SMS, phoneNumber: '+1...' });
+ * // Voice
+ * await mfa.enroll({ mfaToken, factorType: MfaFactorType.VOICE, phoneNumber: '+1...' });
+ * // Email
+ * await mfa.enroll({ mfaToken, factorType: MfaFactorType.EMAIL, email: 'user@example.com' });
+ * // Push
+ * await mfa.enroll({ mfaToken, factorType: MfaFactorType.PUSH });
+ * ```
+ */
+export type MfaEnrollParameters =
+  | MfaEnrollOtpParameters
+  | MfaEnrollSmsParameters
+  | MfaEnrollVoiceParameters
+  | MfaEnrollEmailParameters
+  | MfaEnrollPushParameters;
+
+/** Parameters for requesting an MFA challenge via the MFA API. */
+export interface MfaChallengeWithAuthenticatorParameters {
+  mfaToken: string;
+  authenticatorId: string;
+}
+
+/** Parameters for verifying an MFA OTP code (authenticator app). */
+export interface MfaVerifyOtpParameters {
+  mfaToken: string;
+  otp: string;
+  /** Space-separated list of OAuth 2.0 scopes to request for the returned credentials. */
+  scope?: string;
+  /** API audience to request for the returned credentials. */
+  audience?: string;
+}
+
+/** Parameters for verifying an MFA OOB code (SMS/Email/Push). */
+export interface MfaVerifyOobParameters {
+  mfaToken: string;
+  oobCode: string;
+  bindingCode?: string;
+  /** Space-separated list of OAuth 2.0 scopes to request for the returned credentials. */
+  scope?: string;
+  /** API audience to request for the returned credentials. */
+  audience?: string;
+}
+
+/** Parameters for verifying with a recovery code. */
+export interface MfaVerifyRecoveryCodeParameters {
+  mfaToken: string;
+  recoveryCode: string;
+  /** Space-separated list of OAuth 2.0 scopes to request for the returned credentials. */
+  scope?: string;
+  /** API audience to request for the returned credentials. */
+  audience?: string;
+}
+
+/** Union type for all MFA verification parameter types. */
+export type MfaVerifyParameters =
+  | MfaVerifyOtpParameters
+  | MfaVerifyOobParameters
+  | MfaVerifyRecoveryCodeParameters;
 
 // ========= User Management & Profile Parameters =========
 

--- a/src/types/parameters.ts
+++ b/src/types/parameters.ts
@@ -288,9 +288,11 @@ export interface MfaGetAuthenticatorsParameters {
   /**
    * Restrict the returned authenticators to the given factor types. Use the
    * {@link MfaFactorType} constants as the single, platform-agnostic vocabulary;
-   * each platform maps these to its native filtering tokens. Omit or pass an
-   * empty array to return all enrolled authenticators (the SDK supplies the
-   * full set of factor types on every platform).
+   * each platform maps these to its native filtering tokens. `'recovery-code'`
+   * is also accepted here — it is listable but not enrollable, so it is absent
+   * from the {@link MfaFactorType} const. Omit or pass an empty array to return
+   * all enrolled authenticators (the SDK supplies the full set of factor types
+   * on every platform).
    *
    * @remarks
    * - **Android** cannot isolate `push` — its effective channel is `auth0`,
@@ -301,7 +303,7 @@ export interface MfaGetAuthenticatorsParameters {
    *   (iOS narrows phone-type results by `oobChannel` when only one of
    *   `sms`/`voice` is requested.)
    */
-  factorsAllowed?: MfaFactorType[];
+  factorsAllowed?: (MfaFactorType | 'recovery-code')[];
 }
 
 /**


### PR DESCRIPTION
Adds first-class MFA support to the SDK across iOS, Android, and Web, exposing the Flexible Factors flow through a single consistent API:    
                                                                                                                               
  - `mfa.getAuthenticators()` — list a user's enrolled factors                                                                                 
  - `mfa.enroll()` — enroll a new factor (OTP, SMS, voice, email, push)                                                        
  - `mfa.challenge()` — trigger a challenge for an existing factor                                                                             
  - `mfa.verify()` — verify a code and exchange the MFA token for credentials 
 
An `MfaFactorType` enum and a dedicated `MfaError` (with `MfaErrorCodes`) are exported publicly for type-safe usage and error handling.
                                                                                                                                               
  #### Usage                                                                                                                                   
                                                    
  ```ts                                                                                                                                        
  import { useAuth0, MfaFactorType } from 'react-native-auth0';                                                       
                                                    
  const { mfa } = useAuth0();

  // A login attempt against an MFA-enabled connection returns an mfa_token:
  //   const mfaToken = error.json.mfa_token;                                                                                                  
   
  // List the user's enrolled factors                                                                                                          
  const authenticators = await mfa.getAuthenticators({ mfaToken });                                                   
                                                                                                                                               
  // Verify an existing factor (e.g. TOTP from an authenticator app)
  const credentials = await mfa.verify({ mfaToken, otp: '123456' });                                                                           
                                                                                                                      
  // ...or enroll a new factor                      
  const challenge = await mfa.enroll({                                                                                                         
    mfaToken,
    factorType: MfaFactorType.SMS,                                                                                                             
    phoneNumber: '+12025550135',                                                                                      
  });                                                                                                                                          
   
  if (challenge.type === 'oob') {                                                                                                              
    // user receives the code out-of-band, then:                                                                      
    const credentials = await mfa.verify({ mfaToken, oobCode: '000000' });
  }
  ```