### PR TITLE
feat: support ephemeral sessions on Android

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2767,7 +2767,7 @@ The same `useTrustedWebActivity` option is also accepted by `clearSession` so th
 
 ## Ephemeral Sessions
 
-Pass `ephemeralSession: true` to run web authentication in an isolated, incognito-like browser session. Cookies, cache and history from the login flow are discarded when the browser closes, so no shared session cookie is left behind and Single Sign-On (SSO) does not apply.
+Pass `ephemeralSession: true` to run web authentication in an isolated browser session, so no shared session cookie is left behind. When the browser honours the request, Single Sign-On (SSO) does not apply.
 
 **Behaviour:**
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -97,6 +97,8 @@
 - [Allowed Browsers (Android)](#allowed-browsers-android)
   - [Using with Hooks](#using-with-hooks)
   - [Using with Auth0 Class](#using-with-auth0-class-1)
+- [Trusted Web Activity (Android)](#trusted-web-activity-android)
+- [Ephemeral Sessions](#ephemeral-sessions)
 - [Recovering Login After Process Death (Android)](#recovering-login-after-process-death-android)
   - [Using with Hooks](#recovering-login-using-hooks)
   - [Using with Auth0 Class](#recovering-login-using-the-auth0-class)
@@ -2762,6 +2764,49 @@ await auth0.webAuth.authorize(
 ```
 
 The same `useTrustedWebActivity` option is also accepted by `clearSession` so the logout flow opens in a Trusted Web Activity as well.
+
+## Ephemeral Sessions
+
+Pass `ephemeralSession: true` to run web authentication in an isolated, incognito-like browser session. Cookies, cache and history from the login flow are discarded when the browser closes, so no shared session cookie is left behind and Single Sign-On (SSO) does not apply.
+
+**Behaviour:**
+
+- **iOS:** sets `prefersEphemeralWebBrowserSession` on `ASWebAuthenticationSession`. Because there is no shared cookie to consent to, this also suppresses the SSO alert box. Requires iOS 13+.
+- **Android:** opens the Custom Tab with ephemeral browsing. Requires **Chrome 136+** or another browser that supports it; on unsupported browsers a warning is logged and the flow falls back to a regular Custom Tab — login still completes, but the session is not ephemeral.
+
+> **Platform Support:** iOS and Android. This option is ignored on web.
+
+> **Warning:** On Android, `ephemeralSession` and [`useTrustedWebActivity`](#trusted-web-activity-android) are effectively mutually exclusive. A Trusted Web Activity does not support ephemeral browsing, so if you enable both, TWA takes precedence and the session will **not** be ephemeral. Pick one.
+
+> **Note:** Android support for ephemeral sessions was added in v6. In earlier versions the option was accepted but only took effect on iOS.
+
+### Using with Hooks
+
+```typescript
+import { useAuth0 } from 'react-native-auth0';
+
+const { authorize } = useAuth0();
+
+await authorize({ scope: 'openid profile email' }, { ephemeralSession: true });
+```
+
+### Using with Auth0 Class
+
+```typescript
+import Auth0 from 'react-native-auth0';
+
+const auth0 = new Auth0({
+  domain: 'YOUR_AUTH0_DOMAIN',
+  clientId: 'YOUR_AUTH0_CLIENT_ID',
+});
+
+await auth0.webAuth.authorize(
+  { scope: 'openid profile email' },
+  { ephemeralSession: true }
+);
+```
+
+Because no shared session cookie is stored, you do not need to call `clearSession` to log the user out of the browser session — clearing the stored credentials is enough. Note that this holds only when the browser actually honoured the ephemeral request; on an Android browser that fell back to a regular Custom Tab, a shared cookie may still be present.
 
 ## Recovering Login After Process Death (Android)
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -90,7 +90,7 @@ auth0.webAuth
 
 Note that with `ephemeralSession: true` you don't need to call `clearSession` at all. Just clearing the credentials from the app will suffice. What `clearSession` does is clear the shared session cookie, so that in the next login call the user gets asked to log in again. But with `ephemeralSession: true` there will be no shared cookie to remove.
 
-You still need to call `clearSession` on Android, though, as `ephemeralSession` is iOS-only.
+As of v6, `ephemeralSession` also works on Android, where it opens the Custom Tab with ephemeral browsing. This requires Chrome 136+ (or another browser that supports it); on unsupported browsers the flow falls back to a regular Custom Tab, which does keep a shared cookie — so keep calling `clearSession` on Android unless you can guarantee the browser honours the ephemeral request.
 
 ### Use `SFSafariViewController`
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -143,7 +143,24 @@ For updating `user_metadata`, expose an endpoint on your backend that performs t
 
 ### 8. Native SDK API alignment (Auth0.Android v4 / Auth0.swift v3) ✅
 
-Adopting the new native SDK majors changes two parts of the public surface.
+Adopting the new native SDK majors changes three parts of the public surface.
+
+#### `ephemeralSession` now takes effect on Android
+
+Auth0.Android 4.0 added ephemeral browsing for Custom Tabs, so the `ephemeralSession` option on `authorize()` is no longer iOS-only. Previously the option was accepted on Android but silently ignored; it now opens the Custom Tab in an isolated session where cookies, cache and history are discarded when the browser closes.
+
+Requires **Chrome 136+** or another browser that supports ephemeral browsing. On unsupported browsers a warning is logged and the flow falls back to a regular Custom Tab, so login still completes but the session is not ephemeral.
+
+**⚠️ Action Required:** if your Android code passes `ephemeralSession: true` — for example because the same options object is shared across platforms — SSO will now be disabled on Android too, and users will be prompted to log in on every `authorize()` call. Set the flag per platform if you want to keep SSO on Android.
+
+```typescript
+await authorize(
+  { scope: 'openid profile email' },
+  { ephemeralSession: Platform.OS === 'ios' }
+);
+```
+
+Two further Android caveats: the fallback above means you should keep calling `clearSession` unless you can guarantee the browser honours the ephemeral request, and `ephemeralSession` has no effect when `useTrustedWebActivity` is also enabled (a Trusted Web Activity cannot browse ephemerally, so TWA wins). See [Ephemeral Sessions](EXAMPLES.md#ephemeral-sessions) for details.
 
 #### `SSOCredentials.expiresIn` is now `expiresAt`
 

--- a/android/src/main/java/com/auth0/react/A0Auth0Module.kt
+++ b/android/src/main/java/com/auth0/react/A0Auth0Module.kt
@@ -180,6 +180,9 @@ class A0Auth0Module(private val reactContext: ReactApplicationContext) : A0Auth0
                 )
             }
             if (useTrustedWebActivity) { withTrustedWebActivity() }
+            // Ephemeral browsing only applies to the Custom Tab path; the TWA intent
+            // builder ignores it, so TWA wins when both options are set.
+            if (ephemeralSession == true) { withEphemeralBrowsing() }
         }
 
         builder.withParameters(cleanedParameters)

--- a/example/src/screens/class-based/ClassLogin.tsx
+++ b/example/src/screens/class-based/ClassLogin.tsx
@@ -40,7 +40,8 @@ const ClassLoginScreen = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
-  const [useTrustedWebActivity, setUseTrustedWebActivity] = useState(true);
+  const [useTrustedWebActivity, setUseTrustedWebActivity] = useState(false);
+  const [ephemeralSession, setEphemeralSession] = useState(false);
 
   // MFA state (flat API-test panel)
   const [mfaToken, setMfaToken] = useState('');
@@ -68,10 +69,13 @@ const ClassLoginScreen = () => {
     setLoading(true);
     setError(null);
     try {
-      const credentials = await auth0.webAuth.authorize({
-        scope: 'openid profile email offline_access',
-        audience: `https://${config.domain}/api/v2/`,
-      });
+      const credentials = await auth0.webAuth.authorize(
+        {
+          scope: 'openid profile email offline_access',
+          audience: `https://${config.domain}/api/v2/`,
+        },
+        { useTrustedWebActivity, ephemeralSession }
+      );
       // On success, we save the credentials and navigate to the profile screen.
       await auth0.credentialsManager.saveCredentials(credentials);
       navigation.replace('ClassProfile', { credentials });
@@ -232,11 +236,27 @@ const ClassLoginScreen = () => {
               Dashboard; otherwise it falls back to a Custom Tab. Android only.
             </Text>
             <Button
-              onPress={() => setUseTrustedWebActivity((prev) => !prev)}
+              onPress={() => {
+                setUseTrustedWebActivity((prev) => !prev);
+                setEphemeralSession(false);
+              }}
               title={`Trusted Web Activity: ${
                 useTrustedWebActivity ? 'On' : 'Off'
               }`}
               style={!useTrustedWebActivity ? styles.inactiveButton : undefined}
+            />
+            <Text style={styles.description}>
+              Ephemeral session disables SSO by running login in an
+              incognito-like browser session. On Android this needs Chrome 136+
+              and falls back to a regular Custom Tab otherwise.
+            </Text>
+            <Button
+              onPress={() => {
+                setEphemeralSession((prev) => !prev);
+                setUseTrustedWebActivity(false);
+              }}
+              title={`Ephemeral Session: ${ephemeralSession ? 'On' : 'Off'}`}
+              style={!ephemeralSession ? styles.inactiveButton : undefined}
             />
           </>
         </Section>

--- a/example/src/screens/hooks/Home.tsx
+++ b/example/src/screens/hooks/Home.tsx
@@ -80,6 +80,7 @@ const HomeScreen = () => {
   const [otpChallenge, setOtpChallenge] =
     useState<PasswordlessChallenge | null>(null);
   const [useTrustedWebActivity, setUseTrustedWebActivity] = useState(false);
+  const [ephemeralSession, setEphemeralSession] = useState(false);
 
   // MFA wizard state
   const [mfaToken, setMfaToken] = useState('');
@@ -129,7 +130,7 @@ const HomeScreen = () => {
           scope: 'openid profile email offline_access',
           audience: `https://${config.domain}/api/v2/`,
         },
-        { useTrustedWebActivity }
+        { useTrustedWebActivity, ephemeralSession }
       );
     } catch (e: any) {
       if (e instanceof WebAuthError) {
@@ -921,11 +922,27 @@ const HomeScreen = () => {
               Dashboard; otherwise it falls back to a Custom Tab. Android only.
             </Text>
             <Button
-              onPress={() => setUseTrustedWebActivity((prev) => !prev)}
+              onPress={() => {
+                setUseTrustedWebActivity((prev) => !prev);
+                setEphemeralSession(false);
+              }}
               title={`Trusted Web Activity: ${
                 useTrustedWebActivity ? 'On' : 'Off'
               }`}
               style={!useTrustedWebActivity ? styles.inactiveButton : undefined}
+            />
+            <Text style={styles.description}>
+              Ephemeral session disables SSO by running login in an
+              incognito-like browser session. On Android this needs Chrome 136+
+              and falls back to a regular Custom Tab otherwise.
+            </Text>
+            <Button
+              onPress={() => {
+                setEphemeralSession((prev) => !prev);
+                setUseTrustedWebActivity(false);
+              }}
+              title={`Ephemeral Session: ${ephemeralSession ? 'On' : 'Off'}`}
+              style={!ephemeralSession ? styles.inactiveButton : undefined}
             />
             <Text style={styles.description}>
               Recovers a login that completed after the OS killed the app

--- a/src/platforms/native/bridge/__tests__/NativeBridgeManager.spec.ts
+++ b/src/platforms/native/bridge/__tests__/NativeBridgeManager.spec.ts
@@ -194,6 +194,36 @@ describe('NativeBridgeManager', () => {
       );
     });
 
+    it('should pass ephemeralSession to native webAuth when provided', async () => {
+      MockedAuth0NativeModule.webAuth.mockResolvedValueOnce(
+        nativeSuccessCredentials as any
+      );
+
+      await bridge.authorize(
+        { redirectUrl: 'com.myapp://cb' },
+        { customScheme: 'com.myapp', ephemeralSession: true }
+      );
+
+      expect(MockedAuth0NativeModule.webAuth).toHaveBeenCalledWith(
+        'com.myapp',
+        'com.myapp://cb',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        0,
+        undefined,
+        undefined,
+        0,
+        true, // ephemeralSession
+        99,
+        {},
+        undefined, // allowedBrowserPackages
+        false // useTrustedWebActivity
+      );
+    });
+
     it('should correctly transform the native response to a Credentials model', async () => {
       MockedAuth0NativeModule.webAuth.mockResolvedValueOnce(
         nativeSuccessCredentials as any

--- a/src/types/platform-specific.ts
+++ b/src/types/platform-specific.ts
@@ -110,9 +110,9 @@ export interface NativeAuthorizeOptions {
    */
   leeway?: number;
   /**
-   * Disable Single-Sign-On (SSO) by running web authentication in an isolated,
-   * incognito-like browser session. Cookies, cache and history from the login flow
-   * are discarded when the browser closes, so no shared session cookie is left behind.
+   * Run web authentication in an isolated browser session, so no shared session
+   * cookie is left behind. When the browser honours the request, Single Sign-On
+   * (SSO) does not apply.
    *
    * - **iOS:** sets `prefersEphemeralWebBrowserSession` on `ASWebAuthenticationSession`,
    *   which also suppresses the SSO consent alert box. Requires iOS 13+.

--- a/src/types/platform-specific.ts
+++ b/src/types/platform-specific.ts
@@ -110,8 +110,26 @@ export interface NativeAuthorizeOptions {
    */
   leeway?: number;
   /**
-   * **iOS only**: Disable Single-Sign-On (SSO). It only affects iOS with versions 13 and above.
+   * Disable Single-Sign-On (SSO) by running web authentication in an isolated,
+   * incognito-like browser session. Cookies, cache and history from the login flow
+   * are discarded when the browser closes, so no shared session cookie is left behind.
+   *
+   * - **iOS:** sets `prefersEphemeralWebBrowserSession` on `ASWebAuthenticationSession`,
+   *   which also suppresses the SSO consent alert box. Requires iOS 13+.
+   * - **Android:** opens the Custom Tab with ephemeral browsing. Requires Chrome 136+
+   *   (or another browser that supports it); on unsupported browsers the flow falls back
+   *   to a regular Custom Tab, so login still completes but the session is not ephemeral.
+   *   Ignored when {@link NativeAuthorizeOptions.useTrustedWebActivity} is also enabled,
+   *   as a Trusted Web Activity does not support ephemeral browsing.
+   *
+   * No effect on Web.
+   *
    * @default `false`
+   *
+   * @example
+   * ```typescript
+   * await authorize({ scope: 'openid profile email' }, { ephemeralSession: true });
+   * ```
    */
   ephemeralSession?: boolean;
   /**


### PR DESCRIPTION
### Changes

Wires the existing `ephemeralSession` option through to Android, where it was previously accepted but silently ignored. Auth0.Android 4.0 added ephemeral browsing for Custom Tabs, so the flag can now disable SSO on Android as it already does on iOS.

**Public API:** no signature changes. `NativeAuthorizeOptions.ephemeralSession` already existed; this makes it functional on a second platform and documents the behaviour.

- `A0Auth0Module.kt` — calls `withEphemeralBrowsing()` on the Custom Tab builder when `ephemeralSession` is set
- `platform-specific.ts` — TSDoc updated from "iOS only" to describe per-platform behaviour and caveats
- `EXAMPLES.md` — new [Ephemeral Sessions](EXAMPLES.md#ephemeral-sessions) section with hooks + class-based usage
- `FAQ.md` — corrects the "iOS-only" note, keeps the `clearSession` guidance for the fallback case
- `MIGRATION_GUIDE.md` — documents this as a behaviour change under the native SDK alignment section
- Example app — `Ephemeral Session` toggle on both the hooks and class-based screens

**Behaviour notes:**

- Requires **Chrome 136+** (or another browser supporting ephemeral browsing). On unsupported browsers a warning is logged and the flow falls back to a regular Custom Tab — login still completes, but the session is not ephemeral.
- Ignored when `useTrustedWebActivity` is also enabled, since a TWA cannot browse ephemerally. TWA wins; the example app makes the two toggles mutually exclusive to reflect this.

> [!IMPORTANT]
> This is a **behaviour change** for existing Android callers. Anyone already passing `ephemeralSession: true` from shared cross-platform options will now lose SSO on Android and be prompted to log in on every `authorize()`. `MIGRATION_GUIDE.md` flags this with the per-platform workaround.

### References

Follows on from #1619 (Auth0.Android v4 / Auth0.swift v3 adoption), which brought in the native `withEphemeralBrowsing()` API this depends on.

### Testing

Unit tests added in `NativeBridgeManager.spec.ts` covering that `ephemeralSession` is forwarded to the native `webAuth` call, and that it is omitted when not supplied.

**Manual testing** — verified on a physical device (Android 12, Chrome 151) via the example app's Hooks Demo:

1. Ephemeral **Off** → log in → log out → log in again → password prompt skipped (SSO cookie persisted)
2. Ephemeral **On** → log in → log out → log in again → credentials requested again (no shared cookie)

- [x] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [x] All active GitHub checks have passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Android support for ephemeral web authentication sessions from version 6 when compatible browser features are available.
  - Unsupported browsers fall back to regular sessions with shared cookies.
  - Trusted Web Activity takes precedence when both options are enabled.
  - Updated example screens with mutually exclusive controls and guidance for both authentication modes.

- **Documentation**
  - Added browser requirements, platform behavior, fallback details, migration guidance, logout considerations, and session-clearing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->