### PR TITLE
chore(deps): add gradle updates configuration for android dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,12 @@ updates:
     ignore:
       - dependency-name: '*'
         update-types: ['version-update:semver-major']
+  - package-ecosystem: gradle
+    directory: android
+    schedule:
+      interval: daily
+    allow:
+      - dependency-name: 'com.auth0.android:auth0'
+    ignore:
+      - dependency-name: '*'
+        update-types: ['version-update:semver-major']


### PR DESCRIPTION
Adds a Dependabot gradle rule to track minor/patch updates of `com.auth0.android:auth0` in `android/`, mirroring auth0/auth0-flutter#879.
 Major version updates are ignored.