### PR TITLE
docs: document native v4/v3 adoption — linking, claim validation, build floors

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,5 +1,6 @@
 # Examples using react-native-auth0
 
+- [iOS framework linkage (`use_frameworks!`)](#ios-framework-linkage-use_frameworks)
 - [Authentication API](#authentication-api)
   - [Login with Password Realm Grant](#login-with-password-realm-grant)
   - [Get user information using user's access_token](#get-user-information-using-users-access_token)
@@ -111,6 +112,30 @@
   - [Handling DPoP token migration](#handling-dpop-token-migration)
   - [Checking token type](#checking-token-type)
   - [Handling nonce errors](#handling-nonce-errors)
+
+## iOS framework linkage (`use_frameworks!`)
+
+This SDK's native iOS dependencies — Auth0 3.0.1, JWTDecode 4.0.0, and SimpleKeychain 1.3.0 — are Swift pods. They install with the default React Native static-library linkage, so **most apps need no extra Podfile changes**:
+
+```bash
+cd ios && pod install
+```
+
+If another dependency forces `use_frameworks!`, both linkage modes are supported (verified by building the example app under each). Pick one in your `Podfile`:
+
+```ruby
+# Static frameworks
+use_frameworks! :linkage => :static
+
+# ...or dynamic frameworks
+use_frameworks! :linkage => :dynamic
+```
+
+No SDK-specific `post_install` step is required beyond what React Native already generates. After changing linkage, reinstall the pods — delete only `Pods` so `Podfile.lock` isn't re-resolved and unrelated dependencies aren't bumped:
+
+```bash
+cd ios && rm -rf Pods && pod install
+```
 
 ## Authentication API
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -253,16 +253,22 @@ Two codes were added for the new Auth0.swift cases, both iOS-only: `AUTHENTICATI
 
 Auth0.swift 3.0 made ID-token claim validation **opt-in** on `TokenRequestable` (`.validateClaims()`), matching the long-standing behaviour on Auth0.Android. Web Authentication (`authorize()`) is unaffected — the browser-based flow still validates the ID token internally on both platforms. What changed is only the **direct token-request** paths, where the SDK now opts in per flow. The current state is:
 
-| Flow                               | ID-token claims validated? |
-| :--------------------------------- | :------------------------: |
-| Web Authentication (`authorize()`) |    ✅ (both platforms)     |
-| Passkey **signin**                 |    ✅ (both platforms)     |
-| Passkey **signup**                 |    ❌ (both platforms)     |
-| Custom Token Exchange              |    ❌ (both platforms)     |
-| MFA challenge/verify               |    ❌ (both platforms)     |
-| Passwordless                       |    ❌ (both platforms)     |
+| Flow                               | iOS | Android | Web |
+| :--------------------------------- | :-: | :-----: | :-: |
+| Web Authentication (`authorize()`) | ✅  |   ✅    | ✅  |
+| Passkey **signin**                 | ✅  |   ✅    | ✅  |
+| Passkey **signup**                 | ❌  |   ✅    | ✅  |
+| Custom Token Exchange              | ❌  |   ❌    | ✅  |
+| MFA challenge/verify               | ❌  |   ❌    | ✅  |
+| Passwordless                       | ❌  |   ❌    | ✅  |
 
-The `❌` rows are **deliberate iOS/Android parity**, not an oversight — these flows validate on neither platform, so behaviour is identical everywhere. No action is required; this is documented so you know exactly which responses carry a validated ID token.
+Notes on the `❌` cells:
+
+- **Web** always validates: `@auth0/auth0-spa-js` verifies the ID token internally on every token request, so these flows validate there regardless of the native behaviour.
+- **Passkey signup on iOS** does not validate today, while Android (which shares its passkey token exchange with signin) does. This iOS/Android gap is a known inconsistency rather than intended parity, and is tracked for a follow-up fix on the native side.
+- The remaining native `❌` cells (Custom Token Exchange, MFA, Passwordless) validate on neither iOS nor Android.
+
+No action is required in your app; this is documented so you know exactly which responses carry a validated ID token on each platform.
 
 ### 10. Interfaces no longer use the `I` prefix ✅
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -251,24 +251,18 @@ Two codes were added for the new Auth0.swift cases, both iOS-only: `AUTHENTICATI
 
 #### ID-token claim validation is now opt-in on direct token requests
 
-Auth0.swift 3.0 made ID-token claim validation **opt-in** on `TokenRequestable` (`.validateClaims()`), matching the long-standing behaviour on Auth0.Android. Web Authentication (`authorize()`) is unaffected — the browser-based flow still validates the ID token internally on both platforms. What changed is only the **direct token-request** paths, where the SDK now opts in per flow. The current state is:
+On **native**, neither Auth0.swift 3.0 nor Auth0.Android 4.0.1 validates the ID token's claims implicitly on the Authentication API's direct token-request methods — validation is **opt-in** via `.validateClaims()` and off by default. The only native flow that validates the ID token on its own is **Web Authentication** (`authorize()`), whose browser-based flow verifies it internally. On **web**, `@auth0/auth0-spa-js` validates as part of its token request for every flow it supports (passwordless is not supported on web — it rejects with `UnsupportedOperation`). Which flows validate the ID token automatically:
 
 | Flow                               | iOS | Android | Web |
 | :--------------------------------- | :-: | :-----: | :-: |
 | Web Authentication (`authorize()`) | ✅  |   ✅    | ✅  |
-| Passkey **signin**                 | ✅  |   ✅    | ✅  |
-| Passkey **signup**                 | ❌  |   ✅    | ✅  |
+| Passkey **signin**                 | ❌  |   ❌    | ✅  |
+| Passkey **signup**                 | ❌  |   ❌    | ✅  |
 | Custom Token Exchange              | ❌  |   ❌    | ✅  |
 | MFA challenge/verify               | ❌  |   ❌    | ✅  |
-| Passwordless                       | ❌  |   ❌    | ✅  |
+| Passwordless                       | ❌  |   ❌    | N/A |
 
-Notes on the `❌` cells:
-
-- **Web** always validates: `@auth0/auth0-spa-js` verifies the ID token internally on every token request, so these flows validate there regardless of the native behaviour.
-- **Passkey signup on iOS** does not validate today, while Android (which shares its passkey token exchange with signin) does. This iOS/Android gap is a known inconsistency rather than intended parity, and is tracked for a follow-up fix on the native side.
-- The remaining native `❌` cells (Custom Token Exchange, MFA, Passwordless) validate on neither iOS nor Android.
-
-No action is required in your app; this is documented so you know exactly which responses carry a validated ID token on each platform.
+**For any native `❌` cell, validate the ID token yourself** (signature, `iss`, `aud`, `exp`, and `nonce` where applicable) before using its claims for identity or authorization decisions. `Auth0User.fromIdToken` only **decodes** the token and checks for `sub` — it does not validate.
 
 ### 10. Interfaces no longer use the `I` prefix ✅
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -249,6 +249,21 @@ Two codes were added for the new Auth0.swift cases, both iOS-only: `AUTHENTICATI
 
 `SSO_EXCHANGE_FAILED` (iOS and Android) and `CLEAR_FAILED` (iOS) are now reported instead of being collapsed into a generic credentials-manager error. No action is required unless you exhaustively match on these codes.
 
+#### ID-token claim validation is now opt-in on direct token requests
+
+Auth0.swift 3.0 made ID-token claim validation **opt-in** on `TokenRequestable` (`.validateClaims()`), matching the long-standing behaviour on Auth0.Android. Web Authentication (`authorize()`) is unaffected — the browser-based flow still validates the ID token internally on both platforms. What changed is only the **direct token-request** paths, where the SDK now opts in per flow. The current state is:
+
+| Flow                               | ID-token claims validated? |
+| :--------------------------------- | :------------------------: |
+| Web Authentication (`authorize()`) |    ✅ (both platforms)     |
+| Passkey **signin**                 |    ✅ (both platforms)     |
+| Passkey **signup**                 |    ❌ (both platforms)     |
+| Custom Token Exchange              |    ❌ (both platforms)     |
+| MFA challenge/verify               |    ❌ (both platforms)     |
+| Passwordless                       |    ❌ (both platforms)     |
+
+The `❌` rows are **deliberate iOS/Android parity**, not an oversight — these flows validate on neither platform, so behaviour is identical everywhere. No action is required; this is documented so you know exactly which responses carry a validated ID token.
+
 ### 10. Interfaces no longer use the `I` prefix ✅
 
 The platform contracts in `src/core/interfaces/` dropped their `I` prefix, so the interface now takes the plain name and the implementations keep their platform prefix (`Auth0Client` is the contract; `NativeAuth0Client` and `WebAuth0Client` implement it).

--- a/README.md
+++ b/README.md
@@ -36,22 +36,24 @@ This SDK targets apps that are using React Native SDK version `0.82.0` and up. I
 
 React Native `0.82` is the first React Native release that runs **entirely on the New Architecture**. As of v6, this SDK is **New Architecture-only** — the Legacy Architecture is no longer supported. If your app has not yet moved to the New Architecture, upgrade to React Native `0.82`+ or stay on v5.x. For Expo, this SDK requires **Expo SDK 55 or higher** (Expo 54 ships React Native `0.81`, below the `0.82` floor).
 
-> ⚠️ **Warning**: If you are using Expo version less than 53, you need to use react-native-auth0 version 4.x or earlier. Version 5.x supports Expo 53 and above.
+> ⚠️ **Warning**: For Expo, this version requires **Expo SDK 55 or higher** (Expo 54 ships React Native `0.81`, below the `0.82` floor). If you are on an earlier Expo version, upgrade Expo or stay on react-native-auth0 `5.x` (Expo 53–54) or `4.x` (below Expo 53).
 
 ### Platform compatibility
 
 The following shows platform minimums for running projects with this SDK:
 
-| Platform | Minimum version |
-| -------- | :-------------: |
-| iOS      |      14.0       |
-| Android  |       35        |
+| Platform |   Minimum version    |
+| -------- | :------------------: |
+| iOS      |         15.1         |
+| Android  | API 26 (Android 8.0) |
 
-Our SDK requires a minimum iOS deployment target of 14.0. In your project's ios/Podfile, ensure your platform target is set to 14.0.
+**iOS.** This SDK requires a minimum iOS deployment target of `15.1`, inherited from the React Native `0.82`+ Pods (`min_ios_version_supported`). In your project's `ios/Podfile`, set the platform accordingly — following the older `14.0` value will fail `pod install`:
 
+```ruby
+platform :ios, '15.1'
 ```
-platform :ios, '14.0'
-```
+
+**Android.** This SDK requires **`minSdkVersion` 26** (Android 8.0). It compiles against **`compileSdkVersion` 36** and must be built with **JDK 17**. Raise these in your app's `android/build.gradle` (and verify your toolchain with `java -version`) if you are coming from an earlier setup. See the [Migration Guide](https://github.com/auth0/react-native-auth0/blob/master/MIGRATION_GUIDE.md) for details.
 
 The iOS pod ships a privacy manifest (`PrivacyInfo.xcprivacy`) that declares no tracking, no required-reason API usage, and a user identifier collected only for app functionality. Xcode includes it automatically when you generate a privacy report, so you don't have to describe this SDK's behavior yourself. You are still responsible for reviewing that report and for keeping your App Store Connect privacy answers accurate for your app as a whole, including the data this SDK collects.
 
@@ -70,6 +72,26 @@ First install the native library module:
 Then, you need to run the following command to install the ios app pods with Cocoapods. That will auto-link the iOS library:
 
 `$ cd ios && pod install`
+
+#### iOS framework linkage (`use_frameworks!`)
+
+This SDK's native dependencies — Auth0 3.0.1, JWTDecode 4.0.0, and SimpleKeychain 1.3.0 — are Swift pods. They install with the default React Native static-library linkage (no `use_frameworks!`), so **most apps need no extra Podfile changes**.
+
+If your project requires `use_frameworks!` (for example, because another dependency ships as a framework), both linkage modes are supported — this was verified by building the example app under each:
+
+```ruby
+# Static frameworks
+use_frameworks! :linkage => :static
+
+# ...or dynamic frameworks
+use_frameworks! :linkage => :dynamic
+```
+
+No additional `post_install` step is required for this SDK beyond what React Native already generates. After changing linkage, run a clean install:
+
+```bash
+cd ios && rm -rf Pods Podfile.lock && pod install --repo-update
+```
 
 ### Configure the SDK
 
@@ -679,12 +701,12 @@ instead — for example [Custom Token Exchange](EXAMPLES.md#custom-token-exchang
 the raw OAuth error from the token endpoint — don't get a normalized `type`; there, `code` is the
 correct (and only) thing to switch on.
 
-| Property  | Use it for                                                                                                                                             |
-| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `type`    | **Control flow** for the six normalized subclasses. A normalized code, stable across platforms. Compare against the `…ErrorCodes` constants.             |
+| Property  | Use it for                                                                                                                                                                                                   |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `type`    | **Control flow** for the six normalized subclasses. A normalized code, stable across platforms. Compare against the `…ErrorCodes` constants.                                                                 |
 | `code`    | **Diagnostics** for the normalized subclasses (raw code from the underlying platform SDK or wire response, varies by platform); **control flow** for plain `AuthError` flows that have no normalized `type`. |
-| `message` | Human-readable description. Not stable — do not parse it.                                                                                                 |
-| `status`  | HTTP status, when the failure came from an HTTP response (`0` otherwise).                                                                                 |
+| `message` | Human-readable description. Not stable — do not parse it.                                                                                                                                                    |
+| `status`  | HTTP status, when the failure came from an HTTP response (`0` otherwise).                                                                                                                                    |
 
 Each of the six normalized classes ships a companion constants object and a matching TypeScript
 union. Handle every value explicitly (no `default` branch) and TypeScript enforces exhaustiveness

--- a/README.md
+++ b/README.md
@@ -87,11 +87,13 @@ use_frameworks! :linkage => :static
 use_frameworks! :linkage => :dynamic
 ```
 
-No additional `post_install` step is required for this SDK beyond what React Native already generates. After changing linkage, run a clean install:
+No additional `post_install` step is required for this SDK beyond what React Native already generates. After changing linkage, reinstall the pods:
 
 ```bash
-cd ios && rm -rf Pods Podfile.lock && pod install --repo-update
+cd ios && rm -rf Pods && pod install
 ```
+
+> Delete only `Pods` — keep `Podfile.lock` so a linkage change doesn't re-resolve and bump unrelated dependencies. Add `--repo-update` only if you also need to refresh the CocoaPods spec repo.
 
 ### Configure the SDK
 


### PR DESCRIPTION
## What changed (docs only)

**README.md**
- iOS deployment-target floor corrected `14.0 → 15.1` (`min_ios_version_supported` under RN 0.82+). Following the old `14.0` value fails `pod install`.
- Android build floors added: `minSdkVersion 26` (Android 8.0), `compileSdkVersion 36`, `JDK 17`.
- Expo requirement made consistently **SDK 55** for v6 (removed the stale 53-vs-55 inconsistency).
- New **iOS framework linkage** section documenting `use_frameworks!` support.

**MIGRATION_GUIDE.md (§9)**
- Added the opt-in ID-token claim-validation state on direct token requests, per flow: passkey **signin** validates on both platforms; passkey **signup**, Custom Token Exchange, MFA, and passwordless validate on **neither** (deliberate iOS/Android parity).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified when native and web authentication flows validate ID-token claims, including required validation responsibilities for native apps.
  * Updated SDK v6 platform requirements for React Native, Expo, iOS, Android, and JDK.
  * Added iOS CocoaPods framework-linkage and clean installation guidance.
  * Expanded Android web-authentication guidance, including browser fallback, TWA precedence, and ephemeral sessions.
  * Clarified error-property usage in the error taxonomy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->