### PR TITLE
feat: Add parseIdToken utility to public API

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -137,6 +137,21 @@ auth0.auth
 
 This endpoint requires an access token that was granted the `/userinfo` audience. Check that the authentication request that returned the access token included an audience value of `https://{YOUR_AUTH0_DOMAIN}.auth0.com/userinfo`.
 
+### Parse user profile from an ID token locally
+
+If you already have credentials (e.g. from `webAuth.authorize()` or `credentialsManager.getCredentials()`), you can extract the user profile from the ID token without a network request:
+
+```js
+import Auth0, { parseIdToken } from 'react-native-auth0';
+
+const auth0 = new Auth0({ domain, clientId });
+const credentials = await auth0.webAuth.authorize({ scope: 'openid profile email' });
+const user = parseIdToken(credentials.idToken);
+// user.sub, user.name, user.email, etc.
+```
+
+This is the same parsing that `Auth0Provider` performs internally. It's useful when you manage auth state yourself via the `Auth0` class and want to avoid the network round-trip of `auth.userInfo()`.
+
 ### Getting new access token with refresh token
 
 ```js

--- a/src/core/utils/__tests__/parseIdToken.spec.ts
+++ b/src/core/utils/__tests__/parseIdToken.spec.ts
@@ -1,0 +1,61 @@
+import { parseIdToken } from '../parseIdToken';
+import { jwtDecode } from 'jwt-decode';
+
+jest.mock('jwt-decode');
+
+describe('parseIdToken', () => {
+  const mockJwtDecode = jwtDecode as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a User with decoded profile claims', () => {
+    mockJwtDecode.mockReturnValue({
+      sub: 'auth0|123',
+      name: 'Jane Doe',
+      email: 'jane@example.com',
+      email_verified: true,
+      given_name: 'Jane',
+      family_name: 'Doe',
+    });
+
+    const user = parseIdToken('mock-id-token');
+
+    expect(user.sub).toBe('auth0|123');
+    expect(user.name).toBe('Jane Doe');
+    expect(user.email).toBe('jane@example.com');
+    expect(user.emailVerified).toBe(true);
+    expect(user.givenName).toBe('Jane');
+    expect(user.familyName).toBe('Doe');
+  });
+
+  it('should exclude protocol claims', () => {
+    mockJwtDecode.mockReturnValue({
+      sub: 'auth0|123',
+      iss: 'https://tenant.auth0.com/',
+      aud: 'client-id',
+      exp: 9999999999,
+      iat: 1000000000,
+    });
+
+    const user = parseIdToken('mock-id-token');
+
+    expect(user.sub).toBe('auth0|123');
+    expect((user as any).iss).toBeUndefined();
+    expect((user as any).aud).toBeUndefined();
+    expect((user as any).exp).toBeUndefined();
+    expect((user as any).iat).toBeUndefined();
+  });
+
+  it('should throw if the token is missing the sub claim', () => {
+    mockJwtDecode.mockReturnValue({
+      name: 'No Sub',
+      email: 'nosub@example.com',
+    });
+
+    expect(() => parseIdToken('bad-token')).toThrow(
+      'ID token is missing the required "sub" claim.'
+    );
+  });
+});

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './validation';
 export * from './conversion';
 export * from './fetchWithTimeout';
+export * from './parseIdToken';
 export * from './scope';

--- a/src/core/utils/parseIdToken.ts
+++ b/src/core/utils/parseIdToken.ts
@@ -1,0 +1,27 @@
+import type { User } from '../../types';
+import { Auth0User } from '../models';
+
+/**
+ * Decodes a JWT ID token and returns a {@link User} object with standard OIDC
+ * profile claims (camelCased) and any custom claims present in the token.
+ *
+ * This provides the same user-parsing behavior that {@link Auth0Provider} uses
+ * internally, for consumers managing auth state directly via the {@link Auth0} class.
+ *
+ * @param idToken - A JWT ID token string (e.g. from `credentials.idToken`).
+ * @returns A parsed {@link User} containing profile and custom claims.
+ * @throws If the token is missing the required `sub` claim.
+ *
+ * @example
+ * ```typescript
+ * import Auth0, { parseIdToken } from 'react-native-auth0';
+ *
+ * const auth0 = new Auth0({ domain, clientId });
+ * const credentials = await auth0.webAuth.authorize({ scope: 'openid profile email' });
+ * const user = parseIdToken(credentials.idToken);
+ * // user.sub, user.name, user.email, etc.
+ * ```
+ */
+export function parseIdToken(idToken: string): User {
+  return Auth0User.fromIdToken(idToken);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
   MyAccountError,
 } from './core/models';
 export { TimeoutError } from './core/utils/fetchWithTimeout';
+export { parseIdToken } from './core/utils';
 export { TokenType } from './types/common';
 export { Auth0Provider } from './hooks/Auth0Provider';
 export { useAuth0 } from './hooks/useAuth0';


### PR DESCRIPTION
### Changes

Adds a public `parseIdToken(idToken: string): User` utility function that decodes a JWT ID token locally and returns a `User` object with standard OIDC profile claims (camelCased) and any custom claims.

This is a purely additive change — no existing functionality is modified. It introduces a new export only, so the risk surface is minimal.

- New function exported: `parseIdToken` (from `src/core/utils/parseIdToken.ts`)
- New public API entry in `src/index.ts`

**Usage:**

```typescript
import Auth0, { parseIdToken } from 'react-native-auth0';

const auth0 = new Auth0({ domain, clientId });
const credentials = await auth0.webAuth.authorize({ scope: 'openid profile email' });
const user = parseIdToken(credentials.idToken);
// user.sub, user.name, user.email, etc.
```

`Auth0Provider` already uses this parsing logic internally via `Auth0User.fromIdToken()`. This exposes the same behavior for consumers managing auth state directly via the `Auth0` class, without requiring a network round-trip to `/userinfo`.

### References

- #1536

### Testing

New unit tests in `src/core/utils/__tests__/parseIdToken.spec.ts` covering:
- Standard OIDC claims are decoded and camelCased
- Protocol claims (iss, aud, exp, etc.) are excluded
- Missing `sub` claim throws an error

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed

Closes #1536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public utility to parse an ID token locally and produce a user profile (standard OIDC claims and custom claims) without a network call.

* **Documentation**
  * Added Authentication API docs with examples showing how to parse user profiles from ID tokens.

* **Tests**
  * Added unit tests validating decoding behavior, required claim enforcement, and excluded protocol claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->