### PR TITLE
refactor: deprecate the legacy MFA methods on the auth client

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -187,11 +187,22 @@ authorize({}, { customScheme: 'YOUR_AUTH0_DOMAIN' })
 
 ### Login using MFA with One Time Password code
 
+> **Deprecated — will be removed in v6.** The MFA methods on the auth client (`auth.loginWithOTP`, `auth.loginWithOOB`, `auth.loginWithRecoveryCode`, `auth.multifactorChallenge`) are superseded by the [`mfa` client](#mfa-flexible-factors-grant), which also lets you list and enrol authenticators. See the mapping table in the [Migration Guide](MIGRATION_GUIDE.md#mfa-methods-on-the-auth-client).
+
 This call requires the client to have the _MFA_ Client Grant Type enabled. Check [this article](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
 
-When you sign in to a multifactor authentication enabled connection using the `passwordRealm` method, you receive an error stating that MFA is required for that user along with an `mfa_token` value. Use this value to call `loginWithOTP` and complete the MFA flow passing the One Time Password from the enrolled MFA code generator app.
+When you sign in to a multifactor authentication enabled connection using the `passwordRealm` method, you receive an error stating that MFA is required for that user along with an `mfa_token` value. Use this value to complete the MFA flow, passing the One Time Password from the enrolled MFA code generator app.
 
 ```js
+// Recommended: the `mfa` client
+const credentials = await auth0.mfa.verify({
+  mfaToken: error.json.mfa_token,
+  otp: '{user entered OTP}',
+});
+```
+
+```js
+// Deprecated: removed in v6
 auth0.auth
   .loginWithOTP({
     mfaToken: error.json.mfa_token,

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -187,7 +187,7 @@ authorize({}, { customScheme: 'YOUR_AUTH0_DOMAIN' })
 
 ### Login using MFA with One Time Password code
 
-> **Deprecated — will be removed in v6.** The MFA methods on the auth client (`auth.loginWithOTP`, `auth.loginWithOOB`, `auth.loginWithRecoveryCode`, `auth.multifactorChallenge`) are superseded by the [`mfa` client](#mfa-flexible-factors-grant), which also lets you list and enrol authenticators. See the mapping table in the [Migration Guide](MIGRATION_GUIDE.md#mfa-methods-on-the-auth-client).
+> **Deprecated — will be removed in v6.** The MFA methods on the auth client (`auth0.auth.loginWithOTP`, `auth0.auth.loginWithOOB`, `auth0.auth.loginWithRecoveryCode`, `auth0.auth.multifactorChallenge`) are superseded by the [`mfa` client](#mfa-flexible-factors-grant), which also lets you list and enrol authenticators. See the mapping table in the [Migration Guide](MIGRATION_GUIDE.md#mfa-methods-on-the-auth-client).
 
 This call requires the client to have the _MFA_ Client Grant Type enabled. Check [this article](https://auth0.com/docs/clients/client-grant-types) to learn how to enable it.
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -28,6 +28,13 @@ The same applies to the `useAuth0()` hook: `authorizeWithOTP`, `authorizeWithOOB
 >
 > ```js
 > const authenticators = await auth0.mfa.getAuthenticators({ mfaToken });
+>
+> // A user can reach MFA_REQUIRED with nothing enrolled yet — enrol a factor
+> // with `auth0.mfa.enroll()` before challenging.
+> if (authenticators.length === 0) {
+>   return promptEnrollment();
+> }
+>
 > const challenge = await auth0.mfa.challenge({
 >   mfaToken,
 >   authenticatorId: authenticators[0].id,

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -1,5 +1,39 @@
 # Migration Guide
 
+## Deprecated in v5.x — removed in v6
+
+These APIs still work in v5.x but emit a deprecation warning and will be **removed in v6**. Migrating now means no code changes are needed when you upgrade.
+
+### MFA methods on the auth client
+
+The MFA methods on `auth0.auth` are deprecated in favour of the dedicated `auth0.mfa` client, which covers the same grants and adds authenticator listing and enrolment. The `mfa` client is available on iOS, Android, and web.
+
+| Deprecated on `auth0.auth`                            | Use instead on `auth0.mfa`                   |
+| :---------------------------------------------------- | :------------------------------------------- |
+| `loginWithOTP({ mfaToken, otp })`                     | `verify({ mfaToken, otp })`                  |
+| `loginWithOOB({ mfaToken, oobCode, bindingCode })`    | `verify({ mfaToken, oobCode, bindingCode })` |
+| `loginWithRecoveryCode({ mfaToken, recoveryCode })`   | `verify({ mfaToken, recoveryCode })`         |
+| `multifactorChallenge({ mfaToken, authenticatorId })` | `challenge({ mfaToken, authenticatorId })`   |
+
+The same applies to the `useAuth0()` hook: `authorizeWithOTP`, `authorizeWithOOB`, `authorizeWithRecoveryCode`, and `sendMultifactorChallenge` are deprecated in favour of `mfa`.
+
+```diff
+- const credentials = await auth0.auth.loginWithOTP({ mfaToken, otp });
++ const credentials = await auth0.mfa.verify({ mfaToken, otp });
+```
+
+`verify()` is a superset of the three `loginWith*` methods — it also accepts `scope` and `audience` for the returned credentials.
+
+> **One behavioural difference.** `multifactorChallenge()` treated `authenticatorId` as optional, letting Auth0 pick a default factor. On `mfa.challenge()` it is **required**. If you relied on omitting it, list the user's authenticators first and pass an explicit id:
+>
+> ```js
+> const authenticators = await auth0.mfa.getAuthenticators({ mfaToken });
+> const challenge = await auth0.mfa.challenge({
+>   mfaToken,
+>   authenticatorId: authenticators[0].id,
+> });
+> ```
+
 ## Upgrading from v4 -> v5
 
 Version 5.0 of `react-native-auth0` is a significant update featuring a complete architectural overhaul. This new foundation improves performance, maintainability, and provides a more consistent API across all platforms.

--- a/src/core/interfaces/IAuthenticationProvider.ts
+++ b/src/core/interfaces/IAuthenticationProvider.ts
@@ -36,11 +36,32 @@ export interface IAuthenticationProvider {
   passwordlessWithSMS(parameters: PasswordlessSmsParameters): Promise<void>;
   loginWithEmail(parameters: LoginEmailParameters): Promise<Credentials>;
   loginWithSMS(parameters: LoginSmsParameters): Promise<Credentials>;
+  /**
+   * @deprecated Will be removed in v6. Use `auth0.mfa.verify({ mfaToken, otp })`
+   * instead, which additionally accepts `scope` and `audience`.
+   */
   loginWithOTP(parameters: LoginOtpParameters): Promise<Credentials>;
+  /**
+   * @deprecated Will be removed in v6. Use
+   * `auth0.mfa.verify({ mfaToken, oobCode, bindingCode })` instead, which
+   * additionally accepts `scope` and `audience`.
+   */
   loginWithOOB(parameters: LoginOobParameters): Promise<Credentials>;
+  /**
+   * @deprecated Will be removed in v6. Use
+   * `auth0.mfa.verify({ mfaToken, recoveryCode })` instead, which additionally
+   * accepts `scope` and `audience`.
+   */
   loginWithRecoveryCode(
     parameters: LoginRecoveryCodeParameters
   ): Promise<Credentials>;
+  /**
+   * @deprecated Will be removed in v6. Use
+   * `auth0.mfa.challenge({ mfaToken, authenticatorId })` instead. Note that
+   * `authenticatorId` is required there — if you relied on omitting it to let
+   * Auth0 pick a default factor, call `auth0.mfa.getAuthenticators({ mfaToken })`
+   * first and pass an explicit id.
+   */
   multifactorChallenge(
     parameters: MfaChallengeParameters
   ): Promise<MfaChallengeResponse>;

--- a/src/core/services/AuthenticationOrchestrator.ts
+++ b/src/core/services/AuthenticationOrchestrator.ts
@@ -292,7 +292,13 @@ export class AuthenticationOrchestrator implements IAuthenticationProvider {
     return CredentialsModel.fromResponse(json);
   }
 
+  /**
+   * @deprecated Will be removed in v6. Use `auth0.mfa.verify({ mfaToken, otp })`.
+   */
   async loginWithOTP(parameters: LoginOtpParameters): Promise<Credentials> {
+    console.warn(
+      '`auth.loginWithOTP()` is deprecated and will be removed in v6. Use `mfa.verify({ mfaToken, otp })` instead.'
+    );
     validateParameters(parameters, ['mfaToken', 'otp']);
     const { headers, ...payload } = parameters;
     const body = {
@@ -311,7 +317,14 @@ export class AuthenticationOrchestrator implements IAuthenticationProvider {
     return CredentialsModel.fromResponse(json);
   }
 
+  /**
+   * @deprecated Will be removed in v6. Use
+   * `auth0.mfa.verify({ mfaToken, oobCode, bindingCode })`.
+   */
   async loginWithOOB(parameters: LoginOobParameters): Promise<Credentials> {
+    console.warn(
+      '`auth.loginWithOOB()` is deprecated and will be removed in v6. Use `mfa.verify({ mfaToken, oobCode, bindingCode })` instead.'
+    );
     validateParameters(parameters, ['mfaToken', 'oobCode']);
     const { headers, ...payload } = parameters;
     const body = {
@@ -331,9 +344,16 @@ export class AuthenticationOrchestrator implements IAuthenticationProvider {
     return CredentialsModel.fromResponse(json);
   }
 
+  /**
+   * @deprecated Will be removed in v6. Use
+   * `auth0.mfa.verify({ mfaToken, recoveryCode })`.
+   */
   async loginWithRecoveryCode(
     parameters: LoginRecoveryCodeParameters
   ): Promise<Credentials> {
+    console.warn(
+      '`auth.loginWithRecoveryCode()` is deprecated and will be removed in v6. Use `mfa.verify({ mfaToken, recoveryCode })` instead.'
+    );
     validateParameters(parameters, ['mfaToken', 'recoveryCode']);
     const { headers, ...payload } = parameters;
     const body = {
@@ -352,9 +372,17 @@ export class AuthenticationOrchestrator implements IAuthenticationProvider {
     return CredentialsModel.fromResponse(json);
   }
 
+  /**
+   * @deprecated Will be removed in v6. Use
+   * `auth0.mfa.challenge({ mfaToken, authenticatorId })`, where `authenticatorId`
+   * is required — list them with `auth0.mfa.getAuthenticators({ mfaToken })`.
+   */
   async multifactorChallenge(
     parameters: MfaChallengeParameters
   ): Promise<MfaChallengeResponse> {
+    console.warn(
+      '`auth.multifactorChallenge()` is deprecated and will be removed in v6. Use `mfa.challenge({ mfaToken, authenticatorId })` instead; list authenticators with `mfa.getAuthenticators({ mfaToken })`.'
+    );
     validateParameters(parameters, ['mfaToken']);
     const { headers, ...payload } = parameters;
     const body = {

--- a/src/core/services/__tests__/AuthenticationOrchestrator.spec.ts
+++ b/src/core/services/__tests__/AuthenticationOrchestrator.spec.ts
@@ -564,6 +564,53 @@ describe('AuthenticationOrchestrator', () => {
 
   // New tests for MFA flows
   describe('MFA flows', () => {
+    // These methods are deprecated in favour of the `mfa` client and warn on
+    // every call; silence the noise but assert the warning separately below.
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it.each([
+      [
+        'loginWithOTP',
+        { mfaToken: 'mfa_token_123', otp: '123456' },
+        'mfa.verify',
+      ],
+      [
+        'loginWithOOB',
+        { mfaToken: 'mfa_token_123', oobCode: 'oob_123' },
+        'mfa.verify',
+      ],
+      [
+        'loginWithRecoveryCode',
+        { mfaToken: 'mfa_token_123', recoveryCode: 'rec_123' },
+        'mfa.verify',
+      ],
+      ['multifactorChallenge', { mfaToken: 'mfa_token_123' }, 'mfa.challenge'],
+    ])(
+      '%s warns that it is deprecated and names its replacement',
+      async (method, parameters, replacement) => {
+        mockHttpClientInstance.post.mockResolvedValueOnce({
+          json: tokensResponse,
+          response: new Response(null, { status: 200 }),
+        });
+
+        await (orchestrator as any)[method](parameters);
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const message = warnSpy.mock.calls[0]?.[0] as string;
+        expect(message).toContain(method);
+        expect(message).toContain('v6');
+        expect(message).toContain(replacement);
+      }
+    );
+
     it('loginWithOTP should send correct payload', async () => {
       mockHttpClientInstance.post.mockResolvedValueOnce({
         json: tokensResponse,

--- a/src/hooks/Auth0Context.ts
+++ b/src/hooks/Auth0Context.ts
@@ -360,6 +360,9 @@ export interface Auth0ContextInterface extends AuthState {
    * @param parameters The parameters for the multifactor challenge.
    * @returns A promise that resolves when the challenge has been sent.
    * @throws {AuthError} If sending the challenge fails.
+   *
+   * @deprecated Will be removed in v6. Use `mfa.challenge({ mfaToken, authenticatorId })`,
+   * where `authenticatorId` is required — list them with `mfa.getAuthenticators({ mfaToken })`.
    */
   sendMultifactorChallenge: (
     parameters: MfaChallengeParameters
@@ -370,6 +373,8 @@ export interface Auth0ContextInterface extends AuthState {
    * @param parameters The parameters for OOB authorization.
    * @returns A promise that resolves with the user's credentials.
    * @throws {AuthError} If the authorization fails.
+   *
+   * @deprecated Will be removed in v6. Use `mfa.verify({ mfaToken, oobCode, bindingCode })`.
    */
   authorizeWithOOB: (parameters: LoginOobParameters) => Promise<Credentials>;
 
@@ -378,6 +383,8 @@ export interface Auth0ContextInterface extends AuthState {
    * @param parameters The parameters for OTP authorization.
    * @returns A promise that resolves with the user's credentials.
    * @throws {AuthError} If the authorization fails.
+   *
+   * @deprecated Will be removed in v6. Use `mfa.verify({ mfaToken, otp })`.
    */
   authorizeWithOTP: (parameters: LoginOtpParameters) => Promise<Credentials>;
 
@@ -386,6 +393,8 @@ export interface Auth0ContextInterface extends AuthState {
    * @param parameters The parameters for recovery code authorization.
    * @returns A promise that resolves with the user's credentials.
    * @throws {AuthError} If the authorization fails.
+   *
+   * @deprecated Will be removed in v6. Use `mfa.verify({ mfaToken, recoveryCode })`.
    */
   authorizeWithRecoveryCode: (
     parameters: LoginRecoveryCodeParameters


### PR DESCRIPTION
### Changes

Deprecates the four MFA methods on `auth0.auth` in favour of the dedicated `auth0.mfa` client, so consumers get a migration runway before they are removed in v6. Nothing is removed and no behaviour changes — each method keeps working, but now carries a `@deprecated` JSDoc tag (so editors show a strikethrough) and logs a one-line warning naming its replacement.

The `mfa` client covers the same grants and additionally supports listing and enrolling authenticators. It is available on iOS, Android, and web.

| Deprecated on `auth0.auth`                            | Use instead on `auth0.mfa`                   |
| :---------------------------------------------------- | :------------------------------------------- |
| `loginWithOTP({ mfaToken, otp })`                     | `verify({ mfaToken, otp })`                  |
| `loginWithOOB({ mfaToken, oobCode, bindingCode })`    | `verify({ mfaToken, oobCode, bindingCode })` |
| `loginWithRecoveryCode({ mfaToken, recoveryCode })`   | `verify({ mfaToken, recoveryCode })`         |
| `multifactorChallenge({ mfaToken, authenticatorId })` | `challenge({ mfaToken, authenticatorId })`   |

```diff
- const credentials = await auth0.auth.loginWithOTP({ mfaToken, otp });
+ const credentials = await auth0.mfa.verify({ mfaToken, otp });
```

`verify()` is a superset of the three `loginWith*` methods — it also accepts `scope` and `audience` for the returned credentials. The equivalents exposed on `useAuth0()` (`authorizeWithOTP`, `authorizeWithOOB`, `authorizeWithRecoveryCode`, `sendMultifactorChallenge`) are deprecated too.

One migration is not a straight rename, and both the warning and the migration guide call it out: `multifactorChallenge()` treated `authenticatorId` as optional and let Auth0 pick a default factor, whereas `mfa.challenge()` requires it. Anyone relying on that needs to call `mfa.getAuthenticators({ mfaToken })` first and pass an explicit id.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Deprecated legacy MFA authentication methods with guidance to use the dedicated MFA verification and challenge APIs.
  * Deprecated methods now display runtime warnings identifying their recommended replacements and v6 availability.

* **Documentation**
  * Added v5-to-v6 migration guidance, including authenticator selection, enrollment, and updated OTP verification examples.

* **Tests**
  * Added coverage to confirm deprecation warnings are emitted correctly for legacy MFA methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->