### PR TITLE
feat: add Passwordless OTP for database connections

### DIFF
--- a/A0Auth0.podspec
+++ b/A0Auth0.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source_files = 'ios/**/*.{h,m,mm,swift}'
   s.requires_arc = true
 
-  s.dependency 'Auth0', '2.21.2'
+  s.dependency 'Auth0', '2.23.0'
   s.dependency 'SimpleKeychain', '1.3.0'
 
   install_modules_dependencies(s)

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -356,6 +356,8 @@ const credentials = await auth0.passwordless.loginWithOTP({
 });
 ```
 
+Both challenge methods accept an optional `allowSignup` parameter (defaults to `false`). When set to `true`, a new user is created for the given email or phone number if one does not already exist on the connection; when `false`, the challenge is rejected for unknown identifiers.
+
 The `challenge` object returned from a challenge call is opaque — pass it as-is to `loginWithOTP`. You can optionally provide `audience` and `scope` to `loginWithOTP`.
 
 ### Create user in database connection

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -7,6 +7,7 @@
   - [Using custom scheme for web authentication redirection](#using-custom-scheme-for-web-authentication-redirection)
   - [Login using MFA with One Time Password code](#login-using-mfa-with-one-time-password-code)
   - [Login with Passwordless](#login-with-passwordless)
+  - [Login with Passwordless OTP (Database Connections)](#login-with-passwordless-otp-database-connections)
   - [Create user in database connection](#create-user-in-database-connection)
   - [Using HTTPS callback URLs](#using-https-callback-urls)
   - [Using Custom Headers](#using-custom-headers)
@@ -309,6 +310,53 @@ const subscription = Linking.addEventListener('url', ({ url }) => {
 
 > [!NOTE]
 > For native and Expo apps, the **code flow is recommended** because the SDK handles the full exchange for you. Use the magic link flow only if your use case specifically requires magic links, and be aware that you are responsible for handling the deep link and securely storing the returned tokens.
+
+### Login with Passwordless OTP (Database Connections)
+
+> [!NOTE]
+> This feature is currently in [Early Access](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages#early-access). Reach out to Auth0 support to have it enabled for your tenant.
+>
+> Native only (iOS, Android). Calling `auth0.passwordless.*` on the web platform rejects with an `UnsupportedOperation` error.
+
+This flow lets a user authenticate with a one-time code sent to their email or phone against a standard **database** connection (`auth0` strategy) that has `email_otp` or `phone_otp` enabled. It is distinct from [Login with Passwordless](#login-with-passwordless), which targets dedicated `email` / `sms` connections.
+
+It is a two-step, challenge-response flow: request a challenge (which delivers the OTP and returns an opaque `auth_session`), then exchange the challenge and the user-entered code for credentials.
+
+#### Email challenge
+
+```js
+// 1. Request a challenge — Auth0 emails the OTP and returns the challenge.
+const challenge = await auth0.passwordless.challengeWithEmail({
+  email: 'info@auth0.com',
+  connection: 'Username-Password-Authentication', // required; must have email_otp enabled
+  // allowSignup defaults to false
+});
+
+// 2. Exchange the challenge and the code the user received for credentials.
+const credentials = await auth0.passwordless.loginWithOTP({
+  challenge,
+  otp: '123456',
+});
+```
+
+#### Phone challenge
+
+```js
+// 1. Request a challenge — delivered by SMS ('text') or voice call ('voice').
+const challenge = await auth0.passwordless.challengeWithPhoneNumber({
+  phoneNumber: '+15555550123',
+  connection: 'Username-Password-Authentication', // required; must have phone_otp enabled
+  deliveryMethod: 'text', // defaults to 'text'
+});
+
+// 2. Exchange the challenge and the code for credentials.
+const credentials = await auth0.passwordless.loginWithOTP({
+  challenge,
+  otp: '123456',
+});
+```
+
+The `challenge` object returned from a challenge call is opaque — pass it as-is to `loginWithOTP`. You can optionally provide `audience` and `scope` to `loginWithOTP`.
 
 ### Create user in database connection
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -96,7 +96,7 @@ dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "androidx.browser:browser:1.2.0"
-  implementation 'com.auth0.android:auth0:3.19.0'
+  implementation 'com.auth0.android:auth0:3.20.0'
 }
 
 if (isNewArchitectureEnabled()) {

--- a/android/src/main/java/com/auth0/react/A0Auth0Module.kt
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.kt
@@ -109,6 +109,7 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
 
     private var auth0: Auth0? = null
     private var myAccount: MyAccount? = null
+    private var passwordless: Passwordless? = null
     private lateinit var secureCredentialsManager: SecureCredentialsManager
     private var webAuthPromise: Promise? = null
 
@@ -279,6 +280,7 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
         this.useDPoP = useDPoP ?: true
         auth0 = Auth0.getInstance(clientId, domain)
         myAccount = MyAccount(auth0!!, this.useDPoP, reactContext)
+        passwordless = Passwordless(auth0!!, this.useDPoP, reactContext)
 
         val authAPI = AuthenticationAPIClient(auth0!!)
         if (this.useDPoP) {
@@ -773,6 +775,38 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
         })
     }
 
+
+    @ReactMethod
+    override fun passwordlessChallengeWithEmail(
+        email: String,
+        connection: String,
+        allowSignup: Boolean,
+        promise: Promise
+    ) {
+        passwordless!!.challengeWithEmail(email, connection, allowSignup, promise)
+    }
+
+    @ReactMethod
+    override fun passwordlessChallengeWithPhoneNumber(
+        phoneNumber: String,
+        connection: String,
+        deliveryMethod: String,
+        allowSignup: Boolean,
+        promise: Promise
+    ) {
+        passwordless!!.challengeWithPhoneNumber(phoneNumber, connection, deliveryMethod, allowSignup, promise)
+    }
+
+    @ReactMethod
+    override fun passwordlessLoginWithOTP(
+        authSession: String,
+        otp: String,
+        audience: String?,
+        scope: String?,
+        promise: Promise
+    ) {
+        passwordless!!.loginWithOTP(authSession, otp, audience, scope, promise)
+    }
 
     @ReactMethod
     override fun passkeyEnrollmentChallenge(

--- a/android/src/main/java/com/auth0/react/Passwordless.kt
+++ b/android/src/main/java/com/auth0/react/Passwordless.kt
@@ -1,0 +1,99 @@
+package com.auth0.react
+
+import com.auth0.android.Auth0
+import com.auth0.android.authentication.AuthenticationAPIClient
+import com.auth0.android.authentication.AuthenticationException
+import com.auth0.android.authentication.passwordless.DeliveryMethod
+import com.auth0.android.result.Credentials
+import com.auth0.android.result.PasswordlessChallenge
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableNativeMap
+
+class Passwordless(
+    private val auth0: Auth0,
+    private val useDPoP: Boolean,
+    private val reactContext: ReactApplicationContext
+) {
+
+    private fun createClient(): AuthenticationAPIClient {
+        val client = AuthenticationAPIClient(auth0)
+        if (useDPoP) {
+            client.useDPoP(reactContext)
+        }
+        return client
+    }
+
+    fun challengeWithEmail(
+        email: String,
+        connection: String,
+        allowSignup: Boolean,
+        promise: Promise
+    ) {
+        createClient().passwordlessClient()
+            .challengeWithEmail(email, connection, allowSignup)
+            .start(object : com.auth0.android.callback.Callback<PasswordlessChallenge, AuthenticationException> {
+                override fun onSuccess(result: PasswordlessChallenge) {
+                    val map = WritableNativeMap().apply {
+                        putString("authSession", result.authSession)
+                    }
+                    promise.resolve(map)
+                }
+
+                override fun onFailure(error: AuthenticationException) {
+                    promise.reject("PASSWORDLESS_CHALLENGE_FAILED", error.getDescription(), error)
+                }
+            })
+    }
+
+    fun challengeWithPhoneNumber(
+        phoneNumber: String,
+        connection: String,
+        deliveryMethod: String,
+        allowSignup: Boolean,
+        promise: Promise
+    ) {
+        val method = if (deliveryMethod == "voice") DeliveryMethod.VOICE else DeliveryMethod.TEXT
+
+        createClient().passwordlessClient()
+            .challengeWithPhoneNumber(phoneNumber, connection, method, allowSignup)
+            .start(object : com.auth0.android.callback.Callback<PasswordlessChallenge, AuthenticationException> {
+                override fun onSuccess(result: PasswordlessChallenge) {
+                    val map = WritableNativeMap().apply {
+                        putString("authSession", result.authSession)
+                    }
+                    promise.resolve(map)
+                }
+
+                override fun onFailure(error: AuthenticationException) {
+                    promise.reject("PASSWORDLESS_CHALLENGE_FAILED", error.getDescription(), error)
+                }
+            })
+    }
+
+    fun loginWithOTP(
+        authSession: String,
+        otp: String,
+        audience: String?,
+        scope: String?,
+        promise: Promise
+    ) {
+        val finalScope = if (scope.isNullOrBlank()) "openid profile email" else scope
+        val finalAudience = audience?.trim()?.ifEmpty { null }
+
+        val request = createClient().passwordlessClient()
+            .loginWithOTP(PasswordlessChallenge(authSession), otp)
+        finalAudience?.let { request.setAudience(it) }
+        request.setScope(finalScope)
+
+        request.start(object : com.auth0.android.callback.Callback<Credentials, AuthenticationException> {
+            override fun onSuccess(result: Credentials) {
+                promise.resolve(CredentialsParser.toMap(result))
+            }
+
+            override fun onFailure(error: AuthenticationException) {
+                promise.reject("PASSWORDLESS_LOGIN_FAILED", error.getDescription(), error)
+            }
+        })
+    }
+}

--- a/android/src/main/java/com/auth0/react/Passwordless.kt
+++ b/android/src/main/java/com/auth0/react/Passwordless.kt
@@ -11,26 +11,24 @@ import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.WritableNativeMap
 
 class Passwordless(
-    private val auth0: Auth0,
-    private val useDPoP: Boolean,
-    private val reactContext: ReactApplicationContext
+    auth0: Auth0,
+    useDPoP: Boolean,
+    reactContext: ReactApplicationContext
 ) {
 
-    private fun createClient(): AuthenticationAPIClient {
-        val client = AuthenticationAPIClient(auth0)
+    private val client: AuthenticationAPIClient = AuthenticationAPIClient(auth0).also {
         if (useDPoP) {
-            client.useDPoP(reactContext)
+            it.useDPoP(reactContext)
         }
-        return client
     }
 
     fun challengeWithEmail(
         email: String,
         connection: String,
-        allowSignup: Boolean,
+        allowSignup: Boolean = false,
         promise: Promise
     ) {
-        createClient().passwordlessClient()
+        client.passwordlessClient()
             .challengeWithEmail(email, connection, allowSignup)
             .start(object : com.auth0.android.callback.Callback<PasswordlessChallenge, AuthenticationException> {
                 override fun onSuccess(result: PasswordlessChallenge) {
@@ -50,12 +48,12 @@ class Passwordless(
         phoneNumber: String,
         connection: String,
         deliveryMethod: String,
-        allowSignup: Boolean,
+        allowSignup: Boolean = false,
         promise: Promise
     ) {
         val method = if (deliveryMethod == "voice") DeliveryMethod.VOICE else DeliveryMethod.TEXT
 
-        createClient().passwordlessClient()
+        client.passwordlessClient()
             .challengeWithPhoneNumber(phoneNumber, connection, method, allowSignup)
             .start(object : com.auth0.android.callback.Callback<PasswordlessChallenge, AuthenticationException> {
                 override fun onSuccess(result: PasswordlessChallenge) {
@@ -81,7 +79,7 @@ class Passwordless(
         val finalScope = if (scope.isNullOrBlank()) "openid profile email" else scope
         val finalAudience = audience?.trim()?.ifEmpty { null }
 
-        val request = createClient().passwordlessClient()
+        val request = client.passwordlessClient()
             .loginWithOTP(PasswordlessChallenge(authSession), otp)
         finalAudience?.let { request.setAudience(it) }
         request.setScope(finalScope)

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - A0Auth0 (5.7.0):
-    - Auth0 (= 2.21.2)
+  - A0Auth0 (5.8.0):
+    - Auth0 (= 2.23.0)
     - hermes-engine
     - RCTRequired
     - RCTTypeSafety
@@ -23,7 +23,7 @@ PODS:
     - ReactNativeDependencies
     - SimpleKeychain (= 1.3.0)
     - Yoga
-  - Auth0 (2.21.2):
+  - Auth0 (2.23.0):
     - JWTDecode (= 3.3.0)
     - SimpleKeychain (= 1.3.0)
   - FBLazyVector (0.86.0)
@@ -2242,8 +2242,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  A0Auth0: 3f1b87e65cd0fd4620431b93c8ed2e6eebcdae00
-  Auth0: e15bc9c1e39a53efc8853d16460b9be409d5346f
+  A0Auth0: e14195294c028c4ebce21e45a17ee11749e7a943
+  Auth0: dd46c309079f995e91dfd7af38e8fefd1a43bf4e
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
   hermes-engine: 4ba8c4848d46c6a441e09d1c62f883ba69bc5b76
   JWTDecode: 1ca6f765844457d0dd8690436860fecee788f631

--- a/example/src/screens/class-based/ClassLogin.tsx
+++ b/example/src/screens/class-based/ClassLogin.tsx
@@ -1,12 +1,22 @@
 // example/src/screens/class-based/ClassLogin.tsx
 
 import React, { useState } from 'react';
-import { SafeAreaView, View, StyleSheet } from 'react-native';
+import {
+  SafeAreaView,
+  ScrollView,
+  View,
+  Text,
+  StyleSheet,
+  Alert,
+  Platform,
+} from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { StackNavigationProp } from '@react-navigation/stack';
+import type { PasswordlessChallenge } from 'react-native-auth0';
 import auth0 from '../../api/auth0'; // Import our singleton instance
 import Button from '../../components/Button';
 import Header from '../../components/Header';
+import LabeledInput from '../../components/LabeledInput';
 import Result from '../../components/Result';
 import type { ClassDemoStackParamList } from '../../navigation/ClassDemoNavigator';
 import config from '../../auth0-configuration';
@@ -20,6 +30,14 @@ const ClassLoginScreen = () => {
   const [error, setError] = useState<Error | null>(null);
   const [loading, setLoading] = useState(false);
   const navigation = useNavigation<NavigationProp>();
+
+  const [otpMethod, setOtpMethod] = useState<'email' | 'phone'>('email');
+  const [otpEmail, setOtpEmail] = useState('');
+  const [otpPhone, setOtpPhone] = useState('');
+  const [otp, setOtp] = useState('');
+  const [challenge, setChallenge] = useState<PasswordlessChallenge | null>(
+    null
+  );
 
   const onLogin = async () => {
     setLoading(true);
@@ -39,13 +57,139 @@ const ClassLoginScreen = () => {
     }
   };
 
+  const onSendOtpChallenge = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result =
+        otpMethod === 'email'
+          ? await auth0.passwordless.challengeWithEmail({
+              email: otpEmail,
+              connection: 'Username-Password-Authentication',
+              allowSignup: true,
+            })
+          : await auth0.passwordless.challengeWithPhoneNumber({
+              phoneNumber: otpPhone,
+              connection: 'Username-Password-Authentication',
+              deliveryMethod: 'text',
+              allowSignup: true,
+            });
+      setChallenge(result);
+      Alert.alert(
+        'Success',
+        otpMethod === 'email'
+          ? 'Check your email for the one-time code.'
+          : 'Check your phone for the one-time code.'
+      );
+    } catch (e) {
+      setError(e as Error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onLoginWithOtp = async () => {
+    if (!challenge) {
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const credentials = await auth0.passwordless.loginWithOTP({
+        challenge,
+        otp,
+        audience: `https://${config.domain}/api/v2/`,
+      });
+      await auth0.credentialsManager.saveCredentials(credentials);
+      navigation.replace('ClassProfile', { credentials });
+    } catch (e) {
+      setError(e as Error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <SafeAreaView style={styles.container}>
       <Header title="Class-Based Login" />
-      <View style={styles.content}>
+      <ScrollView contentContainerStyle={styles.content}>
         <Result title="Error" error={error} result={null} />
-        <Button onPress={onLogin} title="Log In" loading={loading} />
-      </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>Web Auth</Text>
+          <Button onPress={onLogin} title="Log In" loading={loading} />
+        </View>
+
+        {Platform.OS !== 'web' && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>
+              Passwordless OTP (Database Connection)
+            </Text>
+            <Text style={styles.description}>
+              Two-step flow on a database connection with email_otp / phone_otp
+              enabled: challenge → verify code.
+            </Text>
+
+            <View style={styles.row}>
+              <Button
+                onPress={() => setOtpMethod('email')}
+                title="Email"
+                style={[
+                  styles.halfButton,
+                  otpMethod !== 'email' && styles.inactiveButton,
+                ]}
+              />
+              <Button
+                onPress={() => setOtpMethod('phone')}
+                title="Phone"
+                style={[
+                  styles.halfButton,
+                  otpMethod !== 'phone' && styles.inactiveButton,
+                ]}
+              />
+            </View>
+
+            {otpMethod === 'email' ? (
+              <LabeledInput
+                label="Email"
+                value={otpEmail}
+                onChangeText={setOtpEmail}
+                autoCapitalize="none"
+                keyboardType="email-address"
+              />
+            ) : (
+              <LabeledInput
+                label="Phone Number (E.164, e.g. +15555550123)"
+                value={otpPhone}
+                onChangeText={setOtpPhone}
+                autoCapitalize="none"
+                keyboardType="phone-pad"
+              />
+            )}
+            <Button
+              onPress={onSendOtpChallenge}
+              title="Send Code"
+              loading={loading}
+            />
+
+            {challenge && (
+              <>
+                <LabeledInput
+                  label="One-Time Code"
+                  value={otp}
+                  onChangeText={setOtp}
+                  keyboardType="numeric"
+                />
+                <Button
+                  onPress={onLoginWithOtp}
+                  title="Log In with Code"
+                  loading={loading}
+                />
+              </>
+            )}
+          </View>
+        )}
+      </ScrollView>
     </SafeAreaView>
   );
 };
