### PR TITLE
fix(android): bump Auth0.Android to 3.21.1-beta.0 for Keystore2 INCOMPATIBLE_DEVICE fix

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -96,7 +96,7 @@ dependencies {
   implementation "com.facebook.react:react-android"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "androidx.browser:browser:1.2.0"
-  implementation 'com.auth0.android:auth0:3.21.0'
+  implementation 'com.auth0.android:auth0:3.21.1-beta.0'
 }
 
 if (isNewArchitectureEnabled()) {


### PR DESCRIPTION
### Changes

Bumps the bundled Auth0.Android dependency from `3.21.0` to `3.21.1-beta.0`.

That release fixes credential storage failing with `INCOMPATIBLE_DEVICE` on newer Keystore2 hardware (Pixel 10, Galaxy S26, Android 16+). The RSA key used by `SecureCredentialsManager` was generated without explicitly authorizing MGF1 digests, which the newer firmware strictly enforces, so saving credentials threw on those devices. Auth0.Android now authorizes both SHA-1 and SHA-256, and treats an existing stale key's MGF1 mismatch as recoverable by deleting and regenerating it on the next login.

Nothing changes in this SDK's public API — the failure surfaced here only because we delegate credential storage to Auth0.Android.

Note that `3.21.1-beta.0` is a prerelease. It should be re-pinned to `3.21.1` once that is on Maven Central.

### References

- https://github.com/auth0/Auth0.Android/releases/tag/3.21.1-beta.0
- https://github.com/auth0/Auth0.Android/pull/1048

### Testing

- `:react-native-auth0:compileDebugKotlin` passes against the new version (no source changes needed).
- `yarn build` and the existing unit tests pass.
- Verified on an affected device: sign in, confirm credentials persist and `getCredentials()` succeeds where it previously threw `INCOMPATIBLE_DEVICE`.

- [ ] This change adds unit test coverage
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] All existing and new tests complete without errors
- [ ] All active GitHub checks have passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Auth0 Android integration to a newer beta release for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->