### PR TITLE
fix: support runtime tenant/domain switching with per-client credential isolation 

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -17,6 +17,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
 
   s.dependency 'Auth0', '2.21.2'
-  
+  s.dependency 'SimpleKeychain', '1.3.0'
+
   install_modules_dependencies(s)
 end

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1955,7 +1955,9 @@ const App = () => {
 
 After switching, the next `authorize()` call opens the login page for the newly selected tenant and the redirect resolves correctly, provided that tenant's domain/scheme was registered using the build-time configuration shown above.
 
-> Note: Switching tenants does not immediately clear the displayed auth state. The provider re-runs its initialization for the new tenant and updates `user` once that check completes, so the previously shown user may briefly remain until then. Persisted credentials are stored per tenant, so a user already logged in to the target tenant is restored on initialization; otherwise `user` becomes `null`.
+> Note: Switching tenants does not immediately clear the displayed auth state. The provider re-runs its initialization for the new tenant and updates `user` once that check completes, so the previously shown user may briefly remain until then.
+
+> **Important — credentials are shared across tenants by default.** The native credentials store (Android `SharedPreferences`, iOS Keychain) is **not** keyed by `domain`/`clientId`. With no extra configuration, every client reads and writes the **same** store, so after switching tenants `getCredentials()` / `hasValidCredentials()` return whatever was saved last — i.e. the _previous_ tenant's session — and a fresh login on the new tenant overwrites it. To give each tenant its own isolated store, set [`credentialsManagerStorageKey`](#isolating-credentials-per-tenant-credentialsmanagerstoragekey) (below).
 
 If you are using the `Auth0` class directly instead of the hooks, simply create (or reuse) an instance per tenant and call the one matching the active tenant:
 
@@ -1976,6 +1978,63 @@ const clients = {
 // Use whichever client corresponds to the active tenant.
 const credentials = await clients[activeTenant].webAuth.authorize();
 ```
+
+#### Isolating credentials per tenant (`credentialsManagerStorageKey`)
+
+By default all clients share a single native credentials store, so credentials from one tenant are visible to another after a switch (see the important note above). To keep each tenant's session separate, pass a unique `credentialsManagerStorageKey`. It maps to the **Android `SharedPreferences` file name** and the **iOS Keychain service**, so a distinct value gives that client its own physically separate store for `saveCredentials` / `getCredentials` / `hasValidCredentials` / `clearCredentials`.
+
+```jsx
+const TENANTS = [
+  // No key → uses the default shared store (keeps any existing logged-in user).
+  { domain: 'tenant-a.us.auth0.com', clientId: 'CLIENT_ID_A' },
+  // Distinct key → isolated store for this tenant.
+  {
+    domain: 'tenant-b.us.auth0.com',
+    clientId: 'CLIENT_ID_B',
+    credentialsManagerStorageKey: 'tenant-b',
+  },
+];
+
+// Hooks: pass it as a prop. Changing it rebuilds the client.
+<Auth0Provider
+  domain={tenant.domain}
+  clientId={tenant.clientId}
+  credentialsManagerStorageKey={tenant.credentialsManagerStorageKey}
+>
+  <LoginScreen />
+</Auth0Provider>;
+```
+
+```js
+// Auth0 class: pass it in the constructor options.
+const auth0 = new Auth0({
+  domain: 'tenant-b.us.auth0.com',
+  clientId: 'CLIENT_ID_B',
+  credentialsManagerStorageKey: 'tenant-b',
+});
+```
+
+With the keys above, logging in to Tenant A and switching to Tenant B no longer surfaces Tenant A's credentials, and each tenant's login persists independently. Switching back to Tenant A restores its session without re-login.
+
+**Recommended usage**
+
+- Leave the **primary/default** tenant **without** a key so existing installs keep using the store they already wrote to — those users are not logged out on upgrade.
+- Give every **additional** tenant a **unique, stable** key (e.g. the tenant slug or client ID).
+- Treat the key as permanent: it is the address of the store, not data inside it.
+
+**When does this make existing users log in again?**
+
+There is **no automatic migration** between stores — a client only ever reads the store its key points to. Changing which store a client uses therefore makes it start from an _empty_ store, requiring a fresh login:
+
+| Scenario                                                                                  | Existing logged-in user re-login required?                                                    |
+| ----------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Upgrade to this version, **no** `credentialsManagerStorageKey` set anywhere               | **No** — still the default shared store.                                                      |
+| Add a key to a client that previously had **none** (e.g. you now key your primary tenant) | **Yes** — its old session lives in the default store, which the keyed client no longer reads. |
+| **Change** an existing key to a different value                                           | **Yes** — points at a different (empty) store.                                                |
+| **Remove** a key that was previously set                                                  | **Yes** — falls back to the default store, not the keyed one.                                 |
+| Add a **new** tenant with its **own new** key (others unchanged)                          | **No** for the others; the new tenant simply starts logged out.                               |
+
+> Because changing or removing a key strands the credentials saved under the old key, choose each tenant's key once and keep it stable across releases. If you must change it, call `clearCredentials()` on the old configuration first (or accept that those credentials become orphaned in the old store).
 
 ## Allowed Browsers (Android)
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -145,7 +145,9 @@ If you already have credentials (e.g. from `webAuth.authorize()` or `credentials
 import Auth0, { parseIdToken } from 'react-native-auth0';
 
 const auth0 = new Auth0({ domain, clientId });
-const credentials = await auth0.webAuth.authorize({ scope: 'openid profile email' });
+const credentials = await auth0.webAuth.authorize({
+  scope: 'openid profile email',
+});
 const user = parseIdToken(credentials.idToken);
 // user.sub, user.name, user.email, etc.
 ```
@@ -1915,6 +1917,62 @@ If you want to support multiple domains, you would have to pass an array of obje
 ```
 
 You can skip sending the `customScheme` property if you do not want to customize it.
+
+#### Switching tenants at runtime
+
+The configuration above is **build-time** setup: it registers the redirect callback for every domain you intend to use. Switching the _active_ tenant while the app is running is done in JavaScript by changing the `domain`/`clientId` you pass to the SDK.
+
+When you change the `domain` or `clientId` prop on `Auth0Provider`, the provider rebuilds its underlying client so subsequent calls target the newly selected tenant. Keep the props in state and update them to switch:
+
+```jsx
+import React, { useState } from 'react';
+import { Auth0Provider, useAuth0 } from 'react-native-auth0';
+
+const TENANTS = [
+  { domain: 'tenant-a.us.auth0.com', clientId: 'CLIENT_ID_A' },
+  { domain: 'tenant-b.us.auth0.com', clientId: 'CLIENT_ID_B' },
+];
+
+const App = () => {
+  const [index, setIndex] = useState(0);
+  const tenant = TENANTS[index];
+
+  return (
+    // Changing domain/clientId recreates the client for the new tenant.
+    <Auth0Provider domain={tenant.domain} clientId={tenant.clientId}>
+      <Button
+        title="Switch Tenant"
+        onPress={() => setIndex((i) => (i + 1) % TENANTS.length)}
+      />
+      <LoginScreen />
+    </Auth0Provider>
+  );
+};
+```
+
+After switching, the next `authorize()` call opens the login page for the newly selected tenant and the redirect resolves correctly, provided that tenant's domain/scheme was registered using the build-time configuration shown above.
+
+> Note: Switching tenants does not immediately clear the displayed auth state. The provider re-runs its initialization for the new tenant and updates `user` once that check completes, so the previously shown user may briefly remain until then. Persisted credentials are stored per tenant, so a user already logged in to the target tenant is restored on initialization; otherwise `user` becomes `null`.
+
+If you are using the `Auth0` class directly instead of the hooks, simply create (or reuse) an instance per tenant and call the one matching the active tenant:
+
+```js
+import Auth0 from 'react-native-auth0';
+
+const clients = {
+  tenantA: new Auth0({
+    domain: 'tenant-a.us.auth0.com',
+    clientId: 'CLIENT_ID_A',
+  }),
+  tenantB: new Auth0({
+    domain: 'tenant-b.us.auth0.com',
+    clientId: 'CLIENT_ID_B',
+  }),
+};
+
+// Use whichever client corresponds to the active tenant.
+const credentials = await clients[activeTenant].webAuth.authorize();
+```
 
 ## Allowed Browsers (Android)
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1956,7 +1956,7 @@ const App = () => {
 After switching, the next `authorize()` call opens the login page for the newly selected tenant and the redirect resolves correctly, provided that tenant's domain/scheme was registered using the build-time configuration shown above.
 
 > Note: Switching tenants does not immediately clear the displayed auth state. The provider re-runs its initialization for the new tenant and updates `user` once that check completes, so the previously shown user may briefly remain until then.
-
+>
 > **Important — credentials are shared across tenants by default.** The native credentials store (Android `SharedPreferences`, iOS Keychain) is **not** keyed by `domain`/`clientId`. With no extra configuration, every client reads and writes the **same** store, so after switching tenants `getCredentials()` / `hasValidCredentials()` return whatever was saved last — i.e. the _previous_ tenant's session — and a fresh login on the new tenant overwrites it. To give each tenant its own isolated store, set [`credentialsManagerStorageKey`](#isolating-credentials-per-tenant-credentialsmanagerstoragekey) (below).
 
 If you are using the `Auth0` class directly instead of the hooks, simply create (or reuse) an instance per tenant and call the one matching the active tenant:

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1925,7 +1925,7 @@ You can skip sending the `customScheme` property if you do not want to customize
 
 The configuration above is **build-time** setup: it registers the redirect callback for every domain you intend to use. Switching the _active_ tenant while the app is running is done in JavaScript by changing the `domain`/`clientId` you pass to the SDK.
 
-When you change the `domain` or `clientId` prop on `Auth0Provider`, the provider rebuilds its underlying client so subsequent calls target the newly selected tenant. Keep the props in state and update them to switch:
+When you change an identity-defining prop on `Auth0Provider` — `domain`, `clientId`, `localAuthenticationOptions`, `timeout`, or `useDPoP` — the provider rebuilds its underlying client so subsequent calls target the newly selected configuration. An unchanged config (or a change limited to options like `headers` or `maxRetries`) reuses the same client instance. Keep the props in state and update them to switch:
 
 ```jsx
 import React, { useState } from 'react';

--- a/android/src/main/java/com/auth0/react/A0Auth0Module.kt
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.kt
@@ -305,7 +305,8 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
                     secureCredentialsManager = getSecureCredentialsManagerWithoutBiometrics(authAPI, storage)
                     promise.reject(
                         BIOMETRICS_AUTHENTICATION_ERROR_CODE,
-                        "Failed to parse the Local Authentication Options, hence proceeding without Biometrics Authentication for handling Credentials"
+                        "Failed to parse the Local Authentication Options, hence proceeding without Biometrics Authentication for handling Credentials",
+                        e
                     )
                     return
                 }

--- a/android/src/main/java/com/auth0/react/A0Auth0Module.kt
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.kt
@@ -269,12 +269,13 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
         localAuthenticationOptions: ReadableMap?,
         useDPoP: Boolean?,
         maxRetries: Double,
+        credentialsManagerStorageKey: String?,
         promise: Promise
     ) {
         // Note: maxRetries parameter is ignored on Android as the Auth0.Android SDK
         // does not currently support retry configuration for credential renewal.
         // This parameter is accepted for API compatibility with iOS.
-        
+
         this.useDPoP = useDPoP ?: true
         auth0 = Auth0.getInstance(clientId, domain)
         myAccount = MyAccount(auth0!!, this.useDPoP, reactContext)
@@ -283,7 +284,8 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
         if (this.useDPoP) {
             authAPI.useDPoP(reactContext)
         }
-        
+        val storage = buildStorage(credentialsManagerStorageKey)
+
         localAuthenticationOptions?.let { options ->
             val activity = reactContext.currentActivity
             if (activity is FragmentActivity) {
@@ -293,14 +295,14 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
                         authAPI,
                         reactContext,
                         auth0!!,
-                        SharedPreferencesStorage(reactContext),
+                        storage,
                         activity,
                         localAuthOptions
                     )
                     promise.resolve(true)
                     return
                 } catch (e: Exception) {
-                    secureCredentialsManager = getSecureCredentialsManagerWithoutBiometrics(authAPI)
+                    secureCredentialsManager = getSecureCredentialsManagerWithoutBiometrics(authAPI, storage)
                     promise.reject(
                         BIOMETRICS_AUTHENTICATION_ERROR_CODE,
                         "Failed to parse the Local Authentication Options, hence proceeding without Biometrics Authentication for handling Credentials"
@@ -308,7 +310,7 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
                     return
                 }
             } else {
-                secureCredentialsManager = getSecureCredentialsManagerWithoutBiometrics(authAPI)
+                secureCredentialsManager = getSecureCredentialsManagerWithoutBiometrics(authAPI, storage)
                 promise.reject(
                     BIOMETRICS_AUTHENTICATION_ERROR_CODE,
                     "Biometrics Authentication for Handling Credentials are supported only on FragmentActivity, since a different activity is supplied, proceeding without it"
@@ -316,10 +318,17 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
                 return
             }
         }
-        
-        secureCredentialsManager = getSecureCredentialsManagerWithoutBiometrics(authAPI)
+
+        secureCredentialsManager = getSecureCredentialsManagerWithoutBiometrics(authAPI, storage)
         promise.resolve(true)
     }
+
+    // Use a per-client SharedPreferences file when a storage key is provided, else the library default shared store.
+    private fun buildStorage(credentialsManagerStorageKey: String?): SharedPreferencesStorage =
+        if (credentialsManagerStorageKey.isNullOrEmpty())
+            SharedPreferencesStorage(reactContext)
+        else
+            SharedPreferencesStorage(reactContext, credentialsManagerStorageKey)
 
     @ReactMethod
     override fun hasValidAuth0InstanceWithConfiguration(clientId: String, domain: String, promise: Promise) {
@@ -928,12 +937,15 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
         promise.resolve(true)
     }
 
-    private fun getSecureCredentialsManagerWithoutBiometrics(authAPI: AuthenticationAPIClient): SecureCredentialsManager {
+    private fun getSecureCredentialsManagerWithoutBiometrics(
+        authAPI: AuthenticationAPIClient,
+        storage: SharedPreferencesStorage
+    ): SecureCredentialsManager {
         return SecureCredentialsManager(
             authAPI,
             reactContext,
             auth0!!,
-            SharedPreferencesStorage(reactContext)
+            storage
         )
     }
 

--- a/android/src/main/oldarch/com/auth0/react/A0Auth0Spec.kt
+++ b/android/src/main/oldarch/com/auth0/react/A0Auth0Spec.kt
@@ -28,6 +28,7 @@ abstract class A0Auth0Spec(context: ReactApplicationContext) : ReactContextBaseJ
         localAuthenticationOptions: ReadableMap?,
         useDPoP: Boolean?,
         maxRetries: Double,
+        credentialsManagerStorageKey: String?,
         promise: Promise
     )
 

--- a/example/ios/Auth0Example.xcodeproj/project.pbxproj
+++ b/example/ios/Auth0Example.xcodeproj/project.pbxproj
@@ -417,6 +417,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0example;
 				PRODUCT_NAME = Auth0Example;
+				SWIFT_OBJC_BRIDGING_HEADER = "Auth0Example/Auth0Example-Bridging-Header.h";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -445,6 +446,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0example;
 				PRODUCT_NAME = Auth0Example;
+				SWIFT_OBJC_BRIDGING_HEADER = "Auth0Example/Auth0Example-Bridging-Header.h";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - A0Auth0 (5.6.0):
+  - A0Auth0 (5.7.0):
     - Auth0 (= 2.21.2)
     - hermes-engine
     - RCTRequired
@@ -2197,7 +2197,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  A0Auth0: 7017e8ccdeda46385612e0b9ab231d81de53d128
+  A0Auth0: 607c4269584a26bac8cc81dda180427306352d89
   Auth0: e15bc9c1e39a53efc8853d16460b9be409d5346f
   FBLazyVector: e97c19a5a442429d1988f182a1940fb08df514da
   hermes-engine: 5a6d36f29e9659a4242ae9acfdaafa16c394a162

--- a/ios/A0Auth0.mm
+++ b/ios/A0Auth0.mm
@@ -100,9 +100,10 @@ RCT_EXPORT_METHOD(initializeAuth0WithConfiguration:(NSString *)clientId
               localAuthenticationOptions:(NSDictionary * _Nullable)localAuthenticationOptions
                                   useDPoP:(nonnull NSNumber *)useDPoP
                                maxRetries:(double)maxRetries
+            credentialsManagerStorageKey:(NSString * _Nullable)credentialsManagerStorageKey
                                  resolve:(RCTPromiseResolveBlock)resolve
                                   reject:(RCTPromiseRejectBlock)reject) {
-    [self tryAndInitializeNativeBridge:clientId domain:domain withLocalAuthenticationOptions:localAuthenticationOptions useDPoP:useDPoP maxRetries:(NSInteger)maxRetries resolve:resolve reject:reject];
+    [self tryAndInitializeNativeBridge:clientId domain:domain withLocalAuthenticationOptions:localAuthenticationOptions useDPoP:useDPoP maxRetries:(NSInteger)maxRetries credentialsManagerStorageKey:credentialsManagerStorageKey resolve:resolve reject:reject];
 }
 
 
@@ -344,9 +345,9 @@ UIBackgroundTaskIdentifier taskId;
     return valid;
 }
 
-- (void)tryAndInitializeNativeBridge:(NSString *)clientId domain:(NSString *)domain withLocalAuthenticationOptions:(NSDictionary*) options useDPoP:(NSNumber *)useDPoP maxRetries:(NSInteger)maxRetries resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+- (void)tryAndInitializeNativeBridge:(NSString *)clientId domain:(NSString *)domain withLocalAuthenticationOptions:(NSDictionary*) options useDPoP:(NSNumber *)useDPoP maxRetries:(NSInteger)maxRetries credentialsManagerStorageKey:(NSString * _Nullable)credentialsManagerStorageKey resolve:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
     BOOL useDPoPBool = [useDPoP boolValue];
-    NativeBridge *bridge = [[NativeBridge alloc] initWithClientId:clientId domain:domain localAuthenticationOptions:options useDPoP:useDPoPBool maxRetries:maxRetries resolve:resolve reject:reject];
+    NativeBridge *bridge = [[NativeBridge alloc] initWithClientId:clientId domain:domain localAuthenticationOptions:options useDPoP:useDPoPBool maxRetries:maxRetries credentialsManagerStorageKey:credentialsManagerStorageKey resolve:resolve reject:reject];
     self.nativeBridge = bridge;
     self.myAccount = [[A0MyAccount alloc] initWithDomain:domain useDPoP:useDPoPBool];
 }

--- a/ios/NativeBridge.swift
+++ b/ios/NativeBridge.swift
@@ -10,6 +10,7 @@ import Auth0
 import AuthenticationServices
 import Foundation
 import LocalAuthentication
+import SimpleKeychain
 
 @objc
 public class NativeBridge: NSObject {
@@ -46,7 +47,7 @@ public class NativeBridge: NSObject {
     var useDPoP: Bool
     var maxRetries: Int
     
-    @objc public init(clientId: String, domain: String, localAuthenticationOptions: [String: Any]?, useDPoP: Bool, maxRetries: Int, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+    @objc public init(clientId: String, domain: String, localAuthenticationOptions: [String: Any]?, useDPoP: Bool, maxRetries: Int, credentialsManagerStorageKey: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         var auth0 = Auth0
             .authentication(clientId: clientId, domain: domain)
         self.clientId = clientId
@@ -56,7 +57,12 @@ public class NativeBridge: NSObject {
         if self.useDPoP {
             auth0 = auth0.useDPoP()
         }
-        self.credentialsManager = CredentialsManager(authentication: auth0, maxRetries: maxRetries)
+        // Namespace the keychain per client when a storage key is provided, else use the default service.
+        if let key = credentialsManagerStorageKey, !key.isEmpty {
+            self.credentialsManager = CredentialsManager(authentication: auth0, storage: SimpleKeychain(service: key), maxRetries: maxRetries)
+        } else {
+            self.credentialsManager = CredentialsManager(authentication: auth0, maxRetries: maxRetries)
+        }
         super.init()
         if let localAuthenticationOptions = localAuthenticationOptions {
             if let title = localAuthenticationOptions["title"] as? String {

--- a/src/core/utils/__tests__/configSignature.spec.ts
+++ b/src/core/utils/__tests__/configSignature.spec.ts
@@ -65,6 +65,14 @@ describe('getConfigSignature', () => {
     );
   });
 
+  it('differs when credentialsManagerStorageKey changes', () => {
+    expect(
+      getConfigSignature({ ...base, credentialsManagerStorageKey: 'a' })
+    ).not.toBe(
+      getConfigSignature({ ...base, credentialsManagerStorageKey: 'b' })
+    );
+  });
+
   it('is unaffected by headers (not part of client identity)', () => {
     expect(getConfigSignature({ ...base, headers: { A: '1' } })).toBe(
       getConfigSignature({ ...base, headers: { A: '2' } })

--- a/src/core/utils/__tests__/configSignature.spec.ts
+++ b/src/core/utils/__tests__/configSignature.spec.ts
@@ -1,0 +1,79 @@
+import { getConfigSignature } from '../configSignature';
+import type { Auth0Options } from '../../../types';
+
+describe('getConfigSignature', () => {
+  const base: Auth0Options = {
+    domain: 'my-tenant.auth0.com',
+    clientId: 'MyClientId123',
+  };
+
+  it('produces the same signature for identical configs', () => {
+    expect(getConfigSignature(base)).toBe(getConfigSignature({ ...base }));
+  });
+
+  it('is insensitive to top-level key order', () => {
+    const a = getConfigSignature({
+      domain: 'd',
+      clientId: 'c',
+    } as Auth0Options);
+    const b = getConfigSignature({
+      clientId: 'c',
+      domain: 'd',
+    } as Auth0Options);
+    expect(a).toBe(b);
+  });
+
+  it('is insensitive to nested object key order', () => {
+    const a = getConfigSignature({
+      ...base,
+      localAuthenticationOptions: {
+        title: 'A',
+        evaluationPolicy: 1,
+      } as Auth0Options['localAuthenticationOptions'],
+    });
+    const b = getConfigSignature({
+      ...base,
+      localAuthenticationOptions: {
+        evaluationPolicy: 1,
+        title: 'A',
+      } as Auth0Options['localAuthenticationOptions'],
+    });
+    expect(a).toBe(b);
+  });
+
+  it('differs when domain changes', () => {
+    expect(getConfigSignature(base)).not.toBe(
+      getConfigSignature({ ...base, domain: 'other.auth0.com' })
+    );
+  });
+
+  it('differs when clientId changes', () => {
+    expect(getConfigSignature(base)).not.toBe(
+      getConfigSignature({ ...base, clientId: 'Other' })
+    );
+  });
+
+  it('differs when useDPoP changes', () => {
+    expect(getConfigSignature({ ...base, useDPoP: true })).not.toBe(
+      getConfigSignature({ ...base, useDPoP: false })
+    );
+  });
+
+  it('differs when timeout changes', () => {
+    expect(getConfigSignature({ ...base, timeout: 1000 })).not.toBe(
+      getConfigSignature({ ...base, timeout: 2000 })
+    );
+  });
+
+  it('is unaffected by headers (not part of client identity)', () => {
+    expect(getConfigSignature({ ...base, headers: { A: '1' } })).toBe(
+      getConfigSignature({ ...base, headers: { A: '2' } })
+    );
+  });
+
+  it('is unaffected by maxRetries (not part of client identity)', () => {
+    expect(getConfigSignature({ ...base, maxRetries: 0 })).toBe(
+      getConfigSignature({ ...base, maxRetries: 3 })
+    );
+  });
+});

--- a/src/core/utils/__tests__/configSignature.spec.ts
+++ b/src/core/utils/__tests__/configSignature.spec.ts
@@ -79,8 +79,8 @@ describe('getConfigSignature', () => {
     );
   });
 
-  it('is unaffected by maxRetries (not part of client identity)', () => {
-    expect(getConfigSignature({ ...base, maxRetries: 0 })).toBe(
+  it('differs when maxRetries changes', () => {
+    expect(getConfigSignature({ ...base, maxRetries: 0 })).not.toBe(
       getConfigSignature({ ...base, maxRetries: 3 })
     );
   });

--- a/src/core/utils/configSignature.ts
+++ b/src/core/utils/configSignature.ts
@@ -1,0 +1,36 @@
+import type { Auth0Options } from '../../types';
+
+// Options that define client identity; changing any forces a fresh client and native re-init. Others (e.g. `headers`) reuse the existing client.
+const SIGNIFICANT_KEYS = [
+  'domain',
+  'clientId',
+  'localAuthenticationOptions',
+  'timeout',
+  'useDPoP',
+] as const satisfies ReadonlyArray<keyof Auth0Options>;
+
+// Stable, order-independent identity string for a config: keys the factory cache, the provider memo, and the native re-init decision. Object values are sorted so key order doesn't matter.
+export function getConfigSignature(options: Auth0Options): string {
+  const significant: Record<string, unknown> = {};
+  for (const key of SIGNIFICANT_KEYS) {
+    if (options[key] !== undefined) {
+      significant[key] = options[key];
+    }
+  }
+  return JSON.stringify(sortValue(significant));
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortValue);
+  }
+  if (value !== null && typeof value === 'object') {
+    return Object.keys(value as Record<string, unknown>)
+      .sort()
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortValue((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}

--- a/src/core/utils/configSignature.ts
+++ b/src/core/utils/configSignature.ts
@@ -7,6 +7,7 @@ const SIGNIFICANT_KEYS = [
   'localAuthenticationOptions',
   'timeout',
   'useDPoP',
+  'maxRetries',
   'credentialsManagerStorageKey',
 ] as const satisfies ReadonlyArray<keyof Auth0Options>;
 

--- a/src/core/utils/configSignature.ts
+++ b/src/core/utils/configSignature.ts
@@ -7,6 +7,7 @@ const SIGNIFICANT_KEYS = [
   'localAuthenticationOptions',
   'timeout',
   'useDPoP',
+  'credentialsManagerStorageKey',
 ] as const satisfies ReadonlyArray<keyof Auth0Options>;
 
 // Stable, order-independent identity string for a config: keys the factory cache, the provider memo, and the native re-init decision. Object values are sorted so key order doesn't matter.

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './validation';
+export * from './configSignature';
 export * from './conversion';
 export * from './fetchWithTimeout';
 export * from './parseIdToken';

--- a/src/factory/Auth0ClientFactory.ts
+++ b/src/factory/Auth0ClientFactory.ts
@@ -1,20 +1,15 @@
 import type { IAuth0Client } from '../core/interfaces';
 import type { Auth0Options } from '../types';
 import type { NativeAuth0Options } from '../types/platform-specific';
-import { validateAuth0Options } from '../core/utils';
+import { validateAuth0Options, getConfigSignature } from '../core/utils';
 
 // This file ONLY imports the Native client.
 import { NativeAuth0Client } from '../platforms/native';
 
 /**
- * A factory class responsible for creating the Native-specific
- * IAuth0Client instance. This file is automatically selected by the Metro
- * bundler during a build for iOS or Android.
- *
- * Instances are cached by domain+clientId so that React component
- * remounts (e.g., Auth0Provider unmount/remount) reuse the same
- * client and its in-flight state, preventing duplicate refresh token
- * exchanges.
+ * Creates the Native-specific IAuth0Client; selected by Metro for iOS/Android.
+ * Clients are cached by config signature so remounts reuse the same instance
+ * (avoiding duplicate refresh exchanges); a config change yields a fresh client.
  */
 export class Auth0ClientFactory {
   private static clientCache = new Map<string, IAuth0Client>();
@@ -28,7 +23,7 @@ export class Auth0ClientFactory {
   static createClient(options: Auth0Options): IAuth0Client {
     validateAuth0Options(options);
 
-    const cacheKey = `${options.domain}|${options.clientId}`;
+    const cacheKey = getConfigSignature(options);
     let client = Auth0ClientFactory.clientCache.get(cacheKey);
     if (!client) {
       client = new NativeAuth0Client(options as NativeAuth0Options);

--- a/src/factory/Auth0ClientFactory.web.ts
+++ b/src/factory/Auth0ClientFactory.web.ts
@@ -1,20 +1,15 @@
 import type { IAuth0Client } from '../core/interfaces';
 import type { Auth0Options } from '../types';
 import type { WebAuth0Options } from '../types/platform-specific';
-import { validateAuth0Options } from '../core/utils';
+import { validateAuth0Options, getConfigSignature } from '../core/utils';
 
 // This file ONLY imports the Web client.
 import { WebAuth0Client } from '../platforms/web';
 
 /**
- * A factory class responsible for creating the Web-specific
- * IAuth0Client instance. This file is automatically selected by bundlers
- * like Webpack when targeting the web.
- *
- * Instances are cached by domain+clientId so that React component
- * remounts (e.g., Auth0Provider unmount/remount) reuse the same
- * client and its in-flight state, preventing duplicate refresh token
- * exchanges.
+ * Creates the Web-specific IAuth0Client; selected by bundlers when targeting web.
+ * Clients are cached by config signature so remounts reuse the same instance
+ * (avoiding duplicate refresh exchanges); a config change yields a fresh client.
  */
 export class Auth0ClientFactory {
   private static clientCache = new Map<string, IAuth0Client>();
@@ -28,7 +23,7 @@ export class Auth0ClientFactory {
   static createClient(options: Auth0Options): IAuth0Client {
     validateAuth0Options(options);
 
-    const cacheKey = `${options.domain}|${options.clientId}`;
+    const cacheKey = getConfigSignature(options);
     let client = Auth0ClientFactory.clientCache.get(cacheKey);
     if (!client) {
       client = new WebAuth0Client(options as WebAuth0Options);

--- a/src/factory/__tests__/Auth0ClientFactory.spec.ts
+++ b/src/factory/__tests__/Auth0ClientFactory.spec.ts
@@ -54,6 +54,36 @@ describe('Auth0ClientFactory (Native)', () => {
     expect(MockNativeAuth0Client).toHaveBeenCalledTimes(2);
   });
 
+  it('should create separate clients when a non-domain/clientId option changes', () => {
+    const client1 = Auth0ClientFactory.createClient({
+      ...options,
+      useDPoP: true,
+    });
+    const client2 = Auth0ClientFactory.createClient({
+      ...options,
+      useDPoP: false,
+    });
+
+    expect(client1).not.toBe(client2);
+    expect(MockNativeAuth0Client).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reuse the cached client when config is identical regardless of key order', () => {
+    const client1 = Auth0ClientFactory.createClient({
+      domain: 'my-tenant.auth0.com',
+      clientId: 'MyClientId123',
+      headers: { A: '1', B: '2' },
+    });
+    const client2 = Auth0ClientFactory.createClient({
+      headers: { B: '2', A: '1' },
+      clientId: 'MyClientId123',
+      domain: 'my-tenant.auth0.com',
+    });
+
+    expect(client1).toBe(client2);
+    expect(MockNativeAuth0Client).toHaveBeenCalledTimes(1);
+  });
+
   it('should create a new client after cache is reset', () => {
     const client1 = Auth0ClientFactory.createClient(options);
     Auth0ClientFactory.resetClientCache();

--- a/src/hooks/Auth0Provider.tsx
+++ b/src/hooks/Auth0Provider.tsx
@@ -45,8 +45,18 @@ export const Auth0Provider = ({
   children,
   ...options
 }: PropsWithChildren<Auth0Options>) => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const client = useMemo(() => new Auth0(options), []);
+  // Recreate the client when the tenant configuration changes so that
+  // `domain`/`clientId` prop updates take effect (e.g. domain switching).
+  // The factory caches clients per domain|clientId, so unchanged configs
+  // still reuse the same underlying instance and its in-flight state.
+  const client = useMemo(
+    () => new Auth0(options),
+    // Intentionally key only on the tenant identity. `options` is a fresh
+    // object every render, so depending on it would recreate the client
+    // (and reset auth state) on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [options.domain, options.clientId]
+  );
   const [state, dispatch] = useReducer(reducer, {
     user: null,
     error: null,

--- a/src/hooks/Auth0Provider.tsx
+++ b/src/hooks/Auth0Provider.tsx
@@ -38,6 +38,7 @@ import type {
   NativeClearSessionOptions,
 } from '../types/platform-specific';
 import { Auth0User, AuthError } from '../core/models';
+import { getConfigSignature } from '../core/utils';
 import Auth0 from '../Auth0';
 import { Platform } from 'react-native';
 
@@ -45,17 +46,14 @@ export const Auth0Provider = ({
   children,
   ...options
 }: PropsWithChildren<Auth0Options>) => {
-  // Recreate the client when the tenant configuration changes so that
-  // `domain`/`clientId` prop updates take effect (e.g. domain switching).
-  // The factory caches clients per domain|clientId, so unchanged configs
-  // still reuse the same underlying instance and its in-flight state.
+  // Recreate the client when the config changes; the factory reuses the same
+  // instance for an unchanged signature.
+  const configSignature = getConfigSignature(options);
   const client = useMemo(
     () => new Auth0(options),
-    // Intentionally key only on the tenant identity. `options` is a fresh
-    // object every render, so depending on it would recreate the client
-    // (and reset auth state) on every render.
+    // Key on the signature, not `options` (a fresh object every render).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [options.domain, options.clientId]
+    [configSignature]
   );
   const [state, dispatch] = useReducer(reducer, {
     user: null,

--- a/src/platforms/native/adapters/NativeAuth0Client.ts
+++ b/src/platforms/native/adapters/NativeAuth0Client.ts
@@ -35,12 +35,15 @@ export class NativeAuth0Client implements IAuth0Client {
   private readonly tokenType: TokenType;
   private readonly bridge: INativeBridge;
   private readonly baseUrl: string;
+  private readonly options: NativeAuth0Options;
+  private syncLock: Promise<void> = Promise.resolve();
   private guardedBridge!: INativeBridge;
   private readonly getDPoPHeadersForOrchestrator?: (
     params: DPoPHeadersParams
   ) => Promise<Record<string, string>>;
 
   constructor(options: NativeAuth0Options) {
+    this.options = options;
     const baseUrl = `https://${options.domain}`;
     this.baseUrl = baseUrl;
     const useDPoP = options.useDPoP ?? true;
@@ -108,6 +111,25 @@ export class NativeAuth0Client implements IAuth0Client {
     }
   }
 
+  /**
+   * Re-points the native singleton at this client's configuration.
+   *
+   * The native module (iOS/Android) keeps a single active Auth0 instance, but
+   * the JS factory caches one client per domain|clientId. When multiple clients
+   * coexist (or a client is reused after another was initialized), the native
+   * instance may belong to a sibling client, so bridge calls would otherwise
+   * target the wrong domain/clientId. Re-initializing only happens when the
+   * native config has drifted, so the common single-client path stays a cheap
+   * `hasValidInstance` check. Serialized via `syncLock` to avoid interleaving
+   * re-initializations from concurrent calls.
+   */
+  private syncNativeConfig(): Promise<void> {
+    this.syncLock = this.syncLock
+      .catch(() => undefined)
+      .then(() => this.initialize(this.bridge, this.options));
+    return this.syncLock;
+  }
+
   users(token: string, tokenType?: TokenType): IUsersClient {
     // Use provided tokenType or fall back to client's default
     const effectiveTokenType = tokenType ?? this.tokenType;
@@ -165,6 +187,10 @@ export class NativeAuth0Client implements IAuth0Client {
       guarded[methodName] = async (...args: any[]) => {
         // This is the "guard": wait for the initialization promise to resolve.
         await this.ready;
+        // Re-point the native singleton at this client's config in case a
+        // sibling client (different domain/clientId) overwrote it. No-op when
+        // the native instance already matches.
+        await this.syncNativeConfig();
         // Call the original method with the correct 'this' context.
         return originalMethod.apply(bridge, args);
       };

--- a/src/platforms/native/adapters/NativeAuth0Client.ts
+++ b/src/platforms/native/adapters/NativeAuth0Client.ts
@@ -106,6 +106,7 @@ export class NativeAuth0Client implements IAuth0Client {
       localAuthenticationOptions,
       useDPoP = true,
       maxRetries,
+      credentialsManagerStorageKey,
     } = options;
     // Re-init when domain/clientId differ (hasValidInstance) or any other
     // identity option drifted from what was last applied to the native side.
@@ -121,7 +122,8 @@ export class NativeAuth0Client implements IAuth0Client {
         domain,
         localAuthenticationOptions,
         useDPoP,
-        maxRetries
+        maxRetries,
+        credentialsManagerStorageKey
       );
     }
     // Record even on the skip path so siblings differing only in a

--- a/src/platforms/native/adapters/NativeAuth0Client.ts
+++ b/src/platforms/native/adapters/NativeAuth0Client.ts
@@ -25,6 +25,7 @@ import {
 import { HttpClient } from '../../../core/services/HttpClient';
 import { TokenType } from '../../../types/common';
 import { AuthError, DPoPError, PasskeyError } from '../../../core/models';
+import { getConfigSignature } from '../../../core/utils';
 
 export class NativeAuth0Client implements IAuth0Client {
   readonly webAuth: NativeWebAuthProvider;
@@ -36,14 +37,21 @@ export class NativeAuth0Client implements IAuth0Client {
   private readonly bridge: INativeBridge;
   private readonly baseUrl: string;
   private readonly options: NativeAuth0Options;
+  private readonly configSignature: string;
   private syncLock: Promise<void> = Promise.resolve();
   private guardedBridge!: INativeBridge;
   private readonly getDPoPHeadersForOrchestrator?: (
     params: DPoPHeadersParams
   ) => Promise<Record<string, string>>;
 
+  // Signature last applied to the shared native singleton. `hasValidInstance`
+  // only checks domain/clientId, so this tracks other identity options
+  // (useDPoP, localAuthenticationOptions) to detect drift and re-init.
+  private static appliedNativeSignature: string | null = null;
+
   constructor(options: NativeAuth0Options) {
     this.options = options;
+    this.configSignature = getConfigSignature(options);
     const baseUrl = `https://${options.domain}`;
     this.baseUrl = baseUrl;
     const useDPoP = options.useDPoP ?? true;
@@ -99,8 +107,15 @@ export class NativeAuth0Client implements IAuth0Client {
       useDPoP = true,
       maxRetries,
     } = options;
+    // Re-init when domain/clientId differ (hasValidInstance) or any other
+    // identity option drifted from what was last applied to the native side.
     const hasValidInstance = await bridge.hasValidInstance(clientId, domain);
-    if (!hasValidInstance) {
+    // Null signature means nothing applied yet, so defer to hasValidInstance
+    // and let genuine remounts reuse the existing native instance.
+    const signatureDrifted =
+      NativeAuth0Client.appliedNativeSignature !== null &&
+      NativeAuth0Client.appliedNativeSignature !== this.configSignature;
+    if (!hasValidInstance || signatureDrifted) {
       await bridge.initialize(
         clientId,
         domain,
@@ -109,20 +124,14 @@ export class NativeAuth0Client implements IAuth0Client {
         maxRetries
       );
     }
+    // Record even on the skip path so siblings differing only in a
+    // native-invisible option (e.g. useDPoP) can detect drift.
+    NativeAuth0Client.appliedNativeSignature = this.configSignature;
   }
 
-  /**
-   * Re-points the native singleton at this client's configuration.
-   *
-   * The native module (iOS/Android) keeps a single active Auth0 instance, but
-   * the JS factory caches one client per domain|clientId. When multiple clients
-   * coexist (or a client is reused after another was initialized), the native
-   * instance may belong to a sibling client, so bridge calls would otherwise
-   * target the wrong domain/clientId. Re-initializing only happens when the
-   * native config has drifted, so the common single-client path stays a cheap
-   * `hasValidInstance` check. Serialized via `syncLock` to avoid interleaving
-   * re-initializations from concurrent calls.
-   */
+  // Re-points the shared native singleton at this client's config before a
+  // bridge call, in case a sibling client overwrote it. Re-init only on drift,
+  // so the single-client path stays cheap. Serialized via syncLock.
   private syncNativeConfig(): Promise<void> {
     this.syncLock = this.syncLock
       .catch(() => undefined)

--- a/src/platforms/native/adapters/__tests__/NativeAuth0Client.spec.ts
+++ b/src/platforms/native/adapters/__tests__/NativeAuth0Client.spec.ts
@@ -22,6 +22,10 @@ describe('NativeAuth0Client', () => {
     // Reset mocks for each test
     jest.clearAllMocks();
 
+    // Reset the cross-instance static that tracks the config last applied to
+    // the shared native singleton, so tests don't leak state into each other.
+    (NativeAuth0Client as any).appliedNativeSignature = null;
+
     // Create the mock functions that can be shared and overridden
     const mockMethods = {
       hasValidInstance: jest.fn().mockResolvedValue(true),
@@ -601,6 +605,56 @@ describe('NativeAuth0Client', () => {
       await client.webAuth.authorize();
 
       // No re-initialization needed; the common single-client path stays cheap.
+      expect(mockBridgeInstance.initialize).not.toHaveBeenCalled();
+      expect(mockBridgeInstance.authorize).toHaveBeenCalledTimes(1);
+    });
+
+    it('re-initializes when a non-domain/clientId option changed, even if hasValidInstance reports valid', async () => {
+      // hasValidInstance only compares domain/clientId, so it reports `true`
+      // here. A sibling client with the SAME domain/clientId but a different
+      // `useDPoP` previously applied its config to the native singleton.
+      mockBridgeInstance.hasValidInstance.mockResolvedValue(true);
+
+      // First client (DPoP enabled) applies its signature to the native side.
+      const first = new NativeAuth0Client({ ...options, useDPoP: true });
+      await new Promise(process.nextTick);
+      await first.webAuth.authorize();
+      mockBridgeInstance.initialize.mockClear();
+
+      // Second client shares domain/clientId but flips useDPoP. Despite
+      // hasValidInstance being true, the changed signature must force a re-init
+      // so the native module reflects the new configuration.
+      const second = new NativeAuth0Client({ ...options, useDPoP: false });
+      await new Promise(process.nextTick);
+      await second.webAuth.authorize();
+
+      expect(mockBridgeInstance.initialize).toHaveBeenCalled();
+      expect(mockBridgeInstance.initialize).toHaveBeenLastCalledWith(
+        options.clientId,
+        options.domain,
+        undefined,
+        false, // useDPoP flipped to false
+        undefined
+      );
+    });
+
+    it('does NOT re-initialize a remounted client with an identical config', async () => {
+      // hasValidInstance returns true (native instance already exists from a
+      // prior mount), and the signature matches because the config is unchanged.
+      mockBridgeInstance.hasValidInstance.mockResolvedValue(true);
+
+      // Simulate a previous client of the same config having applied to native.
+      const first = new NativeAuth0Client(options);
+      await new Promise(process.nextTick);
+      await first.webAuth.authorize();
+      mockBridgeInstance.initialize.mockClear();
+      mockBridgeInstance.authorize.mockClear();
+
+      // A remount with an identical config must reuse the native instance.
+      const second = new NativeAuth0Client(options);
+      await new Promise(process.nextTick);
+      await second.webAuth.authorize();
+
       expect(mockBridgeInstance.initialize).not.toHaveBeenCalled();
       expect(mockBridgeInstance.authorize).toHaveBeenCalledTimes(1);
     });

--- a/src/platforms/native/adapters/__tests__/NativeAuth0Client.spec.ts
+++ b/src/platforms/native/adapters/__tests__/NativeAuth0Client.spec.ts
@@ -24,7 +24,11 @@ describe('NativeAuth0Client', () => {
 
     // Reset the cross-instance static that tracks the config last applied to
     // the shared native singleton, so tests don't leak state into each other.
-    (NativeAuth0Client as any).appliedNativeSignature = null;
+    (
+      NativeAuth0Client as unknown as {
+        appliedNativeSignature: string | null;
+      }
+    ).appliedNativeSignature = null;
 
     // Create the mock functions that can be shared and overridden
     const mockMethods = {

--- a/src/platforms/native/adapters/__tests__/NativeAuth0Client.spec.ts
+++ b/src/platforms/native/adapters/__tests__/NativeAuth0Client.spec.ts
@@ -560,4 +560,49 @@ describe('NativeAuth0Client', () => {
       ).rejects.toBeInstanceOf(PasskeyError);
     });
   });
+
+  describe('native config re-sync (multi-tenant)', () => {
+    it('re-points the native singleton when its config has drifted to a sibling client', async () => {
+      // Simulate the native singleton currently belonging to a different
+      // domain/clientId (overwritten by a sibling Auth0 instance).
+      mockBridgeInstance.hasValidInstance.mockResolvedValue(false);
+
+      const client = new NativeAuth0Client(options);
+      await new Promise(process.nextTick);
+
+      // Constructor initialization re-pointed the native side once.
+      expect(mockBridgeInstance.initialize).toHaveBeenCalledTimes(1);
+      const initCallsAfterConstruct =
+        mockBridgeInstance.initialize.mock.calls.length;
+
+      await client.webAuth.authorize();
+
+      // The guarded path re-asserts this client's config before dispatching to
+      // the native module, so a drifted singleton gets re-initialized to the
+      // correct tenant rather than authorizing against the wrong domain.
+      expect(mockBridgeInstance.initialize.mock.calls.length).toBeGreaterThan(
+        initCallsAfterConstruct
+      );
+      expect(mockBridgeInstance.initialize).toHaveBeenLastCalledWith(
+        options.clientId,
+        options.domain,
+        undefined,
+        true,
+        undefined
+      );
+      expect(mockBridgeInstance.authorize).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT re-initialize when the native singleton already matches', async () => {
+      // Default mock: hasValidInstance returns true (native already matches).
+      const client = new NativeAuth0Client(options);
+      await new Promise(process.nextTick);
+
+      await client.webAuth.authorize();
+
+      // No re-initialization needed; the common single-client path stays cheap.
+      expect(mockBridgeInstance.initialize).not.toHaveBeenCalled();
+      expect(mockBridgeInstance.authorize).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/platforms/native/adapters/__tests__/NativeAuth0Client.spec.ts
+++ b/src/platforms/native/adapters/__tests__/NativeAuth0Client.spec.ts
@@ -115,10 +115,31 @@ describe('NativeAuth0Client', () => {
       options.domain,
       undefined, // No local auth options provided in this test
       true, // useDPoP defaults to true
-      undefined // maxRetries not provided
+      undefined, // maxRetries not provided
+      undefined // credentialsManagerStorageKey not provided
     );
 
     // Use client to avoid unused variable warning
+    expect(client).toBeDefined();
+  });
+
+  it('should pass credentialsManagerStorageKey to initialize when provided', async () => {
+    mockBridgeInstance.hasValidInstance.mockResolvedValue(false);
+
+    const client = new NativeAuth0Client({
+      ...options,
+      credentialsManagerStorageKey: 'tenant-b',
+    });
+    await new Promise(process.nextTick);
+
+    expect(mockBridgeInstance.initialize).toHaveBeenCalledWith(
+      options.clientId,
+      options.domain,
+      undefined,
+      true,
+      undefined,
+      'tenant-b'
+    );
     expect(client).toBeDefined();
   });
 
@@ -137,7 +158,8 @@ describe('NativeAuth0Client', () => {
       options.domain,
       localAuthOptions,
       true, // useDPoP defaults to true
-      undefined // maxRetries not provided
+      undefined, // maxRetries not provided
+      undefined // credentialsManagerStorageKey not provided
     );
 
     // Use client to avoid unused variable warning
@@ -592,6 +614,7 @@ describe('NativeAuth0Client', () => {
         options.domain,
         undefined,
         true,
+        undefined,
         undefined
       );
       expect(mockBridgeInstance.authorize).toHaveBeenCalledTimes(1);
@@ -634,6 +657,7 @@ describe('NativeAuth0Client', () => {
         options.domain,
         undefined,
         false, // useDPoP flipped to false
+        undefined,
         undefined
       );
     });

--- a/src/platforms/native/bridge/INativeBridge.ts
+++ b/src/platforms/native/bridge/INativeBridge.ts
@@ -35,7 +35,7 @@ export interface INativeBridge {
    * @param localAuthenticationOptions Options for local authentication.
    * @param useDPoP Whether to enable DPoP (Demonstrating Proof-of-Possession) for token requests.
    * @param maxRetries The maximum number of retry attempts for transient errors during credential renewal. **iOS only** - ignored on Android. Defaults to 0.
-   * @param credentialsManagerStorageKey Namespaces the credentials store (Android SharedPreferences name / iOS keychain service). Defaults to the shared store when omitted.
+   * @param credentialsManagerStorageKey Namespaces the credentials store. **Android only** SharedPreferences file name. **iOS only** Keychain service name. Defaults to the shared store when omitted.
    */
   initialize(
     clientId: string,

--- a/src/platforms/native/bridge/INativeBridge.ts
+++ b/src/platforms/native/bridge/INativeBridge.ts
@@ -35,13 +35,15 @@ export interface INativeBridge {
    * @param localAuthenticationOptions Options for local authentication.
    * @param useDPoP Whether to enable DPoP (Demonstrating Proof-of-Possession) for token requests.
    * @param maxRetries The maximum number of retry attempts for transient errors during credential renewal. **iOS only** - ignored on Android. Defaults to 0.
+   * @param credentialsManagerStorageKey Namespaces the credentials store (Android SharedPreferences name / iOS keychain service). Defaults to the shared store when omitted.
    */
   initialize(
     clientId: string,
     domain: string,
     localAuthenticationOptions?: LocalAuthenticationOptions,
     useDPoP?: boolean,
-    maxRetries?: number
+    maxRetries?: number,
+    credentialsManagerStorageKey?: string
   ): Promise<void>;
 
   /**

--- a/src/platforms/native/bridge/NativeBridgeManager.ts
+++ b/src/platforms/native/bridge/NativeBridgeManager.ts
@@ -56,7 +56,8 @@ export class NativeBridgeManager implements INativeBridge {
     domain: string,
     localAuthenticationOptions?: LocalAuthenticationOptions,
     useDPoP: boolean = true,
-    maxRetries: number = 0
+    maxRetries: number = 0,
+    credentialsManagerStorageKey?: string
   ): Promise<void> {
     // This is a new method we'd add to the native side to ensure the
     // underlying Auth0.swift/Auth0.android SDKs are configured.
@@ -68,7 +69,8 @@ export class NativeBridgeManager implements INativeBridge {
       domain,
       localAuthenticationOptions,
       useDPoP,
-      maxRetries
+      maxRetries,
+      credentialsManagerStorageKey
     );
   }
 

--- a/src/platforms/native/bridge/__tests__/NativeBridgeManager.spec.ts
+++ b/src/platforms/native/bridge/__tests__/NativeBridgeManager.spec.ts
@@ -174,6 +174,64 @@ describe('NativeBridgeManager', () => {
     });
   });
 
+  describe('initialize', () => {
+    // The native init call builds the credentials manager; the storage key
+    // namespaces its store. No native test harness exists, so we assert the
+    // key threads through here.
+    it('forwards credentialsManagerStorageKey to the native module when provided', async () => {
+      const localAuthenticationOptions = undefined;
+
+      await bridge.initialize(
+        'client-id',
+        'tenant-b.auth0.com',
+        localAuthenticationOptions,
+        true,
+        0,
+        'tenant-b'
+      );
+
+      expect(
+        MockedAuth0NativeModule.initializeAuth0WithConfiguration
+      ).toHaveBeenCalledTimes(1);
+      expect(
+        MockedAuth0NativeModule.initializeAuth0WithConfiguration
+      ).toHaveBeenCalledWith(
+        'client-id',
+        'tenant-b.auth0.com',
+        undefined,
+        true,
+        0,
+        'tenant-b'
+      );
+    });
+
+    it('forwards undefined for credentialsManagerStorageKey when omitted (shared default store)', async () => {
+      await bridge.initialize('client-id', 'tenant-a.auth0.com');
+
+      expect(
+        MockedAuth0NativeModule.initializeAuth0WithConfiguration
+      ).toHaveBeenCalledWith(
+        'client-id',
+        'tenant-a.auth0.com',
+        undefined, // localAuthenticationOptions
+        true, // useDPoP default
+        0, // maxRetries default
+        undefined // credentialsManagerStorageKey
+      );
+    });
+
+    it('wraps a native initialization error in an AuthError', async () => {
+      const nativeError = { code: 'a0.initialize.failed', message: 'boom' };
+      MockedAuth0NativeModule.initializeAuth0WithConfiguration.mockRejectedValueOnce(
+        nativeError
+      );
+
+      await expect(
+        bridge.initialize('client-id', 'tenant-b.auth0.com')
+      ).rejects.toBeInstanceOf(AuthError);
+    });
+  });
+
   describe('clearSession', () => {
     it('should call the native webAuthLogout method with all parameters', async () => {
       const parameters = { federated: true, returnToUrl: 'com.myapp://logout' };

--- a/src/specs/NativeA0Auth0.ts
+++ b/src/specs/NativeA0Auth0.ts
@@ -26,7 +26,8 @@ export interface Spec extends TurboModule {
       | { [key: string]: string | Int32 | boolean }
       | undefined,
     useDPoP: boolean | undefined,
-    maxRetries: Int32
+    maxRetries: Int32,
+    credentialsManagerStorageKey: string | undefined
   ): Promise<void>;
 
   /**

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -164,6 +164,14 @@ export interface Auth0Options {
    * @default 0 (no retries)
    */
   maxRetries?: number;
+  /**
+   * Namespaces this client's credentials store. Maps to the Android
+   * SharedPreferences file name and the iOS keychain service. Omit it for the
+   * primary client to keep the default shared store; set a distinct value per
+   * additional client (e.g. another tenant) to isolate its credentials so
+   * switching clients does not surface or evict another's session.
+   */
+  credentialsManagerStorageKey?: string;
   // Telemetry and localAuthenticationOptions are platform-specific extensions
 }
 

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -170,6 +170,7 @@ export interface Auth0Options {
    * primary client to keep the default shared store; set a distinct value per
    * additional client (e.g. another tenant) to isolate its credentials so
    * switching clients does not surface or evict another's session.
+   * @remarks Native only (iOS/Android). Has no effect on the web platform.
    */
   credentialsManagerStorageKey?: string;
   // Telemetry and localAuthenticationOptions are platform-specific extensions


### PR DESCRIPTION
## Summary
                                                                                                                                               
  Fixes switching between Auth0 tenants (`domain`/`clientId`) at runtime. Previously, changing the `domain` or `clientId` did not take effect — calls kept targeting the original tenant — and all clients shared a single native credentials store, so one tenant's session could surface for another.                                                                                                                               
                                                                                                                                               
  - **#1520:** Updating `domain`/`clientId` on `Auth0Provider` now correctly switches the active tenant.            
  - **#1523:** Using multiple `Auth0` clients (or reusing one after switching) now routes each call to the right tenant.                       
                                                                                                                        
  ## Credential isolation                                                                                                                      
                                                                                                                    
  Adds an optional `credentialsManagerStorageKey` to `Auth0Options`. When set, it namespaces the native credentials store — the Android SharedPreferences file name and the iOS Keychain service — so each client/tenant gets an isolated store instead of sharing one.              
                                                                                                                                 
  - Omit it (default) → unchanged behavior; existing logged-in users keep their session on upgrade.                                            
  - Set a unique value per additional tenant → isolated credentials; switching tenants no longer surfaces another tenant's session.            
                                                                                                                                   
  Available via both the `Auth0Provider` prop and the `Auth0` class constructor. Works on bare React Native and Expo.                          
                                                                                                                                               
  ## ⚠️  Note on re-login                            
                                                                                                                                               
  There is no migration between stores. Changing or removing a previously-set key points a client at a different (empty) store, requiring a fresh login. Keep keys stable, and leave the primary tenant without a key. See the "Switching tenants at runtime" section in `EXAMPLES.md`.  
                                                                                                                                             
  > You still need to register each tenant's callback at build time (manifest / Info.plist / Expo plugin).                                     
                                                                                                                                               
  ## Test plan                                      
                                                                                                                                               
  - [x] Unit tests + typecheck pass.                                                                                
  - [x] Switch tenant at runtime and confirm `authorize()` opens the newly selected tenant's login and the redirect resolves.                  
  - [x] Verified on device: upgrading an existing install kept the prior login (default store), and a new tenant with its own key mapped to a separate credentials manager.                                                                                                                
                                                                                                                    
  Fixes #1520                                       
  Fixes #1523

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `credentialsManagerStorageKey` to scope native credentials storage (Android SharedPreferences / iOS Keychain) per tenant/client.
  * Native clients now re-initialize automatically when identity-relevant options change, ensuring the active configuration stays in sync.

* **Bug Fixes**
  * Improved client caching/remounting so changes to identity-relevant configuration take effect reliably (including when option key order differs).

* **Documentation**
  * Expanded “Switching tenants at runtime” with runtime toggling guidance and updated storage-key isolation recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->