### PR TITLE
chore: add build provenance workflow

### DIFF
--- a/.github/workflows/provenance.yml
+++ b/.github/workflows/provenance.yml
@@ -1,0 +1,92 @@
+name: Build with Provenance
+
+# Reference template: build provenance via Sigstore-backed attestation.
+# ─────────────────────────────────────────────────────────────────────
+# Copy the `build` job below into your own workflow. Do NOT copy it into
+# unified-security-pipeline.yml — provenance must live in the same job that
+# builds and publishes the artifact so the GitHub OIDC identity honestly
+# binds to the run that produced it. Attesting from a different job or
+# workflow would be a false supply-chain claim.
+#
+# Order of operations (required)
+# ───────────────────────────────
+#   1. checkout
+#   2. <your build command>  — artifact file must exist on disk before step 3
+#   3. attest-build-provenance — computes artifact digest and signs it
+#   4. (optional) upload / publish the artifact
+#
+# Permissions (caller job must declare all three)
+# ────────────────────────────────────────────────
+#   contents: read      — checkout
+#   id-token: write     — request OIDC token; Sigstore Fulcio uses this to issue
+#                         a short-lived signing certificate bound to this workflow run
+#   attestations: write — store the signed attestation on GitHub
+#
+# Verification (consumer side)
+# ─────────────────────────────
+#   gh attestation verify <artifact-file> --repo <org>/<repo>
+#
+# npm packages — different mechanism
+# ───────────────────────────────────
+#   For packages published to the npm registry, do NOT use this action for
+#   registry-visible provenance (the npmjs.com badge). Instead, run:
+#     npm publish --provenance
+#   First publish of a new package also needs: npm publish --provenance --access public
+#   Requirements: npm >= 9.5.0, GitHub-hosted runner, id-token: write, and a
+#   matching `repository` field in package.json (case-sensitive). The npm CLI
+#   generates and signs the provenance itself (Sigstore-backed) directly to the
+#   npm registry. Under trusted publishing the --provenance flag is automatic.
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+
+jobs:
+  # ── Caller-owned build: produce the artifact, attest, then publish ──────────
+  build:
+    name: Build
+    runs-on: ubuntu-latest # Use a runner that supports OIDC (Ubuntu, Windows, macOS)
+    permissions:
+      contents: read
+      id-token: write      # OIDC token for Sigstore Fulcio signing certificate
+      attestations: write  # write the signed attestation to GitHub
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # ── Replace this block with your actual build steps ──────────────────────
+      # Examples:
+      #   Maven:   run: mvn --no-transfer-progress package -DskipTests
+      #   Go:      run: go build -o ./bin/myapp ./...
+      #   Node:    run: npm ci && npm run build
+      #             ↳ If publishing to the npm registry, use `npm publish --provenance`
+      #               instead of the attest-build-provenance step below — see note above.
+      #   .NET:    run: dotnet publish -c Release -o ./publish
+      # ─────────────────────────────────────────────────────────────────────────
+      - name: Build artifact
+        run: echo "Replace this step with your build command"
+
+      # ── Attest: must run AFTER the artifact exists on disk ───────────────────
+      # For file/path-based artifacts (JAR, binary, tarball, etc.):
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          # Replace with the path (or glob) to your built artifact, e.g.:
+          #   target/my-sdk-*.jar   |   dist/my-app-*.tgz   |   bin/myapp
+          subject-path: path/to/your/artifact
+
+          # ── Container image alternative (comment out subject-path above) ─────
+          # subject-name: ghcr.io/<org>/<image>   # fully-qualified image name
+          # subject-digest: sha256:<digest>        # exact digest of the pushed image
+          # push-to-registry: true                 # push attestation to the image registry
+
+      # ── Optional: upload artifact for downstream jobs / release assets ───────
+      # - name: Upload artifact
+      #   uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      #   with:
+      #     name: <artifact-name>
+      #     path: <artifact-path>
+      #     if-no-files-found: error


### PR DESCRIPTION
## ✏️ Changes

This pull request adds a security hardening workflow from the unified-pipeline-template (https://github.com/atko-cic/unified-pipeline-template/security). **No functional changes are introduced.**





### Build Provenance

This PR adds `.github/workflows/provenance.yml` from the unified-pipeline-template.

> **⚠️ Before merging, review the added `.github/workflows/provenance.yml` and make the changes described below, plus any other adjustments your CI environment requires.**

> **📦 Publishing to the npm registry?** Do not use `actions/attest-build-provenance` for npm-registry provenance (the npmjs.com badge). Instead, run `npm publish --provenance` (npm ≥ 9.5.0, GitHub-hosted runner, `id-token: write`, and a `repository` field in `package.json` that matches case-sensitively). For a package's first publish, also add `--access public`: `npm publish --provenance --access public`. The npm CLI generates and signs provenance directly to the registry; `attest-build-provenance` only produces a GitHub-side attestation.
>
> **If this repo only builds and publishes an npm package and already runs `npm publish --provenance`, build provenance is fully covered — close and discard this PR.**

> **⚠️ Required before attestation is meaningful — the build must happen in this job:**
> 1. **Build & pass:** replace the `Build artifact` placeholder step with your real build command so the artifact exists on disk before the `Attest build provenance` step runs, then set `subject-path` to that artifact.
> 2. **Adapt into your existing build job:** move the `Attest build provenance` step into the job that already builds and publishes your artifact — provenance must live in the **same job** that produces it. Attesting from a separate job would be a false supply-chain claim.
>
> Optionally, add an `upload-artifact` step after attestation to pass the attested artifact to downstream jobs or release assets.

### Placeholders to fill in before merging

| Placeholder | Description |
|---|---|
| `echo "Replace this step with your build command"` | Replace with your real build command (e.g. `go build`, `mvn package`, `npm run build`) — the artifact must exist on disk before the attestation step |
| `path/to/your/artifact` | Set `subject-path` to the concrete path (or glob) of the built artifact to attest |

## 🔮 Type of Change

- [x] Standard

## 🔗 References

https://auth0team.atlassian.net/browse/SEPIO-1674

- [x] I added at least one link (task, slack thread, etc) to explain why this change is needed.

## 📖 Documentation

No user-facing changes have been introduced.

- [x] I reflected this change in the (internal and/or user-facing) documentation, or added an explanation for why no documentation update is needed.

## 🎯 Testing

This change adds a CI workflow only; validated by the workflow running on this PR.

- [x] This change has integration, unit, or performance test coverage, or I explained why not.

## 🚀 Deployment

- [x] This change can support multiple releases of the code serving traffic at the same time.

## 🔥 Rollback

Reverting this PR removes the added workflow file — no further action required.

- [x] I explained what the rollback for this change will look like.