@@ -56,11 +200,21 @@ const styles = StyleSheet.create({
     backgroundColor: '#FFFFFF',
   },
   content: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
     padding: 16,
+    gap: 20,
   },
+  section: {
+    borderWidth: 1,
+    borderColor: '#E0E0E0',
+    borderRadius: 8,
+    padding: 16,
+    gap: 10,
+  },
+  sectionTitle: { fontSize: 18, fontWeight: 'bold', marginBottom: 8 },
+  description: { fontSize: 13, color: '#666', marginBottom: 4 },
+  row: { flexDirection: 'row', gap: 8 },
+  halfButton: { flex: 1, minWidth: 0 },
+  inactiveButton: { backgroundColor: '#BDBDBD' },
 });
 
 export default ClassLoginScreen;

--- a/example/src/screens/hooks/Home.tsx
+++ b/example/src/screens/hooks/Home.tsx
@@ -15,6 +15,7 @@ import {
   PasskeyError,
   PasskeyErrorCodes,
 } from 'react-native-auth0';
+import type { PasswordlessChallenge } from 'react-native-auth0';
 import Button from '../../components/Button';
 import Header from '../../components/Header';
 import LabeledInput from '../../components/LabeledInput';
@@ -36,6 +37,7 @@ const HomeScreen = () => {
     passkeySignupChallenge,
     passkeyLoginChallenge,
     getTokenByPasskey,
+    passwordless,
     error,
   } = useAuth0();
 
