### PR TITLE
ci: set read-only workflow token permissions

### DIFF
--- a/.github/workflows/sca_scan.yml
+++ b/.github/workflows/sca_scan.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ['master', 'main', '**']
 
+
+permissions:
+  contents: read
 jobs:
   snyk-cli:
     uses: auth0/devsecops-tooling/.github/workflows/sca-scan.yml@main


### PR DESCRIPTION
## Summary
- set explicit read-only `GITHUB_TOKEN` permissions for CI workflows that only need repository checkout/read access
- leave release/deploy/write-capable workflows unchanged

## Why
This follows GitHub Actions least-privilege guidance and reduces the default token scope available to routine CI jobs without changing the test/build commands.

## Verification
- Parsed the changed workflow YAML with PyYAML.
- Ran `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated scan workflow to explicitly set GitHub Actions permissions for the run.
* **Security**
  * Restricted access to repository contents to read-only during these checks.
  * Improves least-privilege handling and clarity for automated security scanning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->