@@ -47,6 +49,12 @@ const HomeScreen = () => {
   const [passkeyEmail, setPasskeyEmail] = useState('');
   const [loading, setLoading] = useState(false);
   const [lastResult, setLastResult] = useState<object | null>(null);
+  const [otpMethod, setOtpMethod] = useState<'email' | 'phone'>('email');
+  const [otpEmail, setOtpEmail] = useState('');
+  const [otpPhone, setOtpPhone] = useState('');
+  const [otpCode, setOtpCode] = useState('');
+  const [otpChallenge, setOtpChallenge] =
+    useState<PasswordlessChallenge | null>(null);
 
   const onLogin = async () => {
     try {
@@ -112,6 +120,59 @@ const HomeScreen = () => {
       await authorizeWithEmail({ email, code: otp });
     } catch (e) {
       setApiError(e as Error);
+    }
+  };
+
+  // --- Passwordless OTP (Database Connection) ---
+
+  const onSendOtpChallenge = async () => {
+    setApiError(null);
+    setLoading(true);
+    try {
+      const challenge =
+        otpMethod === 'email'
+          ? await passwordless.challengeWithEmail({
+              email: otpEmail,
+              connection: 'Username-Password-Authentication',
+              allowSignup: true,
+            })
+          : await passwordless.challengeWithPhoneNumber({
+              phoneNumber: otpPhone,
+              connection: 'Username-Password-Authentication',
+              deliveryMethod: 'text',
+              allowSignup: true,
+            });
+      setOtpChallenge(challenge);
+      Alert.alert(
+        'Success',
+        otpMethod === 'email'
+          ? 'Check your email for the one-time code.'
+          : 'Check your phone for the one-time code.'
+      );
+    } catch (e) {
+      setApiError(e as Error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const onLoginWithOtp = async () => {
+    if (!otpChallenge) {
+      return;
+    }
+    setApiError(null);
+    setLoading(true);
+    try {
+      // A successful loginWithOTP updates the hook's auth state, which
+      // navigates the app to the authenticated stack automatically.
+      await passwordless.loginWithOTP({
+        challenge: otpChallenge,
+        otp: otpCode,
+      });
+    } catch (e) {
+      setApiError(e as Error);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -337,6 +398,73 @@ const HomeScreen = () => {
         </Section>
 
         {Platform.OS !== 'web' && (
+          <Section title="Passwordless OTP (Database Connection)">
+            <Text style={styles.description}>
+              Two-step flow on a database connection with email_otp / phone_otp
+              enabled: challenge → verify code.
+            </Text>
+
+            <View style={styles.row}>
+              <Button
+                onPress={() => setOtpMethod('email')}
+                title="Email"
+                style={[
+                  styles.halfButton,
+                  otpMethod !== 'email' && styles.inactiveButton,
+                ]}
+              />
+              <Button
+                onPress={() => setOtpMethod('phone')}
+                title="Phone"
+                style={[
+                  styles.halfButton,
+                  otpMethod !== 'phone' && styles.inactiveButton,
+                ]}
+              />
+            </View>
+
+            {otpMethod === 'email' ? (
+              <LabeledInput
+                label="Email"
+                value={otpEmail}
+                onChangeText={setOtpEmail}
+                autoCapitalize="none"
+                keyboardType="email-address"
+              />
+            ) : (
+              <LabeledInput
+                label="Phone Number (E.164, e.g. +15555550123)"
+                value={otpPhone}
+                onChangeText={setOtpPhone}
+                autoCapitalize="none"
+                keyboardType="phone-pad"
+              />
+            )}
+            <Button
+              onPress={onSendOtpChallenge}
+              title="Send Code"
+              loading={loading}
+            />
+
+            {otpChallenge && (
+              <>
+                <LabeledInput
+                  label="One-Time Code"
+                  value={otpCode}
+                  onChangeText={setOtpCode}
+                  keyboardType="numeric"
+                />
+                <Button
+                  onPress={onLoginWithOtp}
+                  title="Log In with Code"
+                  loading={loading}
+                />
+              </>
+            )}
+          </Section>
+        )}
+
+        {Platform.OS !== 'web' && (
           <Section title="Passkeys">
             <Text style={styles.description}>
               Full passkey flow: challenge → credential manager → exchange.
@@ -442,6 +570,7 @@ const styles = StyleSheet.create({
   description: { fontSize: 13, color: '#666', marginBottom: 4 },
   row: { flexDirection: 'row', gap: 8 },
   halfButton: { flex: 1, minWidth: 0 },
+  inactiveButton: { backgroundColor: '#BDBDBD' },
   resultBox: {
     backgroundColor: '#F5F5F5',
     borderRadius: 6,

--- a/ios/A0Auth0.mm
+++ b/ios/A0Auth0.mm
@@ -26,6 +26,7 @@
 @interface A0Auth0 ()
 @property (strong, nonatomic) NativeBridge *nativeBridge;
 @property (strong, nonatomic) A0MyAccount *myAccount;
+@property (strong, nonatomic) A0Passwordless *passwordless;
 @end
 
 @implementation A0Auth0
@@ -224,6 +225,32 @@ RCT_EXPORT_METHOD(getTokenByPasskey:(NSString *)authSession
     [self.nativeBridge getTokenByPasskeyWithAuthSession:authSession authResponse:authResponse realm:realm audience:audience scope:scope organization:organization resolve:resolve reject:reject];
 }
 
+RCT_EXPORT_METHOD(passwordlessChallengeWithEmail:(NSString *)email
+                  connection:(NSString *)connection
+                  allowSignup:(BOOL)allowSignup
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [self.passwordless challengeWithEmail:email connection:connection allowSignup:allowSignup resolve:resolve reject:reject];
+}
+
+RCT_EXPORT_METHOD(passwordlessChallengeWithPhoneNumber:(NSString *)phoneNumber
+                  connection:(NSString *)connection
+                  deliveryMethod:(NSString *)deliveryMethod
+                  allowSignup:(BOOL)allowSignup
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [self.passwordless challengeWithPhoneNumber:phoneNumber connection:connection deliveryMethod:deliveryMethod allowSignup:allowSignup resolve:resolve reject:reject];
+}
+
+RCT_EXPORT_METHOD(passwordlessLoginWithOTP:(NSString *)authSession
+                  otp:(NSString *)otp
+                  audience:(NSString * _Nullable)audience
+                  scope:(NSString * _Nullable)scope
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject) {
+    [self.passwordless loginWithOTP:authSession otp:otp audience:audience scope:scope resolve:resolve reject:reject];
+}
+
 RCT_EXPORT_METHOD(passkeyEnrollmentChallenge:(NSString *)accessToken
                   userIdentity:(NSString * _Nullable)userIdentity
                   connection:(NSString * _Nullable)connection
@@ -350,6 +377,7 @@ UIBackgroundTaskIdentifier taskId;
     NativeBridge *bridge = [[NativeBridge alloc] initWithClientId:clientId domain:domain localAuthenticationOptions:options useDPoP:useDPoPBool maxRetries:maxRetries credentialsManagerStorageKey:credentialsManagerStorageKey resolve:resolve reject:reject];
     self.nativeBridge = bridge;
     self.myAccount = [[A0MyAccount alloc] initWithDomain:domain useDPoP:useDPoPBool];
+    self.passwordless = [[A0Passwordless alloc] initWithClientId:clientId domain:domain useDPoP:useDPoPBool];
 }
 #ifdef RCT_NEW_ARCH_ENABLED
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:(const facebook::react::ObjCTurboModule::InitParams &)params { 

--- a/ios/Passwordless.swift
+++ b/ios/Passwordless.swift
@@ -4,27 +4,19 @@ import Foundation
 @objc
 public class A0Passwordless: NSObject {
 
-    private let clientId: String
-    private let domain: String
-    private let useDPoP: Bool
+    private let client: Authentication
 
     @objc public init(clientId: String, domain: String, useDPoP: Bool) {
-        self.clientId = clientId
-        self.domain = domain
-        self.useDPoP = useDPoP
-    }
-
-    private func createClient() -> Authentication {
-        var client = Auth0.authentication(clientId: self.clientId, domain: self.domain)
-        if self.useDPoP {
+        var client = Auth0.authentication(clientId: clientId, domain: domain)
+        if useDPoP {
             client = client.useDPoP()
         }
-        return client
+        self.client = client
     }
 
     @objc(challengeWithEmail:connection:allowSignup:resolve:reject:)
     public func challengeWithEmail(email: String, connection: String, allowSignup: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
-        createClient().passwordlessChallenge(
+        client.passwordlessChallenge(
             email: email,
             connection: connection,
             allowSignup: allowSignup
@@ -42,7 +34,7 @@ public class A0Passwordless: NSObject {
     public func challengeWithPhoneNumber(phoneNumber: String, connection: String, deliveryMethod: String, allowSignup: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
         let method = DeliveryMethod(rawValue: deliveryMethod) ?? .text
 
-        createClient().passwordlessChallenge(
+        client.passwordlessChallenge(
             phoneNumber: phoneNumber,
             connection: connection,
             deliveryMethod: method,
@@ -70,7 +62,7 @@ public class A0Passwordless: NSObject {
             return
         }
 
-        createClient().login(
+        client.login(
             otp: otp,
             challenge: challenge,
             audience: audienceValue,

--- a/ios/Passwordless.swift
+++ b/ios/Passwordless.swift
@@ -1,0 +1,87 @@
+import Auth0
+import Foundation
+
+@objc
+public class A0Passwordless: NSObject {
+
+    private let clientId: String
+    private let domain: String
+    private let useDPoP: Bool
+
+    @objc public init(clientId: String, domain: String, useDPoP: Bool) {
+        self.clientId = clientId
+        self.domain = domain
+        self.useDPoP = useDPoP
+    }
+
+    private func createClient() -> Authentication {
+        var client = Auth0.authentication(clientId: self.clientId, domain: self.domain)
+        if self.useDPoP {
+            client = client.useDPoP()
+        }
+        return client
+    }
+
+    @objc(challengeWithEmail:connection:allowSignup:resolve:reject:)
+    public func challengeWithEmail(email: String, connection: String, allowSignup: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        createClient().passwordlessChallenge(
+            email: email,
+            connection: connection,
+            allowSignup: allowSignup
+        ).start { result in
+            switch result {
+            case .success(let challenge):
+                resolve(["authSession": challenge.authSession])
+            case .failure(let error):
+                reject("PASSWORDLESS_CHALLENGE_FAILED", error.localizedDescription, error)
+            }
+        }
+    }
+
+    @objc(challengeWithPhoneNumber:connection:deliveryMethod:allowSignup:resolve:reject:)
+    public func challengeWithPhoneNumber(phoneNumber: String, connection: String, deliveryMethod: String, allowSignup: Bool, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        let method = DeliveryMethod(rawValue: deliveryMethod) ?? .text
+
+        createClient().passwordlessChallenge(
+            phoneNumber: phoneNumber,
+            connection: connection,
+            deliveryMethod: method,
+            allowSignup: allowSignup
+        ).start { result in
+            switch result {
+            case .success(let challenge):
+                resolve(["authSession": challenge.authSession])
+            case .failure(let error):
+                reject("PASSWORDLESS_CHALLENGE_FAILED", error.localizedDescription, error)
+            }
+        }
+    }
+
+    @objc(loginWithOTP:otp:audience:scope:resolve:reject:)
+    public func loginWithOTP(authSession: String, otp: String, audience: String?, scope: String?, resolve: @escaping RCTPromiseResolveBlock, reject: @escaping RCTPromiseRejectBlock) {
+        let audienceValue = audience?.isEmpty == true ? nil : audience
+        let finalScope = scope?.isEmpty == true ? "openid profile email" : (scope ?? "openid profile email")
+
+        // PasswordlessChallenge has no public initializer, but it is Codable with
+        // `authSession` mapped to the `auth_session` JSON key. Reconstruct it by decoding.
+        guard let challengeData = try? JSONSerialization.data(withJSONObject: ["auth_session": authSession]),
+              let challenge = try? JSONDecoder().decode(PasswordlessChallenge.self, from: challengeData) else {
+            reject("PASSWORDLESS_LOGIN_FAILED", "Invalid passwordless challenge", nil)
+            return
+        }
+
+        createClient().login(
+            otp: otp,
+            challenge: challenge,
+            audience: audienceValue,
+            scope: finalScope
+        ).start { result in
+            switch result {
+            case .success(let credentials):
+                resolve(credentials.asDictionary())
+            case .failure(let error):
+                reject("PASSWORDLESS_LOGIN_FAILED", error.localizedDescription, error)
+            }
+        }
+    }
+}

--- a/src/Auth0.ts
+++ b/src/Auth0.ts
@@ -79,6 +79,26 @@ class Auth0 {
   }
 
   /**
+   * Provides access to the passwordless OTP flow for database connections.
+   *
+   * @remarks Native only (iOS, Android). Not supported on web.
+   *
+   * @example
+   * ```typescript
+   * const challenge = await auth0.passwordless.challengeWithEmail({
+   *   email: 'user@example.com',
+   * });
+   * const credentials = await auth0.passwordless.loginWithOTP({
+   *   challenge,
+   *   otp: '123456',
+   * });
+   * ```
+   */
+  get passwordless() {
+    return this.client.passwordless;
+  }
+
+  /**
    * Provides access to the Management API (e.g., for user patching).
    * @param token An access token with the required permissions for the management operations.
    * @param tokenType Optional token type ('Bearer' or 'DPoP'). Defaults to the client's configured token type.

--- a/src/core/interfaces/IAuth0Client.ts
+++ b/src/core/interfaces/IAuth0Client.ts
@@ -2,6 +2,7 @@ import type { IWebAuthProvider } from './IWebAuthProvider';
 import type { ICredentialsManager } from './ICredentialsManager';
 import type { IAuthenticationProvider } from './IAuthenticationProvider';
 import type { IMyAccountClient } from './IMyAccountClient';
+import type { IPasswordlessClient } from './IPasswordlessClient';
 import type { IUsersClient } from './IUsersClient';
 import type {
   DPoPHeadersParams,
@@ -41,6 +42,13 @@ export interface IAuth0Client {
    * Provides access to methods for interacting with the My Account API for managing authentication methods.
    */
   readonly myAccount: IMyAccountClient;
+
+  /**
+   * Provides access to the passwordless OTP flow for database connections.
+   *
+   * @remarks Native only (iOS, Android). Not supported on web.
+   */
+  readonly passwordless: IPasswordlessClient;
 
   /**
    * Creates a client for interacting with the Auth0 Management API's user endpoints.

--- a/src/core/interfaces/IPasswordlessClient.ts
+++ b/src/core/interfaces/IPasswordlessClient.ts
@@ -1,0 +1,48 @@
+import type {
+  Credentials,
+  PasswordlessChallenge,
+  PasswordlessChallengeEmailParameters,
+  PasswordlessChallengePhoneParameters,
+  PasswordlessLoginOtpParameters,
+} from '../../types';
+
+/**
+ * Client for the passwordless OTP flow on database connections.
+ *
+ * This is a two-step, challenge-response flow: issue a challenge to an email or
+ * phone number (which delivers a one-time code and returns an opaque
+ * `auth_session`), then complete the login by verifying the code.
+ *
+ * @remarks Native only (iOS, Android). Not supported on web.
+ */
+export interface IPasswordlessClient {
+  /**
+   * Issues an OTP challenge to an email address for a database connection.
+   *
+   * @param parameters The email-challenge parameters.
+   * @returns A promise resolving with a {@link PasswordlessChallenge}.
+   */
+  challengeWithEmail(
+    parameters: PasswordlessChallengeEmailParameters
+  ): Promise<PasswordlessChallenge>;
+
+  /**
+   * Issues an OTP challenge to a phone number for a database connection.
+   *
+   * @param parameters The phone-challenge parameters.
+   * @returns A promise resolving with a {@link PasswordlessChallenge}.
+   */
+  challengeWithPhoneNumber(
+    parameters: PasswordlessChallengePhoneParameters
+  ): Promise<PasswordlessChallenge>;
+
+  /**
+   * Completes the OTP flow by verifying the one-time code and obtaining credentials.
+   *
+   * @param parameters The login parameters including the challenge and OTP code.
+   * @returns A promise resolving with the user's {@link Credentials}.
+   */
+  loginWithOTP(
+    parameters: PasswordlessLoginOtpParameters
+  ): Promise<Credentials>;
+}

--- a/src/core/interfaces/index.ts
+++ b/src/core/interfaces/index.ts
@@ -3,5 +3,6 @@ export * from './IAuth0Client';
 export * from './IAuthenticationProvider';
 export * from './ICredentialsManager';
 export * from './IMyAccountClient';
+export * from './IPasswordlessClient';
 export * from './IWebAuthProvider';
 export * from './IUsersClient';

--- a/src/hooks/Auth0Context.ts
+++ b/src/hooks/Auth0Context.ts
@@ -29,6 +29,12 @@ import type {
   SessionTransferCredentials,
 } from '../types';
 import type { IMyAccountClient } from '../core/interfaces';
+import type {
+  PasswordlessChallenge,
+  PasswordlessChallengeEmailParameters,
+  PasswordlessChallengePhoneParameters,
+  PasswordlessLoginOtpParameters,
+} from '../types';
 import type { ApiCredentials } from '../core/models';
 import type {
   NativeAuthorizeOptions,
@@ -287,6 +293,35 @@ export interface Auth0ContextInterface extends AuthState {
   myAccount: IMyAccountClient;
 
   /**
+   * Provides access to the Passwordless OTP flow for database connections.
+   *
+   * This is a two-step, challenge-response flow: issue a challenge to an email
+   * or phone number (which delivers a one-time code and returns an opaque
+   * `auth_session`), then complete the login by verifying the code. A successful
+   * `loginWithOTP` updates the hook's authentication state.
+   *
+   * @remarks Native only (iOS, Android). Not supported on web.
+   *
+   * @example
+   * ```typescript
+   * const { passwordless } = useAuth0();
+   * const challenge = await passwordless.challengeWithEmail({ email });
+   * await passwordless.loginWithOTP({ challenge, otp });
+   * ```
+   */
+  passwordless: {
+    challengeWithEmail: (
+      parameters: PasswordlessChallengeEmailParameters
+    ) => Promise<PasswordlessChallenge>;
+    challengeWithPhoneNumber: (
+      parameters: PasswordlessChallengePhoneParameters
+    ) => Promise<PasswordlessChallenge>;
+    loginWithOTP: (
+      parameters: PasswordlessLoginOtpParameters
+    ) => Promise<Credentials>;
+  };
+
+  /**
    * Sends a verification code to the user's email.
    * @param parameters The parameters for sending the email code.
    * @throws {AuthError} If sending the email code fails.
@@ -497,6 +532,11 @@ const initialContext: Auth0ContextInterface = {
     updateAuthenticationMethodById: stub,
     deleteAuthenticationMethodById: stub,
     getFactors: stub,
+  },
+  passwordless: {
+    challengeWithEmail: stub,
+    challengeWithPhoneNumber: stub,
+    loginWithOTP: stub,
   },
   sendEmailCode: stub,
   sendSMSCode: stub,

--- a/src/hooks/Auth0Provider.tsx
+++ b/src/hooks/Auth0Provider.tsx
@@ -32,6 +32,9 @@ import type {
   ResetPasswordParameters,
   MfaChallengeResponse,
   DPoPHeadersParams,
+  PasswordlessChallengeEmailParameters,
+  PasswordlessChallengePhoneParameters,
+  PasswordlessLoginOtpParameters,
 } from '../types';
 import type {
   NativeAuthorizeOptions,
@@ -369,6 +372,36 @@ export const Auth0Provider = ({
 
   const myAccount = useMemo(() => client.myAccount, [client]);
 
+  const passwordless = useMemo(
+    () => ({
+      challengeWithEmail: async (
+        parameters: PasswordlessChallengeEmailParameters
+      ) => {
+        try {
+          return await client.passwordless.challengeWithEmail(parameters);
+        } catch (e) {
+          const error = e as AuthError;
+          dispatch({ type: 'ERROR', error });
+          throw error;
+        }
+      },
+      challengeWithPhoneNumber: async (
+        parameters: PasswordlessChallengePhoneParameters
+      ) => {
+        try {
+          return await client.passwordless.challengeWithPhoneNumber(parameters);
+        } catch (e) {
+          const error = e as AuthError;
+          dispatch({ type: 'ERROR', error });
+          throw error;
+        }
+      },
+      loginWithOTP: (parameters: PasswordlessLoginOtpParameters) =>
+        loginFlow(client.passwordless.loginWithOTP(parameters)),
+    }),
+    [client, loginFlow]
+  );
+
   const sendEmailCode = useCallback(
     (parameters: PasswordlessEmailParameters) =>
       voidFlow(client.auth.passwordlessWithEmail(parameters)),
@@ -483,6 +516,7 @@ export const Auth0Provider = ({
       passkeyLoginChallenge,
       getTokenByPasskey,
       myAccount,
+      passwordless,
       sendEmailCode,
       authorizeWithEmail,
       sendSMSCode,
@@ -518,6 +552,7 @@ export const Auth0Provider = ({
       passkeyLoginChallenge,
       getTokenByPasskey,
       myAccount,
+      passwordless,
       sendEmailCode,
       authorizeWithEmail,
       sendSMSCode,

--- a/src/platforms/native/adapters/NativeAuth0Client.ts
+++ b/src/platforms/native/adapters/NativeAuth0Client.ts
@@ -2,6 +2,7 @@ import type {
   IAuth0Client,
   IAuthenticationProvider,
   IMyAccountClient,
+  IPasswordlessClient,
   IUsersClient,
 } from '../../../core/interfaces';
 import type { NativeAuth0Options } from '../../../types/platform-specific';
@@ -17,6 +18,7 @@ import type {
 import { NativeWebAuthProvider } from './NativeWebAuthProvider';
 import { NativeCredentialsManager } from './NativeCredentialsManager';
 import { NativeMyAccountClient } from './NativeMyAccountClient';
+import { NativePasswordlessClient } from './NativePasswordlessClient';
 import { type INativeBridge, NativeBridgeManager } from '../bridge';
 import {
   AuthenticationOrchestrator,
@@ -31,6 +33,7 @@ export class NativeAuth0Client implements IAuth0Client {
   readonly webAuth: NativeWebAuthProvider;
   readonly credentialsManager: NativeCredentialsManager;
   readonly auth: IAuthenticationProvider;
+  readonly passwordless: IPasswordlessClient;
   private ready: Promise<void>;
   private readonly httpClient: HttpClient;
   private readonly tokenType: TokenType;
@@ -94,6 +97,7 @@ export class NativeAuth0Client implements IAuth0Client {
     this.webAuth = new NativeWebAuthProvider(guardedBridge, options.domain);
     this.credentialsManager = new NativeCredentialsManager(guardedBridge);
     this.myAccount = new NativeMyAccountClient(guardedBridge);
+    this.passwordless = new NativePasswordlessClient(guardedBridge);
   }
 
   private async initialize(

--- a/src/platforms/native/adapters/NativePasswordlessClient.ts
+++ b/src/platforms/native/adapters/NativePasswordlessClient.ts
@@ -1,0 +1,52 @@
+import type { IPasswordlessClient } from '../../../core/interfaces';
+import type {
+  Credentials,
+  PasswordlessChallenge,
+  PasswordlessChallengeEmailParameters,
+  PasswordlessChallengePhoneParameters,
+  PasswordlessLoginOtpParameters,
+} from '../../../types';
+import type { INativeBridge } from '../bridge';
+
+export class NativePasswordlessClient implements IPasswordlessClient {
+  private readonly bridge: INativeBridge;
+
+  constructor(bridge: INativeBridge) {
+    this.bridge = bridge;
+  }
+
+  async challengeWithEmail(
+    parameters: PasswordlessChallengeEmailParameters
+  ): Promise<PasswordlessChallenge> {
+    const { email, connection, allowSignup } = parameters;
+    return this.bridge.passwordlessChallengeWithEmail(
+      email,
+      connection,
+      allowSignup ?? false
+    );
+  }
+
+  async challengeWithPhoneNumber(
+    parameters: PasswordlessChallengePhoneParameters
+  ): Promise<PasswordlessChallenge> {
+    const { phoneNumber, connection, deliveryMethod, allowSignup } = parameters;
+    return this.bridge.passwordlessChallengeWithPhoneNumber(
+      phoneNumber,
+      connection,
+      deliveryMethod ?? 'text',
+      allowSignup ?? false
+    );
+  }
+
+  async loginWithOTP(
+    parameters: PasswordlessLoginOtpParameters
+  ): Promise<Credentials> {
+    const { challenge, otp, audience, scope } = parameters;
+    return this.bridge.passwordlessLoginWithOTP(
+      challenge.authSession,
+      otp,
+      audience,
+      scope
+    );
+  }
+}

--- a/src/platforms/native/adapters/NativePasswordlessClient.ts
+++ b/src/platforms/native/adapters/NativePasswordlessClient.ts
@@ -15,6 +15,12 @@ export class NativePasswordlessClient implements IPasswordlessClient {
     this.bridge = bridge;
   }
 
+  /**
+   * Issues an OTP challenge to an email address for a database connection.
+   *
+   * @param parameters The email-challenge parameters.
+   * @returns A promise resolving with a {@link PasswordlessChallenge}.
+   */
   async challengeWithEmail(
     parameters: PasswordlessChallengeEmailParameters
   ): Promise<PasswordlessChallenge> {
@@ -26,6 +32,12 @@ export class NativePasswordlessClient implements IPasswordlessClient {
     );
   }
 
+  /**
+   * Issues an OTP challenge to a phone number for a database connection.
+   *
+   * @param parameters The phone-challenge parameters.
+   * @returns A promise resolving with a {@link PasswordlessChallenge}.
+   */
   async challengeWithPhoneNumber(
     parameters: PasswordlessChallengePhoneParameters
   ): Promise<PasswordlessChallenge> {
@@ -38,6 +50,12 @@ export class NativePasswordlessClient implements IPasswordlessClient {
     );
   }
 
+  /**
+   * Completes the OTP flow by verifying the one-time code and obtaining credentials.
+   *
+   * @param parameters The login parameters including the challenge and OTP code.
+   * @returns A promise resolving with the user's {@link Credentials}.
+   */
   async loginWithOTP(
     parameters: PasswordlessLoginOtpParameters
   ): Promise<Credentials> {

--- a/src/platforms/native/adapters/__tests__/NativePasswordlessClient.spec.ts
+++ b/src/platforms/native/adapters/__tests__/NativePasswordlessClient.spec.ts
@@ -1,0 +1,158 @@
+import { NativePasswordlessClient } from '../NativePasswordlessClient';
+import type { INativeBridge } from '../../bridge';
+
+const mockBridge = {
+  passwordlessChallengeWithEmail: jest.fn(),
+  passwordlessChallengeWithPhoneNumber: jest.fn(),
+  passwordlessLoginWithOTP: jest.fn(),
+} as unknown as jest.Mocked<INativeBridge>;
+
+describe('NativePasswordlessClient', () => {
+  let client: NativePasswordlessClient;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    client = new NativePasswordlessClient(mockBridge);
+  });
+
+  describe('challengeWithEmail', () => {
+    it('forwards email and connection and defaults allowSignup', async () => {
+      mockBridge.passwordlessChallengeWithEmail.mockResolvedValueOnce({
+        authSession: 'session_email',
+      });
+
+      const result = await client.challengeWithEmail({
+        email: 'user@example.com',
+        connection: 'my-db',
+      });
+
+      expect(mockBridge.passwordlessChallengeWithEmail).toHaveBeenCalledWith(
+        'user@example.com',
+        'my-db',
+        false
+      );
+      expect(result).toEqual({ authSession: 'session_email' });
+    });
+
+    it('passes through provided connection and allowSignup', async () => {
+      mockBridge.passwordlessChallengeWithEmail.mockResolvedValueOnce({
+        authSession: 'session_email',
+      });
+
+      await client.challengeWithEmail({
+        email: 'user@example.com',
+        connection: 'custom-db',
+        allowSignup: true,
+      });
+
+      expect(mockBridge.passwordlessChallengeWithEmail).toHaveBeenCalledWith(
+        'user@example.com',
+        'custom-db',
+        true
+      );
+    });
+
+    it('propagates errors from the bridge', async () => {
+      const error = new Error('challenge failed');
+      mockBridge.passwordlessChallengeWithEmail.mockRejectedValueOnce(error);
+
+      await expect(
+        client.challengeWithEmail({
+          email: 'user@example.com',
+          connection: 'my-db',
+        })
+      ).rejects.toThrow(error);
+    });
+  });
+
+  describe('challengeWithPhoneNumber', () => {
+    it('forwards connection and defaults deliveryMethod and allowSignup', async () => {
+      mockBridge.passwordlessChallengeWithPhoneNumber.mockResolvedValueOnce({
+        authSession: 'session_phone',
+      });
+
+      const result = await client.challengeWithPhoneNumber({
+        phoneNumber: '+15555550123',
+        connection: 'my-db',
+      });
+
+      expect(
+        mockBridge.passwordlessChallengeWithPhoneNumber
+      ).toHaveBeenCalledWith('+15555550123', 'my-db', 'text', false);
+      expect(result).toEqual({ authSession: 'session_phone' });
+    });
+
+    it('passes through provided values including voice delivery', async () => {
+      mockBridge.passwordlessChallengeWithPhoneNumber.mockResolvedValueOnce({
+        authSession: 'session_phone',
+      });
+
+      await client.challengeWithPhoneNumber({
+        phoneNumber: '+15555550123',
+        connection: 'custom-db',
+        deliveryMethod: 'voice',
+        allowSignup: true,
+      });
+
+      expect(
+        mockBridge.passwordlessChallengeWithPhoneNumber
+      ).toHaveBeenCalledWith('+15555550123', 'custom-db', 'voice', true);
+    });
+  });
+
+  describe('loginWithOTP', () => {
+    const credentials = {
+      idToken: 'id_token',
+      accessToken: 'access_token',
+      tokenType: 'Bearer',
+      expiresAt: 1700000000,
+    };
+
+    it('forwards the challenge authSession and otp', async () => {
+      mockBridge.passwordlessLoginWithOTP.mockResolvedValueOnce(credentials);
+
+      const result = await client.loginWithOTP({
+        challenge: { authSession: 'session_login' },
+        otp: '123456',
+      });
+
+      expect(mockBridge.passwordlessLoginWithOTP).toHaveBeenCalledWith(
+        'session_login',
+        '123456',
+        undefined,
+        undefined
+      );
+      expect(result).toEqual(credentials);
+    });
+
+    it('forwards audience and scope when provided', async () => {
+      mockBridge.passwordlessLoginWithOTP.mockResolvedValueOnce(credentials);
+
+      await client.loginWithOTP({
+        challenge: { authSession: 'session_login' },
+        otp: '123456',
+        audience: 'https://api.example.com',
+        scope: 'openid profile',
+      });
+
+      expect(mockBridge.passwordlessLoginWithOTP).toHaveBeenCalledWith(
+        'session_login',
+        '123456',
+        'https://api.example.com',
+        'openid profile'
+      );
+    });
+
+    it('propagates errors from the bridge', async () => {
+      const error = new Error('login failed');
+      mockBridge.passwordlessLoginWithOTP.mockRejectedValueOnce(error);
+
+      await expect(
+        client.loginWithOTP({
+          challenge: { authSession: 'session_login' },
+          otp: '000000',
+        })
+      ).rejects.toThrow(error);
+    });
+  });
+});

--- a/src/platforms/native/bridge/INativeBridge.ts
+++ b/src/platforms/native/bridge/INativeBridge.ts
@@ -283,6 +283,52 @@ export interface INativeBridge {
   ): Promise<Credentials>;
 
   /**
+   * Issue a passwordless OTP challenge to an email address for a database connection.
+   *
+   * @param email The email address to send the one-time code to.
+   * @param connection The database connection name; must have `email_otp` enabled.
+   * @param allowSignup Whether to allow sign-up if the user does not yet exist.
+   * @returns A promise that resolves with the opaque auth session.
+   */
+  passwordlessChallengeWithEmail(
+    email: string,
+    connection: string,
+    allowSignup: boolean
+  ): Promise<{ authSession: string }>;
+
+  /**
+   * Issue a passwordless OTP challenge to a phone number for a database connection.
+   *
+   * @param phoneNumber The E.164 phone number to send the one-time code to.
+   * @param connection The database connection name; must have `phone_otp` enabled.
+   * @param deliveryMethod How to deliver the code: `'text'` or `'voice'`.
+   * @param allowSignup Whether to allow sign-up if the user does not yet exist.
+   * @returns A promise that resolves with the opaque auth session.
+   */
+  passwordlessChallengeWithPhoneNumber(
+    phoneNumber: string,
+    connection: string,
+    deliveryMethod: string,
+    allowSignup: boolean
+  ): Promise<{ authSession: string }>;
+
+  /**
+   * Complete a passwordless OTP flow by verifying the code and obtaining credentials.
+   *
+   * @param authSession The opaque auth session from a prior challenge.
+   * @param otp The one-time code the user received.
+   * @param audience Optional target API identifier.
+   * @param scope Optional space-separated scopes.
+   * @returns A promise that resolves with Auth0 credentials.
+   */
+  passwordlessLoginWithOTP(
+    authSession: string,
+    otp: string,
+    audience?: string,
+    scope?: string
+  ): Promise<Credentials>;
+
+  /**
    * Request a passkey enrollment challenge from the My Account API.
    *
    * @param accessToken Access token for My Account API.

--- a/src/platforms/native/bridge/NativeBridgeManager.ts
+++ b/src/platforms/native/bridge/NativeBridgeManager.ts
@@ -324,6 +324,52 @@ export class NativeBridgeManager implements INativeBridge {
     return new CredentialsModel(credential);
   }
 
+  async passwordlessChallengeWithEmail(
+    email: string,
+    connection: string,
+    allowSignup: boolean
+  ): Promise<{ authSession: string }> {
+    return this.a0_call(
+      Auth0NativeModule.passwordlessChallengeWithEmail.bind(Auth0NativeModule),
+      email,
+      connection,
+      allowSignup
+    );
+  }
+
+  async passwordlessChallengeWithPhoneNumber(
+    phoneNumber: string,
+    connection: string,
+    deliveryMethod: string,
+    allowSignup: boolean
+  ): Promise<{ authSession: string }> {
+    return this.a0_call(
+      Auth0NativeModule.passwordlessChallengeWithPhoneNumber.bind(
+        Auth0NativeModule
+      ),
+      phoneNumber,
+      connection,
+      deliveryMethod,
+      allowSignup
+    );
+  }
+
+  async passwordlessLoginWithOTP(
+    authSession: string,
+    otp: string,
+    audience?: string,
+    scope?: string
+  ): Promise<Credentials> {
+    const credential = await this.a0_call(
+      Auth0NativeModule.passwordlessLoginWithOTP.bind(Auth0NativeModule),
+      authSession,
+      otp,
+      audience,
+      scope
+    );
+    return new CredentialsModel(credential);
+  }
+
   async passkeyEnrollmentChallenge(
     accessToken: string,
     userIdentity?: string,

--- a/src/platforms/native/bridge/__tests__/NativeBridgeManager.spec.ts
+++ b/src/platforms/native/bridge/__tests__/NativeBridgeManager.spec.ts
@@ -22,6 +22,9 @@ jest.mock('../../../../specs/NativeA0Auth0', () => ({
   customTokenExchange: jest.fn(),
   getApiCredentials: jest.fn(),
   clearApiCredentials: jest.fn(),
+  passwordlessChallengeWithEmail: jest.fn(),
+  passwordlessChallengeWithPhoneNumber: jest.fn(),
+  passwordlessLoginWithOTP: jest.fn(),
 }));
 const MockedAuth0NativeModule = Auth0NativeModule as jest.Mocked<
   typeof Auth0NativeModule
@@ -432,6 +435,108 @@ describe('NativeBridgeManager', () => {
         expect(tokenExchangeError.message).toBe('Token exchange failed');
         expect(tokenExchangeError.code).toBe('custom_token_exchange_failed');
       }
+    });
+  });
+
+  describe('passwordlessChallengeWithEmail', () => {
+    it('forwards all parameters to the native module and returns the authSession', async () => {
+      MockedAuth0NativeModule.passwordlessChallengeWithEmail.mockResolvedValueOnce(
+        { authSession: 'session_email' } as any
+      );
+
+      const result = await bridge.passwordlessChallengeWithEmail(
+        'user@example.com',
+        'Username-Password-Authentication',
+        false
+      );
+
+      expect(
+        MockedAuth0NativeModule.passwordlessChallengeWithEmail
+      ).toHaveBeenCalledWith(
+        'user@example.com',
+        'Username-Password-Authentication',
+        false
+      );
+      expect(result).toEqual({ authSession: 'session_email' });
+    });
+
+    it('wraps a native error in an AuthError', async () => {
+      MockedAuth0NativeModule.passwordlessChallengeWithEmail.mockRejectedValue({
+        code: 'a0.passwordless.challenge_failed',
+        message: 'boom',
+      });
+
+      await expect(
+        bridge.passwordlessChallengeWithEmail(
+          'user@example.com',
+          'Username-Password-Authentication',
+          false
+        )
+      ).rejects.toThrow(AuthError);
+    });
+  });
+
+  describe('passwordlessChallengeWithPhoneNumber', () => {
+    it('forwards all parameters including delivery method to the native module', async () => {
+      MockedAuth0NativeModule.passwordlessChallengeWithPhoneNumber.mockResolvedValueOnce(
+        { authSession: 'session_phone' } as any
+      );
+
+      const result = await bridge.passwordlessChallengeWithPhoneNumber(
+        '+15555550123',
+        'Username-Password-Authentication',
+        'voice',
+        true
+      );
+
+      expect(
+        MockedAuth0NativeModule.passwordlessChallengeWithPhoneNumber
+      ).toHaveBeenCalledWith(
+        '+15555550123',
+        'Username-Password-Authentication',
+        'voice',
+        true
+      );
+      expect(result).toEqual({ authSession: 'session_phone' });
+    });
+  });
+
+  describe('passwordlessLoginWithOTP', () => {
+    it('forwards parameters and transforms the response into a Credentials model', async () => {
+      MockedAuth0NativeModule.passwordlessLoginWithOTP.mockResolvedValueOnce(
+        nativeSuccessCredentials as any
+      );
+
+      const credentials = await bridge.passwordlessLoginWithOTP(
+        'session_login',
+        '123456',
+        'https://api.example.com',
+        'openid profile'
+      );
+
+      expect(
+        MockedAuth0NativeModule.passwordlessLoginWithOTP
+      ).toHaveBeenCalledWith(
+        'session_login',
+        '123456',
+        'https://api.example.com',
+        'openid profile'
+      );
+      expect(credentials).toBeInstanceOf(Credentials);
+      expect(credentials.accessToken).toBe(
+        nativeSuccessCredentials.accessToken
+      );
+    });
+
+    it('wraps a native error in an AuthError', async () => {
+      MockedAuth0NativeModule.passwordlessLoginWithOTP.mockRejectedValue({
+        code: 'a0.passwordless.login_failed',
+        message: 'boom',
+      });
+
+      await expect(
+        bridge.passwordlessLoginWithOTP('session_login', '000000')
+      ).rejects.toThrow(AuthError);
     });
   });
 });

--- a/src/platforms/web/adapters/WebAuth0Client.ts
+++ b/src/platforms/web/adapters/WebAuth0Client.ts
@@ -7,6 +7,7 @@ import type {
   IAuth0Client,
   IAuthenticationProvider,
   IMyAccountClient,
+  IPasswordlessClient,
   IUsersClient,
 } from '../../../core/interfaces';
 import type { WebAuth0Options } from '../../../types/platform-specific';
@@ -22,6 +23,7 @@ import type {
 import { WebWebAuthProvider } from './WebWebAuthProvider';
 import { WebCredentialsManager } from './WebCredentialsManager';
 import { WebMyAccountClient } from './WebMyAccountClient';
+import { WebPasswordlessClient } from './WebPasswordlessClient';
 import { ssoExchangeNotSupported } from './WebAuthenticationProvider';
 import {
   AuthenticationOrchestrator,
@@ -146,6 +148,8 @@ export class WebAuth0Client implements IAuth0Client {
   }
 
   readonly myAccount: IMyAccountClient = new WebMyAccountClient();
+
+  readonly passwordless: IPasswordlessClient = new WebPasswordlessClient();
 
   public async logout(options?: LogoutOptions): Promise<void> {
     // If a logout process has already started, do nothing.

--- a/src/platforms/web/adapters/WebPasswordlessClient.ts
+++ b/src/platforms/web/adapters/WebPasswordlessClient.ts
@@ -1,0 +1,31 @@
+import type { IPasswordlessClient } from '../../../core/interfaces';
+import type {
+  Credentials,
+  PasswordlessChallenge,
+  PasswordlessChallengeEmailParameters,
+  PasswordlessChallengePhoneParameters,
+  PasswordlessLoginOtpParameters,
+} from '../../../types';
+import { AuthError } from '../../../core/models';
+
+const NOT_SUPPORTED = 'Passwordless OTP is not supported on the web platform';
+
+export class WebPasswordlessClient implements IPasswordlessClient {
+  async challengeWithEmail(
+    _parameters: PasswordlessChallengeEmailParameters
+  ): Promise<PasswordlessChallenge> {
+    throw new AuthError('UnsupportedOperation', NOT_SUPPORTED);
+  }
+
+  async challengeWithPhoneNumber(
+    _parameters: PasswordlessChallengePhoneParameters
+  ): Promise<PasswordlessChallenge> {
+    throw new AuthError('UnsupportedOperation', NOT_SUPPORTED);
+  }
+
+  async loginWithOTP(
+    _parameters: PasswordlessLoginOtpParameters
+  ): Promise<Credentials> {
+    throw new AuthError('UnsupportedOperation', NOT_SUPPORTED);
+  }
+}

--- a/src/platforms/web/adapters/__tests__/WebPasswordlessClient.spec.ts
+++ b/src/platforms/web/adapters/__tests__/WebPasswordlessClient.spec.ts
@@ -10,19 +10,31 @@ describe('WebPasswordlessClient', () => {
 
   it('challengeWithEmail rejects with an UnsupportedOperation AuthError', async () => {
     await expect(
-      client.challengeWithEmail({ email: 'user@example.com' })
+      client.challengeWithEmail({
+        email: 'user@example.com',
+        connection: 'Username-Password-Authentication',
+      })
     ).rejects.toThrow(AuthError);
     await expect(
-      client.challengeWithEmail({ email: 'user@example.com' })
+      client.challengeWithEmail({
+        email: 'user@example.com',
+        connection: 'Username-Password-Authentication',
+      })
     ).rejects.toMatchObject({ name: 'UnsupportedOperation' });
   });
 
   it('challengeWithPhoneNumber rejects with an UnsupportedOperation AuthError', async () => {
     await expect(
-      client.challengeWithPhoneNumber({ phoneNumber: '+15555550123' })
+      client.challengeWithPhoneNumber({
+        phoneNumber: '+15555550123',
+        connection: 'Username-Password-Authentication',
+      })
     ).rejects.toThrow(AuthError);
     await expect(
-      client.challengeWithPhoneNumber({ phoneNumber: '+15555550123' })
+      client.challengeWithPhoneNumber({
+        phoneNumber: '+15555550123',
+        connection: 'Username-Password-Authentication',
+      })
     ).rejects.toMatchObject({ name: 'UnsupportedOperation' });
   });
 

--- a/src/platforms/web/adapters/__tests__/WebPasswordlessClient.spec.ts
+++ b/src/platforms/web/adapters/__tests__/WebPasswordlessClient.spec.ts
@@ -1,0 +1,43 @@
+import { WebPasswordlessClient } from '../WebPasswordlessClient';
+import { AuthError } from '../../../../core/models';
+
+describe('WebPasswordlessClient', () => {
+  let client: WebPasswordlessClient;
+
+  beforeEach(() => {
+    client = new WebPasswordlessClient();
+  });
+
+  it('challengeWithEmail rejects with an UnsupportedOperation AuthError', async () => {
+    await expect(
+      client.challengeWithEmail({ email: 'user@example.com' })
+    ).rejects.toThrow(AuthError);
+    await expect(
+      client.challengeWithEmail({ email: 'user@example.com' })
+    ).rejects.toMatchObject({ name: 'UnsupportedOperation' });
+  });
+
+  it('challengeWithPhoneNumber rejects with an UnsupportedOperation AuthError', async () => {
+    await expect(
+      client.challengeWithPhoneNumber({ phoneNumber: '+15555550123' })
+    ).rejects.toThrow(AuthError);
+    await expect(
+      client.challengeWithPhoneNumber({ phoneNumber: '+15555550123' })
+    ).rejects.toMatchObject({ name: 'UnsupportedOperation' });
+  });
+
+  it('loginWithOTP rejects with an UnsupportedOperation AuthError', async () => {
+    await expect(
+      client.loginWithOTP({
+        challenge: { authSession: 'session' },
+        otp: '123456',
+      })
+    ).rejects.toThrow(AuthError);
+    await expect(
+      client.loginWithOTP({
+        challenge: { authSession: 'session' },
+        otp: '123456',
+      })
+    ).rejects.toMatchObject({ name: 'UnsupportedOperation' });
+  });
+});

--- a/src/specs/NativeA0Auth0.ts
+++ b/src/specs/NativeA0Auth0.ts
@@ -206,6 +206,35 @@ export interface Spec extends TurboModule {
   ): Promise<Credentials>;
 
   /**
+   * Issue a passwordless OTP challenge to an email address for a database connection.
+   */
+  passwordlessChallengeWithEmail(
+    email: string,
+    connection: string,
+    allowSignup: boolean
+  ): Promise<{ authSession: string }>;
+
+  /**
+   * Issue a passwordless OTP challenge to a phone number for a database connection.
+   */
+  passwordlessChallengeWithPhoneNumber(
+    phoneNumber: string,
+    connection: string,
+    deliveryMethod: string,
+    allowSignup: boolean
+  ): Promise<{ authSession: string }>;
+
+  /**
+   * Complete a passwordless OTP flow by verifying the code and obtaining credentials.
+   */
+  passwordlessLoginWithOTP(
+    authSession: string,
+    otp: string,
+    audience: string | undefined,
+    scope: string | undefined
+  ): Promise<Credentials>;
+
+  /**
    * Request a passkey enrollment challenge from the My Account API.
    */
   passkeyEnrollmentChallenge(

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -35,6 +35,22 @@ export type Credentials = {
 };
 
 /**
+ * Result of a passwordless OTP challenge for a database connection.
+ *
+ * Holds the opaque `auth_session` token returned when a challenge is issued.
+ * Pass the whole object back to `loginWithOTP` together with the code the user
+ * received — the token is opaque and should not be inspected.
+ *
+ * @remarks Native only (iOS, Android). Not supported on web.
+ */
+export type PasswordlessChallenge = {
+  /** The opaque auth session token used to complete the OTP login. */
+  authSession: string;
+  /** Allows for additional, non-standard properties returned from the server. */
+  [key: string]: any;
+};
+
+/**
  * Represents the session transfer credentials used for Native to Web SSO.
  * These credentials are obtained by exchanging a refresh token and can be used
  * to authenticate in web contexts without requiring the user to log in again.

--- a/src/types/parameters.ts
+++ b/src/types/parameters.ts
@@ -576,6 +576,9 @@ export interface PasswordlessLoginOtpParameters {
   audience?: string;
   /**
    * Space-separated list of OAuth 2.0 scopes.
+   *
+   * An empty string is treated the same as omitting the value and falls back
+   * to the default. The `openid` scope is always included by the underlying SDK.
    * @default "openid profile email"
    */
   scope?: string;

--- a/src/types/parameters.ts
+++ b/src/types/parameters.ts
@@ -1,4 +1,4 @@
-import type { TokenType } from './common';
+import type { PasswordlessChallenge, TokenType } from './common';
 
 /** A base interface for API calls that allow passing custom headers.
  * @hidden
@@ -484,6 +484,101 @@ export interface PasskeyAuthenticationMethod {
   aaguid: string;
   /** Relying party identifier. */
   relyingPartyId: string;
+}
+
+// ========= Passwordless OTP (Database Connections) =========
+
+/**
+ * Runtime constants for passwordless OTP delivery methods.
+ *
+ * `TEXT` sends the one-time code via SMS (the server default); `VOICE`
+ * delivers it through a voice call.
+ *
+ * @example
+ * ```typescript
+ * import { DeliveryMethod } from 'react-native-auth0';
+ *
+ * await auth0.passwordless.challengeWithPhoneNumber({
+ *   phoneNumber: '+15555550123',
+ *   connection: 'Username-Password-Authentication',
+ *   deliveryMethod: DeliveryMethod.VOICE,
+ * });
+ * ```
+ */
+export const DeliveryMethod = {
+  TEXT: 'text',
+  VOICE: 'voice',
+} as const;
+
+/**
+ * Delivery method for a phone-number OTP challenge.
+ *
+ * Derived from {@link DeliveryMethod} so the union and the runtime constants
+ * cannot drift apart.
+ */
+export type PasswordlessDeliveryMethod =
+  (typeof DeliveryMethod)[keyof typeof DeliveryMethod];
+
+/**
+ * Parameters for issuing a passwordless OTP challenge to an email address.
+ *
+ * @remarks Native only (iOS, Android). Not supported on web.
+ */
+export interface PasswordlessChallengeEmailParameters {
+  /** The email address to send the one-time code to. */
+  email: string;
+  /**
+   * The name of the database connection; it must have `email_otp` enabled.
+   */
+  connection: string;
+  /**
+   * Whether to allow sign-up if the user does not yet exist.
+   * @default false
+   */
+  allowSignup?: boolean;
+}
+
+/**
+ * Parameters for issuing a passwordless OTP challenge to a phone number.
+ *
+ * @remarks Native only (iOS, Android). Not supported on web.
+ */
+export interface PasswordlessChallengePhoneParameters {
+  /** The E.164 phone number to send the one-time code to (e.g. `"+15555550123"`). */
+  phoneNumber: string;
+  /**
+   * The name of the database connection; it must have `phone_otp` enabled.
+   */
+  connection: string;
+  /**
+   * How to deliver the code, by SMS or voice call.
+   * @default "text"
+   */
+  deliveryMethod?: PasswordlessDeliveryMethod;
+  /**
+   * Whether to allow sign-up if the user does not yet exist.
+   * @default false
+   */
+  allowSignup?: boolean;
+}
+
+/**
+ * Parameters for completing a passwordless OTP flow by verifying the code.
+ *
+ * @remarks Native only (iOS, Android). Not supported on web.
+ */
+export interface PasswordlessLoginOtpParameters {
+  /** The challenge returned by a prior `challengeWithEmail`/`challengeWithPhoneNumber` call. */
+  challenge: PasswordlessChallenge;
+  /** The one-time code the user received via email, SMS, or voice call. */
+  otp: string;
+  /** The target API identifier for the issued access token. */
+  audience?: string;
+  /**
+   * Space-separated list of OAuth 2.0 scopes.
+   * @default "openid profile email"
+   */
+  scope?: string;
 }
 
 // ========= My Account — Authentication Method Management =========


### PR DESCRIPTION
Adds support for **Passwordless OTP on database connections** — an embedded (non-redirect) flow where a user authenticates with a one-time code sent to their email or phone, against a  standard database connection that has `email_otp` / `phone_otp` enabled.                                                                               
                                                                                                                                     
  This is distinct from the existing `/passwordless/start` flow (which only works with dedicated `email`/`sms` strategy connections). It is delegated to the native SDKs (Auth0.swift ≥ 2.23.0, Auth0.Android ≥ 3.20.0) and exposed through a new `auth0.passwordless` namespace.                                                                      
                                                                                                                                                         
  > **Note:** Not supported on web — calls reject with `UnsupportedOperation`.                                                                           
                                                                                                                                                         
  ## Public API                                                                                                                                          
                                                                                                                                     
  A new `passwordless` client, available on both the `Auth0` instance and the `useAuth0` hook:                                                           
  
  ```ts                                                                                                                                                  
  passwordless.challengeWithEmail(params): Promise<PasswordlessChallenge>                                                            
  passwordless.challengeWithPhoneNumber(params): Promise<PasswordlessChallenge>                                                                          
  passwordless.loginWithOTP(params): Promise<Credentials>                                                                                                
   ```                                                                 
- connection is required (the database connection name).                                                                                               
- deliveryMethod (phone only) is 'text' | 'voice', defaults to 'text'.                                                                                 
- allowSignup defaults to false.                                                                                                                       
- The PasswordlessChallenge returned by a challenge is opaque — pass it straight into loginWithOTP.                                                    
                                                                                                                                                         
### Example                                                                                                                                                
  ```ts                                                                                                                                          
  import { useAuth0 } from 'react-native-auth0';                                                                                     
                                                                                                                                                         
  const { passwordless } = useAuth0();
                                                                                                                                                         
  // 1. Request a code                                                                                                               
  const challenge = await passwordless.challengeWithEmail({
    email: 'user@example.com',                                                                                                                           
    connection: 'Username-Password-Authentication',                                                                                                      
  });                                                                                                                                                    
                                                                                                                                                         
  // 2. Verify the code the user received                                                                                                                
  const credentials = await passwordless.loginWithOTP({
    challenge,                                                                                                                                           
    otp: '123456',                                                                                                                   
  });                                                                                                                                                    
  ```                                                                                                                                   
  > Class-based usage is identical via `auth0.passwordless.*`.                                                                                               
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native-only Passwordless OTP (database connections) support to request email/phone challenges and complete sign-in with an OTP.
  * Exposed a new `passwordless` API in the SDK, including native bindings (web will report it as unsupported).
* **Documentation**
  * Expanded authentication examples with a Passwordless OTP (database connections) flow.
* **Tests**
  * Added coverage for native passwordless behavior and confirmed web rejects with an “unsupported” error.
* **Chores**
  * Updated Auth0 dependency versions for iOS/Android.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->